### PR TITLE
fix: close Sonar/CodeQL findings and shrink Codacy backlog

### DIFF
--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -1,6 +1,7 @@
 # Branch Protection Policy
 
 ## Overview
+
 This document defines the branch protection requirements for the `env-inspector` repository to ensure code quality, security, and proper review processes.
 
 ## Main Branch Protection
@@ -8,12 +9,15 @@ This document defines the branch protection requirements for the `env-inspector`
 The `main` branch MUST enforce the following protections:
 
 ### Required Reviews
+
 - **Minimum:** At least 1 human approval required before merge
 - **Dismiss stale reviews:** When new commits are pushed
 - **Code owners review:** Required (see `.github/CODEOWNERS`)
 
 ### Required Status Checks
+
 The following checks MUST pass before merge:
+
 - `make verify` (compile + test)
 - Any configured CI/CD workflows that validate:
   - Code compilation
@@ -21,6 +25,7 @@ The following checks MUST pass before merge:
   - Security scanning (if configured)
 
 ### Additional Protections
+
 - **Require branches to be up to date:** Yes (ensure merge with latest main)
 - **Include administrators:** Yes (protections apply to all)
 - **Restrict who can push:** Only maintainers with write access
@@ -30,7 +35,9 @@ The following checks MUST pass before merge:
 ## Development Workflow
 
 ### Pre-Merge Checklist
+
 Before requesting merge, ensure:
+
 1. ✅ PR description follows template (Summary, Risk, Evidence, Rollback, Scope Guard)
 2. ✅ At least 1 human approval obtained
 3. ✅ All required status checks passing
@@ -39,7 +46,9 @@ Before requesting merge, ensure:
 6. ✅ Rollback steps documented for medium/high risk changes
 
 ### Agent Tasks
+
 For agent-driven work:
+
 - Agent creates PR with all required sections
 - Agent reports progress with commit messages
 - Agent DOES NOT merge PRs
@@ -48,14 +57,17 @@ For agent-driven work:
 ## Risk-Based Gates
 
 ### Low Risk (`risk:low`)
+
 - Standard review (1 approval)
 - Required checks must pass
 
 ### Medium Risk (`risk:medium`)
+
 - Standard review + extra scrutiny on rollback plan
 - Verification evidence mandatory
 
 ### High Risk (`risk:high`)
+
 - Multiple reviewer approval recommended (though 1 required)
 - Rollback steps MUST be explicit and tested
 - Consider feature flag or phased rollout
@@ -65,15 +77,18 @@ For agent-driven work:
 **Definition:** A regression is "escaped" if it reaches production/main and is discovered post-merge.
 
 **Tracking Signal:**
+
 - Issues labeled `bug` + `escaped-regression`
 - Opened within 7 days of related PR merge
 
 **Reporting:**
+
 - Weekly via KPI digest
 - Immediate notification for critical regressions
 
 **Root Cause Analysis:**
 When escaped regressions occur:
+
 1. Label the issue `bug` + `escaped-regression`
 2. Link to the causative PR
 3. Document why existing checks didn't catch it
@@ -83,6 +98,7 @@ When escaped regressions occur:
 ## Configuration Commands
 
 ### Via GitHub CLI
+
 ```bash
 # Enable branch protection with required reviews
 gh api repos/:owner/:repo/branches/main/protection \
@@ -96,6 +112,7 @@ gh api repos/:owner/:repo/branches/main/protection \
 ```
 
 ### Via GitHub Web UI
+
 1. Go to **Settings** > **Branches**
 2. Add rule for `main` branch
 3. Enable:
@@ -116,6 +133,7 @@ gh api repos/:owner/:repo/branches/main/protection | jq '.required_pull_request_
 ```
 
 Expected output should show:
+
 - `required_approving_review_count: 1`
 - `dismiss_stale_reviews: true`
 - Required status checks configured

--- a/.github/FLEET_BASELINE_LITE.md
+++ b/.github/FLEET_BASELINE_LITE.md
@@ -1,12 +1,15 @@
 # Fleet Baseline Lite - Reusable Bundle Export
 
 ## Overview
+
 This checklist documents the reusable baseline components that can be exported and adapted for other repositories following the evidence-first, zero-external-API-cost workflow model.
 
 ## Core Components
 
 ### 1. Agent Operating Guide
+
 **File:** `AGENTS.md`
+
 - [x] Operating model (evidence-first, zero-external-API-cost)
 - [x] Risk policy (risk labels, merge gates)
 - [x] Canonical verification command
@@ -14,11 +17,13 @@ This checklist documents the reusable baseline components that can be exported a
 - [x] Agent queue contract
 
 **Reuse Instructions:**
+
 1. Copy `AGENTS.md` to target repository root
 2. Update verification command to match target repo's build/test system
 3. Adjust scope guardrails for repo-specific constraints
 
 **Customization Points:**
+
 - Verification command (e.g., `npm test`, `mvn verify`, `cargo test`)
 - Runtime state exclusions (e.g., `.env-inspector-state/` → `.app-state/`)
 - Tech stack specific guardrails
@@ -26,7 +31,9 @@ This checklist documents the reusable baseline components that can be exported a
 ---
 
 ### 2. Agent Task Issue Template
+
 **File:** `.github/ISSUE_TEMPLATE/agent_task.yml`
+
 - [x] Structured task packet fields
 - [x] Problem statement, current/target behavior
 - [x] Non-goals section
@@ -36,11 +43,13 @@ This checklist documents the reusable baseline components that can be exported a
 - [x] Evidence command list
 
 **Reuse Instructions:**
+
 1. Copy to `.github/ISSUE_TEMPLATE/agent_task.yml` in target repo
 2. Update `primary_area` options to match target repo domains
 3. Update default evidence command value
 
 **Customization Points:**
+
 - Primary area options (frontend, backend, infra, etc.)
 - Default evidence commands
 - Additional domain-specific fields
@@ -48,7 +57,9 @@ This checklist documents the reusable baseline components that can be exported a
 ---
 
 ### 3. PR Template
+
 **File:** `.github/pull_request_template.md`
+
 - [x] Summary section
 - [x] Risk assessment with regression surface
 - [x] Evidence checklist with verification command
@@ -57,11 +68,13 @@ This checklist documents the reusable baseline components that can be exported a
 - [x] Linked issues
 
 **Reuse Instructions:**
+
 1. Copy to `.github/pull_request_template.md` in target repo
 2. Update verification command reference
 3. Adjust scope guard checklist for repo specifics
 
 **Customization Points:**
+
 - Evidence command references
 - Scope guard items (security, runtime state, secrets)
 - Risk assessment prompts
@@ -69,18 +82,22 @@ This checklist documents the reusable baseline components that can be exported a
 ---
 
 ### 4. Agent Label Sync Workflow
+
 **File:** `.github/workflows/agent-label-sync.yml`
+
 - [x] Agent state labels (ready, in-progress, blocked)
 - [x] Risk level labels (low, medium, high)
 - [x] Area labels (frontend, backend, infra, docs, security, release)
 - [x] Workflow dispatch trigger
 
 **Reuse Instructions:**
+
 1. Copy to `.github/workflows/agent-label-sync.yml` in target repo
 2. Add/remove area labels to match target repo structure
 3. Run workflow to create labels: `gh workflow run agent-label-sync.yml`
 
 **Customization Points:**
+
 - Area labels (add domain-specific categories)
 - Label colors and descriptions
 - Additional workflow-specific labels
@@ -88,7 +105,9 @@ This checklist documents the reusable baseline components that can be exported a
 ---
 
 ### 5. Agent Task Queue Workflow
+
 **File:** `.github/workflows/agent-task-queue.yml`
+
 - [x] Triggered by `agent:ready` label on issues
 - [x] Builds task packet from issue
 - [x] Notifies @copilot with execution contract
@@ -96,11 +115,13 @@ This checklist documents the reusable baseline components that can be exported a
 - [x] References verification command
 
 **Reuse Instructions:**
+
 1. Copy to `.github/workflows/agent-task-queue.yml` in target repo
 2. Update `VERIFY_COMMAND` env var to match target repo
 3. Adjust task packet template if needed
 
 **Customization Points:**
+
 - Verification command
 - Task packet template
 - Agent notification format
@@ -109,7 +130,9 @@ This checklist documents the reusable baseline components that can be exported a
 ---
 
 ### 6. Agent Profiles
+
 **Files:** `.github/agents/*.agent.md`
+
 - [x] `test-specialist.agent.md` - Deterministic test focus
 - [x] `docs-gardener.agent.md` - Documentation alignment
 - [x] `security-sheriff.agent.md` - Security hardening
@@ -118,12 +141,14 @@ This checklist documents the reusable baseline components that can be exported a
 - [x] `ui-polish.agent.md` - UX improvements
 
 **Reuse Instructions:**
+
 1. Copy relevant agent profiles to `.github/agents/` in target repo
 2. Update verification command references
 3. Adjust agent descriptions for repo context
 4. Create additional domain-specific agents as needed
 
 **Customization Points:**
+
 - Agent-specific tools and permissions
 - Verification command references
 - Domain knowledge and context
@@ -134,7 +159,9 @@ This checklist documents the reusable baseline components that can be exported a
 ## Supporting Workflows
 
 ### 7. KPI Weekly Digest (New in Phase 3)
+
 **File:** `.github/workflows/kpi-weekly-digest.yml`
+
 - [x] Lead time tracking
 - [x] Cycle time tracking
 - [x] Rework rate calculation
@@ -143,11 +170,13 @@ This checklist documents the reusable baseline components that can be exported a
 - [x] Escaped regression reporting
 
 **Reuse Instructions:**
+
 1. Copy to `.github/workflows/kpi-weekly-digest.yml` in target repo
 2. Adjust KPI thresholds if needed
 3. Schedule may be customized (default: Monday 9 AM UTC)
 
 **Customization Points:**
+
 - KPI calculation logic (org-specific definitions)
 - Reporting thresholds
 - Schedule frequency
@@ -156,7 +185,9 @@ This checklist documents the reusable baseline components that can be exported a
 ---
 
 ### 8. Branch Protection Policy (New in Phase 3)
+
 **File:** `.github/BRANCH_PROTECTION.md`
+
 - [x] Required review count
 - [x] Required status checks
 - [x] Additional protections
@@ -165,12 +196,14 @@ This checklist documents the reusable baseline components that can be exported a
 - [x] Configuration commands
 
 **Reuse Instructions:**
+
 1. Copy to `.github/BRANCH_PROTECTION.md` in target repo
 2. Update required status checks
 3. Adjust review requirements if needed
 4. Apply configuration via GitHub CLI or UI
 
 **Customization Points:**
+
 - Number of required approvals
 - Required status check names
 - Risk level definitions
@@ -181,7 +214,9 @@ This checklist documents the reusable baseline components that can be exported a
 ## Repo-Specific Overlay Exceptions
 
 ### env-inspector Specifics (NOT in baseline)
+
 The following are specific to this repository and should NOT be exported:
+
 - `.env-inspector-state/` exclusion (app-specific runtime state)
 - Windows EXE release workflow (`env-inspector-exe-release.yml`)
 - `env_inspector.py` and `env_inspector_core` module structure
@@ -189,7 +224,9 @@ The following are specific to this repository and should NOT be exported:
 - WSL environment inspection logic
 
 ### General Principles for Overlays
+
 When adapting baseline to new repos:
+
 1. **Preserve core workflow:** agent queue, label sync, PR template
 2. **Customize verification:** Match target repo's build/test toolchain
 3. **Adjust area labels:** Reflect actual codebase domains

--- a/.github/agents/docs-gardener.agent.md
+++ b/.github/agents/docs-gardener.agent.md
@@ -7,6 +7,7 @@ tools: ["read", "search", "edit"]
 You are the Docs Curator.
 
 Rules:
+
 - Update docs only where behavior/contracts changed.
 - Preserve concise, actionable documentation style.
 - Avoid speculative architecture edits.

--- a/.github/agents/docs-gardener.agent.md
+++ b/.github/agents/docs-gardener.agent.md
@@ -4,6 +4,8 @@ description: Keep docs and operational guides aligned with code behavior and rel
 tools: ["read", "search", "edit"]
 ---
 
+# Docs Gardener Agent
+
 You are the Docs Curator.
 
 Rules:

--- a/.github/agents/release-assistant.agent.md
+++ b/.github/agents/release-assistant.agent.md
@@ -7,6 +7,7 @@ tools: ["read", "search", "edit", "execute"]
 You are the Release Steward.
 
 Rules:
+
 - Validate release-impacting changes with deterministic evidence.
 - Ensure changelog/release notes clearly describe behavior changes.
 - Include rollback guidance for medium/high-risk changes.

--- a/.github/agents/release-assistant.agent.md
+++ b/.github/agents/release-assistant.agent.md
@@ -4,6 +4,8 @@ description: Prepare release notes, artifact checks, and rollback-ready release 
 tools: ["read", "search", "edit", "execute"]
 ---
 
+# Release Assistant Agent
+
 You are the Release Steward.
 
 Rules:

--- a/.github/agents/security-sheriff.agent.md
+++ b/.github/agents/security-sheriff.agent.md
@@ -7,6 +7,7 @@ tools: ["read", "search", "edit", "execute"]
 You are the Risk Reviewer for security.
 
 Rules:
+
 - Flag risky changes to auth, secrets, or privilege boundaries.
 - Prefer least-privilege and explicit error handling.
 - Add or improve tests for security-sensitive logic when possible.

--- a/.github/agents/security-sheriff.agent.md
+++ b/.github/agents/security-sheriff.agent.md
@@ -4,6 +4,8 @@ description: Perform security-focused hardening, dependency hygiene, and secret-
 tools: ["read", "search", "edit", "execute"]
 ---
 
+# Security Sheriff Agent
+
 You are the Risk Reviewer for security.
 
 Rules:

--- a/.github/agents/test-specialist.agent.md
+++ b/.github/agents/test-specialist.agent.md
@@ -7,6 +7,7 @@ tools: ["read", "search", "edit", "execute"]
 You are the Deterministic Verifier.
 
 Rules:
+
 - Prefer tests before production edits.
 - Keep changes minimal and scoped.
 - Run `make verify` before handoff.

--- a/.github/agents/test-specialist.agent.md
+++ b/.github/agents/test-specialist.agent.md
@@ -4,6 +4,8 @@ description: Improve or add deterministic tests first, then make minimal impleme
 tools: ["read", "search", "edit", "execute"]
 ---
 
+# Test Specialist Agent
+
 You are the Deterministic Verifier.
 
 Rules:

--- a/.github/agents/triage.agent.md
+++ b/.github/agents/triage.agent.md
@@ -7,6 +7,7 @@ tools: ["read", "search"]
 You are the Intake Planner for this repository.
 
 Rules:
+
 - Do not implement code.
 - Convert ambiguous issues into clear execution packets.
 - Require explicit acceptance criteria and non-goals.
@@ -14,6 +15,7 @@ Rules:
 - Require deterministic verification command: `make verify`.
 
 Output format:
+
 1. Final task packet
 2. Suggested labels
 3. Open risks/unknowns

--- a/.github/agents/triage.agent.md
+++ b/.github/agents/triage.agent.md
@@ -4,6 +4,8 @@ description: Turn issues into decision-complete implementation packets with expl
 tools: ["read", "search"]
 ---
 
+# Triage Agent
+
 You are the Intake Planner for this repository.
 
 Rules:

--- a/.github/agents/ui-polish.agent.md
+++ b/.github/agents/ui-polish.agent.md
@@ -7,6 +7,7 @@ tools: ["read", "search", "edit"]
 You are the UI/UX Polisher.
 
 Rules:
+
 - Limit edits to presentation/accessibility unless explicitly requested otherwise.
 - Avoid broad refactors.
 - Prefer semantic, accessible improvements.

--- a/.github/agents/ui-polish.agent.md
+++ b/.github/agents/ui-polish.agent.md
@@ -4,6 +4,8 @@ description: Improve UX clarity and accessibility without changing core business
 tools: ["read", "search", "edit"]
 ---
 
+# Ui Polish Agent
+
 You are the UI/UX Polisher.
 
 Rules:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+# Pull Request Template
+
 ## Summary
 
 - What changed?

--- a/.github/workflows/codecov-analytics.yml
+++ b/.github/workflows/codecov-analytics.yml
@@ -35,7 +35,7 @@ jobs:
           python -m pytest --cov=. --cov-report=xml:coverage/python-coverage.xml
       - name: Upload coverage to Codecov
         if: ${{ always() }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
         with:
           files: coverage/python-coverage.xml
           flags: python

--- a/.github/workflows/env-inspector-exe-release.yml
+++ b/.github/workflows/env-inspector-exe-release.yml
@@ -59,12 +59,20 @@ jobs:
       - name: Resolve release tag
         id: release_tag
         shell: pwsh
+        env:
+          GH_REF_TYPE: ${{ github.ref_type }}
+          GH_REF_NAME: ${{ github.ref_name }}
+          GH_EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
           $tag = ""
-          if ("${{ github.ref_type }}" -eq "tag") {
-            $tag = "${{ github.ref_name }}"
-          } elseif ("${{ github.event_name }}" -eq "workflow_dispatch" -and "${{ inputs.tag }}" -ne "") {
-            $tag = "${{ inputs.tag }}"
+          if ($env:GH_REF_TYPE -eq "tag") {
+            $tag = $env:GH_REF_NAME
+          } elseif ($env:GH_EVENT_NAME -eq "workflow_dispatch" -and $env:INPUT_TAG -ne "") {
+            if ($env:INPUT_TAG -notmatch '^v[0-9]+(\.[0-9]+)*([-.][0-9A-Za-z]+)*$') {
+              throw "Invalid tag format. Expected semantic-style tag such as v1.0.0."
+            }
+            $tag = $env:INPUT_TAG
           }
           "tag=$tag" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 

--- a/.github/workflows/quality-zero-gate.yml
+++ b/.github/workflows/quality-zero-gate.yml
@@ -7,13 +7,12 @@ on:
     branches: [main, master]
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 jobs:
   secrets-preflight:
     name: Quality Secrets Preflight
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       CODACY_API_TOKEN: ${{ secrets.CODACY_API_TOKEN }}
@@ -43,6 +42,8 @@ jobs:
     name: Quality Zero Gate
     if: always()
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs:
       - secrets-preflight
     env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,18 @@
 # AGENTS.md
 
 ## Operating Model
+
 This repository follows an evidence-first, zero-external-API-cost workflow.
 Use GitHub Copilot coding agent and Codex app/IDE/CLI for implementation and review, then verify with deterministic commands before merge.
 
 ## Risk Policy
+
 - Default merge policy: human-reviewed only.
 - Use explicit risk labels: `risk:low`, `risk:medium`, `risk:high`.
 - High-risk changes require rollback notes in the PR.
 
 ## Canonical Verification Command
+
 Run this command before claiming completion:
 
 ```bash
@@ -17,14 +20,17 @@ make verify
 ```
 
 ## Scope Guardrails
+
 - Keep changes small and task-focused.
 - Do not commit runtime state (`.env-inspector-state/`) or secrets.
 - Prefer tests/docs updates together with behavior changes.
 
 ## Agent Queue Contract
+
 - Intake issues via `.github/ISSUE_TEMPLATE/agent_task.yml`.
 - Queue work by adding `agent:ready` label.
 - Queue workflow will post a task packet and notify `@copilot`.
 
 ## Queue Trigger Warning
+
 Applying label `agent:ready` triggers the queue workflow immediately.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [1.0.0] - 2026-02-18
 
-### Added
+### Added (1.0.0)
 
 - Stable CLI surface for `list`, `set`, `remove`, `export`, `backup`, and `restore`.
 - Cross-context record inspection across Windows, WSL, and Linux runtime modes.
@@ -46,7 +46,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Export flows for JSON/CSV/table with masked-by-default secret behavior.
 - CI release workflow to build `env-inspector.exe` and attach checksumed release assets.
 
-### Changed
+### Changed (1.0.0)
 
 - Platform context handling now uses runtime-aware defaults instead of Windows-only assumptions.
 - Effective value resolver now applies strict context isolation and Linux precedence rules.

--- a/PLAN.md
+++ b/PLAN.md
@@ -89,9 +89,9 @@ Add operation result schema:
 - Current user profile
 - All users profile (read/edit behavior as selected)
 
-3. Add WSL `/etc/environment` provider per distro.
-4. Add WSL filesystem dotenv provider with explicit distro+path scanning.
-5. Add context-based effective-value resolver:
+1. Add WSL `/etc/environment` provider per distro.
+2. Add WSL filesystem dotenv provider with explicit distro+path scanning.
+3. Add context-based effective-value resolver:
 
 - Windows context precedence
 - Per-distro WSL context precedence
@@ -138,26 +138,26 @@ Add operation result schema:
 - bashrc export parser
 - `/etc/environment` parser
 
-3. Add writer tests:
+1. Add writer tests:
 
 - upsert/remove semantics
 - quote handling
 - newline preservation
 - backup creation and retention
 
-4. Add privilege strategy tests with mocked subprocess:
+1. Add privilege strategy tests with mocked subprocess:
 
 - root path success
 - root fail + sudo success
 - both fail
 
-5. Add context precedence tests:
+1. Add context precedence tests:
 
 - Windows effective value
 - WSL distro-specific effective value
 
-6. Add GUI logic tests where feasible via isolated logic functions.
-7. Add manual Windows validation checklist in README:
+1. Add GUI logic tests where feasible via isolated logic functions.
+2. Add manual Windows validation checklist in README:
 
 - Source mode run
 - EXE run
@@ -176,7 +176,7 @@ Add operation result schema:
 - Export
 - Context effective preview
 
-4. Record known limitations and troubleshooting steps in README.
+1. Record known limitations and troubleshooting steps in README.
 
 ## Test Cases and Scenarios
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -88,9 +88,10 @@ Add operation result schema:
 
 - Current user profile
 - All users profile (read/edit behavior as selected)
-1. Add WSL `/etc/environment` provider per distro.
-2. Add WSL filesystem dotenv provider with explicit distro+path scanning.
-3. Add context-based effective-value resolver:
+
+3. Add WSL `/etc/environment` provider per distro.
+4. Add WSL filesystem dotenv provider with explicit distro+path scanning.
+5. Add context-based effective-value resolver:
 
 - Windows context precedence
 - Per-distro WSL context precedence
@@ -136,23 +137,27 @@ Add operation result schema:
 - PowerShell profile parser
 - bashrc export parser
 - `/etc/environment` parser
-1. Add writer tests:
+
+3. Add writer tests:
 
 - upsert/remove semantics
 - quote handling
 - newline preservation
 - backup creation and retention
-1. Add privilege strategy tests with mocked subprocess:
+
+4. Add privilege strategy tests with mocked subprocess:
 
 - root path success
 - root fail + sudo success
 - both fail
-1. Add context precedence tests:
+
+5. Add context precedence tests:
 
 - Windows effective value
 - WSL distro-specific effective value
-1. Add GUI logic tests where feasible via isolated logic functions.
-2. Add manual Windows validation checklist in README:
+
+6. Add GUI logic tests where feasible via isolated logic functions.
+7. Add manual Windows validation checklist in README:
 
 - Source mode run
 - EXE run
@@ -170,7 +175,8 @@ Add operation result schema:
 - Backup/restore
 - Export
 - Context effective preview
-1. Record known limitations and troubleshooting steps in README.
+
+4. Record known limitations and troubleshooting steps in README.
 
 ## Test Cases and Scenarios
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,7 +1,9 @@
 # Env Inspector Reliability Upgrade Plan (Windows + WSL + Multi-Source Editing)
 
 ## Summary
+
 Build a robust `CLI core` and keep `Tkinter` as the GUI wrapper so the app can reliably inspect and edit environment variables/tokens across Windows and WSL, including:
+
 - Windows process vars, User/Machine registry vars, and PowerShell profile vars
 - WSL `~/.bashrc` and `/etc/environment`
 - Editable `.env` and `.env.*` files (Windows paths and WSL filesystem paths)
@@ -13,7 +15,9 @@ This plan also fixes existing path breakages in docs/build/spec (`tools/env-insp
 ## Public Interfaces and Type Changes
 
 ### CLI surface (new stable interface)
+
 Add subcommands in `env_inspector.py` (or a new package entrypoint) with machine-readable JSON output:
+
 1. `list`
 2. `set`
 3. `remove`
@@ -22,6 +26,7 @@ Add subcommands in `env_inspector.py` (or a new package entrypoint) with machine
 6. `restore`
 
 Add common flags:
+
 - `--context windows|wsl:<distro>`
 - `--source process|windows_user|windows_machine|powershell_profile|wsl_bashrc|wsl_etc_environment|dotenv`
 - `--target` repeated target identifiers for multi-target writes
@@ -31,7 +36,9 @@ Add common flags:
 - `--output json|csv|table`
 
 ### Data model updates
+
 Extend `EnvRecord` to include:
+
 - `source_path` (file/registry path)
 - `context` (`windows` or `wsl:<distro>`)
 - `precedence_rank`
@@ -39,6 +46,7 @@ Extend `EnvRecord` to include:
 - `last_error` (optional, per-source read/write status)
 
 Add operation result schema:
+
 - `operation_id`
 - `target`
 - `action`
@@ -48,6 +56,7 @@ Add operation result schema:
 - `error_message`
 
 ### GUI behavior changes
+
 - Add top context dropdown (`Windows` + each WSL distro)
 - Add multi-target picker dialog for Set/Remove
 - Add diff-preview confirm dialog before any write
@@ -58,12 +67,14 @@ Add operation result schema:
 ## Implementation Plan
 
 ### Phase 1: Stabilize current project entry/build paths
+
 1. Update `README.md` paths from `tools/env-inspector/...` to local repo-root paths.
 2. Update `build-windows-exe.ps1` to install/run local files (`requirements-build.txt`, `env_inspector.py`).
 3. Update `env-inspector.spec` script path to local `env_inspector.py`.
 4. Add a quick validation section in `README.md` with exact commands for source run and build run.
 
 ### Phase 2: Create CLI core architecture
+
 1. Introduce module split while keeping `env_inspector.py` as main entrypoint.
 2. Create provider modules for each source type.
 3. Create writer modules for each writable target.
@@ -71,17 +82,21 @@ Add operation result schema:
 5. Ensure GUI calls CLI-core functions (direct import or subprocess contract), not ad-hoc inline logic.
 
 ### Phase 3: Source providers (read flows)
+
 1. Keep existing process/registry/bashrc providers.
 2. Add PowerShell profile provider:
+
 - Current user profile
 - All users profile (read/edit behavior as selected)
-3. Add WSL `/etc/environment` provider per distro.
-4. Add WSL filesystem dotenv provider with explicit distro+path scanning.
-5. Add context-based effective-value resolver:
+1. Add WSL `/etc/environment` provider per distro.
+2. Add WSL filesystem dotenv provider with explicit distro+path scanning.
+3. Add context-based effective-value resolver:
+
 - Windows context precedence
 - Per-distro WSL context precedence
 
 ### Phase 4: Write engine with safety
+
 1. Implement diff generation for each target before write.
 2. Implement backup creation before write for every file/target.
 3. Store backups in project folder under `./.env-inspector-state/backups`.
@@ -90,11 +105,13 @@ Add operation result schema:
 6. Implement audit log in project folder under `./.env-inspector-state/audit.log`.
 7. Write masking rules in logs (no raw secret values).
 8. Implement WSL privileged write strategy for `/etc/environment`:
+
 - Try `wsl.exe -d <distro> -u root ...`
 - If that fails, attempt sudo-based fallback
 - Return explicit actionable error when both fail
 
 ### Phase 5: GUI integration for new capability
+
 1. Add context dropdown at top of UI.
 2. Add effective-value panel for selected key in current context.
 3. Add multi-target picker dialog for Set/Remove actions.
@@ -104,91 +121,109 @@ Add operation result schema:
 7. Keep existing secret masking toggle and only-secret filter behavior.
 
 ### Phase 6: Export support
+
 1. Add JSON export of current filtered view with source metadata.
 2. Add CSV export with source metadata.
 3. Default exports to masked secrets.
 4. Add explicit opt-in for raw secrets in export path only.
 
 ### Phase 7: Tests and validation
+
 1. Add pytest suite folder.
 2. Add parser tests:
+
 - dotenv parser
 - PowerShell profile parser
 - bashrc export parser
 - `/etc/environment` parser
-3. Add writer tests:
+1. Add writer tests:
+
 - upsert/remove semantics
 - quote handling
 - newline preservation
 - backup creation and retention
-4. Add privilege strategy tests with mocked subprocess:
+1. Add privilege strategy tests with mocked subprocess:
+
 - root path success
 - root fail + sudo success
 - both fail
-5. Add context precedence tests:
+1. Add context precedence tests:
+
 - Windows effective value
 - WSL distro-specific effective value
-6. Add GUI logic tests where feasible via isolated logic functions.
-7. Add manual Windows validation checklist in README:
+1. Add GUI logic tests where feasible via isolated logic functions.
+2. Add manual Windows validation checklist in README:
+
 - Source mode run
 - EXE run
 - Read across all selected sources
 - Write/remove with diff, backup, rollback, audit verification
 
 ### Phase 8: Packaging and verification gate
+
 1. Build `dist/env-inspector.exe` using updated script.
 2. Run source mode and EXE mode on Windows.
 3. Execute checklist for:
+
 - Read coverage
 - Write coverage
 - Backup/restore
 - Export
 - Context effective preview
-4. Record known limitations and troubleshooting steps in README.
+1. Record known limitations and troubleshooting steps in README.
 
 ## Test Cases and Scenarios
 
 1. Windows registry write:
+
 - Set/remove in User scope.
 - Set/remove in Machine scope with elevation path.
 - Validate persistence and refresh.
 
-2. PowerShell profile edit:
+1. PowerShell profile edit:
+
 - Add new variable line.
 - Update existing variable.
 - Remove variable.
 - Verify file integrity and backup created.
 
-3. WSL bashrc edit:
+1. WSL bashrc edit:
+
 - Set/remove across selected distros.
 - Confirm helper distros default unchecked behavior remains.
 
-4. WSL `/etc/environment` edit:
+1. WSL `/etc/environment` edit:
+
 - Root invocation succeeds.
 - Root fails, sudo fallback succeeds.
 - Both fail with clear error and no silent corruption.
 
-5. Dotenv editing:
+1. Dotenv editing:
+
 - Single-file update.
 - Duplicate key in multiple files with explicit target selection.
 - Removal from selected file only.
 - WSL filesystem dotenv edit path.
 
-6. Backup/restore:
+1. Backup/restore:
+
 - Backup generated before each write.
 - Rotation keeps last 20 per target.
 - Restore recovers exact previous content.
 
-7. Export:
+1. Export:
+
 - JSON/CSV include source metadata.
 - Secret masking default enforced.
 - Raw secret export requires explicit opt-in.
 
-8. Effective value context:
+1. Effective value context:
+
 - Same key across multiple sources resolves differently by selected context.
 - UI preview matches resolver output.
 
 ## Assumptions and Defaults
+
 - Full functionality target is Windows host with WSL integration.
 - Linux native mode remains secondary and can stay read-only/minimal where Windows APIs are required.
 - Secrets are masked by default in UI, logs, and exports.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 Security fixes are applied to the latest release series.
 
 | Version | Supported |
-|---|---|
+| --- | --- |
 | Latest | Yes |
 | Older releases | No |
 

--- a/env_inspector_core/service.py
+++ b/env_inspector_core/service.py
@@ -373,13 +373,6 @@ class EnvInspectorService:
             return upsert_export(before, key, value or "")
         return upsert_key_value(before, key, value or "", quote=False)
 
-    def _resolve_linux_target(self, target: str) -> tuple[Path, str, bool]:
-        if target == "linux:bashrc":
-            return Path.home() / ".bashrc", "export", False
-        if target == "linux:etc_environment":
-            return self._linux_etc_environment_path(), "key_value", True
-        raise RuntimeError(f"Unsupported Linux target: {target}")
-
     def _update_linux_file(
         self,
         *,
@@ -389,21 +382,24 @@ class EnvInspectorService:
         action: str,
         apply_changes: bool,
     ) -> tuple[str, str, str | None, bool, str | None]:
-        path, style, requires_priv = self._resolve_linux_target(target)
-        before = path.read_text(encoding="utf-8", errors="ignore") if path.exists() else ""
-        after = self._mutate_shell_content(before, key=key, value=value, action=action, style=style)
-
-        is_etc_environment = target == "linux:etc_environment"
-        if apply_changes:
-            if is_etc_environment:
-                self._write_linux_etc_environment_with_privilege(after)
-            else:
-                bashrc_path = Path.home() / ".bashrc"
+        if target == "linux:bashrc":
+            bashrc_path = Path.home() / ".bashrc"
+            before = bashrc_path.read_text(encoding="utf-8", errors="ignore") if bashrc_path.exists() else ""
+            after = self._mutate_shell_content(before, key=key, value=value, action=action, style="export")
+            if apply_changes:
                 bashrc_path.parent.mkdir(parents=True, exist_ok=True)
                 bashrc_path.write_text(after, encoding="utf-8")
+            return before, after, str(bashrc_path), False, None
 
-        out_path = self._LINUX_ETC_ENV_PATH if is_etc_environment else str(path)
-        return before, after, out_path, requires_priv, None
+        if target == "linux:etc_environment":
+            etc_path = self._linux_etc_environment_path()
+            before = etc_path.read_text(encoding="utf-8", errors="ignore") if etc_path.exists() else ""
+            after = self._mutate_shell_content(before, key=key, value=value, action=action, style="key_value")
+            if apply_changes:
+                self._write_linux_etc_environment_with_privilege(after)
+            return before, after, self._LINUX_ETC_ENV_PATH, True, None
+
+        raise RuntimeError(f"Unsupported Linux target: {target}")
 
     @staticmethod
     def _validate_wsl_distro_name(raw: str) -> str:

--- a/env_inspector_core/service.py
+++ b/env_inspector_core/service.py
@@ -680,15 +680,23 @@ class EnvInspectorService:
 
     def _restore_dotenv_target(self, *, target: str, text: str, scope_roots: list[Path]) -> None:
         scoped = parse_scoped_dotenv_target(target, roots=scope_roots)
+        candidate_abs = os.path.realpath(os.path.normpath(str(scoped.path)))
+        allowed_roots_abs = [os.path.realpath(os.path.normpath(str(root))) for root in scope_roots]
 
-        candidate_abs = os.path.abspath(os.path.normpath(str(scoped.path)))
-        allowed_roots_abs = [os.path.abspath(os.path.normpath(str(root))) for root in scope_roots]
-        if not any(os.path.commonpath([candidate_abs, root_abs]) == root_abs for root_abs in allowed_roots_abs):
+        allowed = False
+        for root_abs in allowed_roots_abs:
+            root_prefix = root_abs if root_abs.endswith(os.sep) else root_abs + os.sep
+            if candidate_abs == root_abs or candidate_abs.startswith(root_prefix):
+                allowed = True
+                break
+
+        if not allowed:
             raise RuntimeError(f"restore dotenv path is outside approved roots: {candidate_abs}")
 
-        safe_path = Path(candidate_abs).resolve(strict=False)
+        safe_path = Path(candidate_abs)
         safe_path.parent.mkdir(parents=True, exist_ok=True)
-        safe_path.write_text(text, encoding="utf-8")
+        with safe_path.open("w", encoding="utf-8", newline="") as handle:
+            handle.write(text)
 
     def _restore_linux_target(self, *, target: str, text: str) -> None:
         if target == "linux:bashrc":

--- a/env_inspector_core/service.py
+++ b/env_inspector_core/service.py
@@ -8,7 +8,7 @@ import os
 import subprocess
 import uuid
 from dataclasses import replace
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 from .constants import (
@@ -403,10 +403,36 @@ class EnvInspectorService:
         out_path = self._LINUX_ETC_ENV_PATH if requires_priv else str(path)
         return before, after, out_path, requires_priv, None
 
+    @staticmethod
+    def _validate_wsl_distro_name(raw: str) -> str:
+        distro = (raw or "").strip()
+        if not distro or ":" in distro or "\x00" in distro:
+            raise RuntimeError(f"Unsupported WSL distro name: {raw!r}")
+        return distro
+
+    @staticmethod
+    def _validate_wsl_dotenv_path(raw: str) -> str:
+        candidate = (raw or "").strip()
+        if not candidate or "\x00" in candidate:
+            raise RuntimeError("Unsupported WSL dotenv target path")
+        path = PurePosixPath(candidate)
+        if ".." in path.parts or not str(path).startswith("/"):
+            raise RuntimeError("Unsupported WSL dotenv target path")
+        if path.name != ".env" and not path.name.startswith(".env."):
+            raise RuntimeError("Unsupported WSL dotenv target path")
+        return str(path)
+
+    def _parse_wsl_dotenv_target(self, target: str) -> tuple[str, str]:
+        raw = target[len("wsl_dotenv:") :]
+        try:
+            distro, path = raw.split(":", 1)
+        except ValueError as exc:
+            raise RuntimeError(f"Unsupported WSL target: {target}") from exc
+        return self._validate_wsl_distro_name(distro), self._validate_wsl_dotenv_path(path)
+
     def _resolve_wsl_target(self, target: str) -> tuple[str, str, str, bool]:
         if target.startswith("wsl_dotenv:"):
-            raw = target[len("wsl_dotenv:") :]
-            distro, path = raw.split(":", 1)
+            distro, path = self._parse_wsl_dotenv_target(target)
             return distro, path, "key_value", False
 
         if not target.startswith("wsl:"):
@@ -417,10 +443,11 @@ class EnvInspectorService:
             raise RuntimeError(f"Unsupported WSL target: {target}")
 
         _prefix, distro, suffix = parts
+        distro_name = self._validate_wsl_distro_name(distro)
         if suffix == "bashrc":
-            return distro, "~/.bashrc", "export", False
+            return distro_name, "~/.bashrc", "export", False
         if suffix == "etc_environment":
-            return distro, self._LINUX_ETC_ENV_PATH, "key_value", True
+            return distro_name, self._LINUX_ETC_ENV_PATH, "key_value", True
         raise RuntimeError(f"Unsupported WSL target: {target}")
 
     def _update_wsl_file(
@@ -731,16 +758,15 @@ class EnvInspectorService:
 
     def _restore_wsl_target(self, *, target: str, text: str) -> None:
         if target.startswith("wsl_dotenv:"):
-            raw = target[len("wsl_dotenv:") :]
-            distro, pth = raw.split(":", 1)
+            distro, pth = self._parse_wsl_dotenv_target(target)
             self.wsl.write_file(distro, pth, text)
             return
         if target.startswith("wsl:") and target.endswith(":bashrc"):
-            distro = target.split(":", 2)[1]
+            distro = self._validate_wsl_distro_name(target.split(":", 2)[1])
             self.wsl.write_file(distro, "~/.bashrc", text)
             return
         if target.startswith("wsl:") and target.endswith(":etc_environment"):
-            distro = target.split(":", 2)[1]
+            distro = self._validate_wsl_distro_name(target.split(":", 2)[1])
             self.wsl.write_file_with_privilege(distro, self._LINUX_ETC_ENV_PATH, text)
             return
         raise RuntimeError(f"Unsupported WSL restore target: {target}")

--- a/env_inspector_core/service.py
+++ b/env_inspector_core/service.py
@@ -88,6 +88,35 @@ class EnvInspectorService:
         all_users = Path(r"C:\\Program Files\\PowerShell\\7\\profile.ps1")
         return [current, all_users]
 
+    @staticmethod
+    def _is_path_within(path: Path, root: Path) -> bool:
+        try:
+            path.relative_to(root)
+            return True
+        except ValueError:
+            return False
+
+    @classmethod
+    def _validate_path_in_roots(cls, path: Path, roots: list[Path] | tuple[Path, ...], *, label: str) -> Path:
+        resolved_path = path.resolve(strict=False)
+        resolved_roots = [root.resolve(strict=False) for root in roots]
+        for root in resolved_roots:
+            if cls._is_path_within(resolved_path, root):
+                return resolved_path
+        raise RuntimeError(f"{label} is outside approved roots: {resolved_path}")
+
+    def _validated_powershell_restore_path(self, target: str) -> Path:
+        if target not in {"powershell:current_user", "powershell:all_users"}:
+            raise RuntimeError(f"Unsupported PowerShell target: {target}")
+        profile = self._powershell_profile_path(target).resolve(strict=False)
+        if target == "powershell:current_user":
+            allowed_root = Path.home().resolve(strict=False)
+        else:
+            allowed_root = Path(os.environ.get("ProgramFiles", r"C:\\Program Files")).resolve(strict=False)
+        if not self._is_path_within(profile, allowed_root):
+            raise RuntimeError(f"PowerShell profile path is outside expected root: {profile}")
+        return profile
+
     def list_contexts(self) -> list[str]:
         contexts = [self.runtime_context]
         if self.wsl.available():
@@ -186,7 +215,9 @@ class EnvInspectorService:
         return "\n".join(diff)
 
     def _write_linux_etc_environment_with_privilege(self, text: str) -> None:
-        path = Path("/etc/environment")
+        path = Path("/etc/environment").resolve(strict=False)
+        if str(path) != "/etc/environment":
+            raise RuntimeError(f"Unexpected /etc/environment resolution: {path}")
         try:
             path.write_text(text, encoding="utf-8")
             return
@@ -286,7 +317,7 @@ class EnvInspectorService:
     ) -> tuple[str, str, str | None, bool, str | None]:
         if target.startswith("dotenv:"):
             scoped = parse_scoped_dotenv_target(target, roots=scope_roots)
-            path = scoped.path
+            path = self._validate_path_in_roots(scoped.path, list(scoped.roots), label="dotenv target path")
             before = path.read_text(encoding="utf-8", errors="ignore") if path.exists() else ""
             after = upsert_key_value(before, key, value or "", quote=False) if action == "set" else remove_key_value(before, key)
             if apply_changes:
@@ -564,8 +595,9 @@ class EnvInspectorService:
 
             if target.startswith("dotenv:"):
                 scoped = parse_scoped_dotenv_target(target, roots=resolved_scope_roots)
-                scoped.path.parent.mkdir(parents=True, exist_ok=True)
-                scoped.path.write_text(text, encoding="utf-8")
+                safe_path = self._validate_path_in_roots(scoped.path, list(scoped.roots), label="restore dotenv path")
+                safe_path.parent.mkdir(parents=True, exist_ok=True)
+                safe_path.write_text(text, encoding="utf-8")
             elif target == "linux:bashrc":
                 path_out = Path.home() / ".bashrc"
                 path_out.parent.mkdir(parents=True, exist_ok=True)
@@ -582,8 +614,8 @@ class EnvInspectorService:
             elif target.startswith("wsl:") and target.endswith(":etc_environment"):
                 distro = target.split(":", 2)[1]
                 self.wsl.write_file_with_privilege(distro, "/etc/environment", text)
-            elif target.startswith("powershell:"):
-                profile = self._powershell_profile_path(target)
+            elif target in {"powershell:current_user", "powershell:all_users"}:
+                profile = self._validated_powershell_restore_path(target)
                 profile.parent.mkdir(parents=True, exist_ok=True)
                 profile.write_text(text, encoding="utf-8")
             elif target in {"windows:user", "windows:machine"}:

--- a/env_inspector_core/service.py
+++ b/env_inspector_core/service.py
@@ -112,7 +112,7 @@ class EnvInspectorService:
         if target == "powershell:current_user":
             allowed_root = Path.home().resolve(strict=False)
         else:
-            allowed_root = Path(os.environ.get("ProgramFiles", r"C:\\Program Files")).resolve(strict=False)
+            allowed_root = Path(r"C:\\Program Files").resolve(strict=False)
         if not self._is_path_within(profile, allowed_root):
             raise RuntimeError(f"PowerShell profile path is outside expected root: {profile}")
         return profile
@@ -595,7 +595,15 @@ class EnvInspectorService:
 
             if target.startswith("dotenv:"):
                 scoped = parse_scoped_dotenv_target(target, roots=resolved_scope_roots)
-                safe_path = self._validate_path_in_roots(scoped.path, list(scoped.roots), label="restore dotenv path")
+                safe_path = scoped.path.resolve(strict=False)
+                in_scope = False
+                for root in resolved_scope_roots:
+                    root_resolved = root.resolve(strict=False)
+                    if self._is_path_within(safe_path, root_resolved):
+                        in_scope = True
+                        break
+                if not in_scope:
+                    raise RuntimeError(f"restore dotenv path is outside approved roots: {safe_path}")
                 safe_path.parent.mkdir(parents=True, exist_ok=True)
                 safe_path.write_text(text, encoding="utf-8")
             elif target == "linux:bashrc":

--- a/env_inspector_core/service.py
+++ b/env_inspector_core/service.py
@@ -393,14 +393,16 @@ class EnvInspectorService:
         before = path.read_text(encoding="utf-8", errors="ignore") if path.exists() else ""
         after = self._mutate_shell_content(before, key=key, value=value, action=action, style=style)
 
+        is_etc_environment = target == "linux:etc_environment"
         if apply_changes:
-            if requires_priv:
+            if is_etc_environment:
                 self._write_linux_etc_environment_with_privilege(after)
             else:
-                path.parent.mkdir(parents=True, exist_ok=True)
-                path.write_text(after, encoding="utf-8")
+                bashrc_path = Path.home() / ".bashrc"
+                bashrc_path.parent.mkdir(parents=True, exist_ok=True)
+                bashrc_path.write_text(after, encoding="utf-8")
 
-        out_path = self._LINUX_ETC_ENV_PATH if requires_priv else str(path)
+        out_path = self._LINUX_ETC_ENV_PATH if is_etc_environment else str(path)
         return before, after, out_path, requires_priv, None
 
     @staticmethod

--- a/env_inspector_core/service.py
+++ b/env_inspector_core/service.py
@@ -289,24 +289,28 @@ class EnvInspectorService:
         return sorted(targets)
 
     @staticmethod
-    def _record_target(record: EnvRecord) -> str | None:
-        if record.source_type == SOURCE_DOTENV:
-            return f"dotenv:{record.source_path}"
-        if record.source_type == SOURCE_LINUX_BASHRC:
-            return "linux:bashrc"
-        if record.source_type == SOURCE_LINUX_ETC_ENV:
-            return "linux:etc_environment"
-        if record.source_type == SOURCE_WSL_DOTENV:
-            return f"wsl_dotenv:{record.source_path}"
-        if record.source_type == SOURCE_WSL_BASHRC:
-            return f"wsl:{record.source_id}:bashrc"
-        if record.source_type == SOURCE_WSL_ETC_ENV:
-            return f"wsl:{record.source_id}:etc_environment"
-        if record.source_type == SOURCE_POWERSHELL_PROFILE:
-            if "Program Files" in record.source_path:
-                return "powershell:all_users"
-            return "powershell:current_user"
-        return None
+    def _powershell_target_for_path(source_path: str) -> str:
+        return "powershell:all_users" if "Program Files" in source_path else "powershell:current_user"
+
+    @classmethod
+    def _record_target(cls, record: EnvRecord) -> str | None:
+        static_targets = {
+            SOURCE_LINUX_BASHRC: "linux:bashrc",
+            SOURCE_LINUX_ETC_ENV: "linux:etc_environment",
+        }
+        dynamic_targets = {
+            SOURCE_DOTENV: lambda rec: f"dotenv:{rec.source_path}",
+            SOURCE_WSL_DOTENV: lambda rec: f"wsl_dotenv:{rec.source_path}",
+            SOURCE_WSL_BASHRC: lambda rec: f"wsl:{rec.source_id}:bashrc",
+            SOURCE_WSL_ETC_ENV: lambda rec: f"wsl:{rec.source_id}:etc_environment",
+            SOURCE_POWERSHELL_PROFILE: lambda rec: cls._powershell_target_for_path(rec.source_path),
+        }
+
+        static_target = static_targets.get(record.source_type)
+        if static_target is not None:
+            return static_target
+        builder = dynamic_targets.get(record.source_type)
+        return builder(record) if builder is not None else None
 
     def _registry_write(
         self,
@@ -361,6 +365,21 @@ class EnvInspectorService:
             path.write_text(after, encoding="utf-8")
         return before, after, str(path), False, None
 
+    @staticmethod
+    def _mutate_shell_content(before: str, *, key: str, value: str | None, action: str, style: str) -> str:
+        if action != "set":
+            return remove_export(before, key) if style == "export" else remove_key_value(before, key)
+        if style == "export":
+            return upsert_export(before, key, value or "")
+        return upsert_key_value(before, key, value or "", quote=False)
+
+    def _resolve_linux_target(self, target: str) -> tuple[Path, str, bool]:
+        if target == "linux:bashrc":
+            return Path.home() / ".bashrc", "export", False
+        if target == "linux:etc_environment":
+            return self._linux_etc_environment_path(), "key_value", True
+        raise RuntimeError(f"Unsupported Linux target: {target}")
+
     def _update_linux_file(
         self,
         *,
@@ -370,22 +389,39 @@ class EnvInspectorService:
         action: str,
         apply_changes: bool,
     ) -> tuple[str, str, str | None, bool, str | None]:
-        if target == "linux:bashrc":
-            path = Path.home() / ".bashrc"
-            before = path.read_text(encoding="utf-8", errors="ignore") if path.exists() else ""
-            after = upsert_export(before, key, value or "") if action == "set" else remove_export(before, key)
-            if apply_changes:
+        path, style, requires_priv = self._resolve_linux_target(target)
+        before = path.read_text(encoding="utf-8", errors="ignore") if path.exists() else ""
+        after = self._mutate_shell_content(before, key=key, value=value, action=action, style=style)
+
+        if apply_changes:
+            if requires_priv:
+                self._write_linux_etc_environment_with_privilege(after)
+            else:
                 path.parent.mkdir(parents=True, exist_ok=True)
                 path.write_text(after, encoding="utf-8")
-            return before, after, str(path), False, None
-        if target == "linux:etc_environment":
-            path = self._linux_etc_environment_path()
-            before = path.read_text(encoding="utf-8", errors="ignore") if path.exists() else ""
-            after = upsert_key_value(before, key, value or "", quote=False) if action == "set" else remove_key_value(before, key)
-            if apply_changes:
-                self._write_linux_etc_environment_with_privilege(after)
-            return before, after, self._LINUX_ETC_ENV_PATH, True, None
-        raise RuntimeError(f"Unsupported Linux target: {target}")
+
+        out_path = self._LINUX_ETC_ENV_PATH if requires_priv else str(path)
+        return before, after, out_path, requires_priv, None
+
+    def _resolve_wsl_target(self, target: str) -> tuple[str, str, str, bool]:
+        if target.startswith("wsl_dotenv:"):
+            raw = target[len("wsl_dotenv:") :]
+            distro, path = raw.split(":", 1)
+            return distro, path, "key_value", False
+
+        if not target.startswith("wsl:"):
+            raise RuntimeError(f"Unsupported WSL target: {target}")
+
+        parts = target.split(":", 2)
+        if len(parts) != 3:
+            raise RuntimeError(f"Unsupported WSL target: {target}")
+
+        _prefix, distro, suffix = parts
+        if suffix == "bashrc":
+            return distro, "~/.bashrc", "export", False
+        if suffix == "etc_environment":
+            return distro, self._LINUX_ETC_ENV_PATH, "key_value", True
+        raise RuntimeError(f"Unsupported WSL target: {target}")
 
     def _update_wsl_file(
         self,
@@ -396,31 +432,15 @@ class EnvInspectorService:
         action: str,
         apply_changes: bool,
     ) -> tuple[str, str, str | None, bool, str | None]:
-        if target.startswith("wsl_dotenv:"):
-            raw = target[len("wsl_dotenv:") :]
-            distro, path = raw.split(":", 1)
-            before = self.wsl.read_file(distro, path)
-            after = upsert_key_value(before, key, value or "", quote=False) if action == "set" else remove_key_value(before, key)
-            if apply_changes:
-                self.wsl.write_file(distro, path, after)
-            return before, after, f"{distro}:{path}", False, None
-        if target.startswith("wsl:") and target.endswith(":bashrc"):
-            distro = target.split(":", 2)[1]
-            path = "~/.bashrc"
-            before = self.wsl.read_file(distro, path)
-            after = upsert_export(before, key, value or "") if action == "set" else remove_export(before, key)
-            if apply_changes:
-                self.wsl.write_file(distro, path, after)
-            return before, after, f"{distro}:{path}", False, None
-        if target.startswith("wsl:") and target.endswith(":etc_environment"):
-            distro = target.split(":", 2)[1]
-            path = self._LINUX_ETC_ENV_PATH
-            before = self.wsl.read_file(distro, path)
-            after = upsert_key_value(before, key, value or "", quote=False) if action == "set" else remove_key_value(before, key)
-            if apply_changes:
-                self.wsl.write_file_with_privilege(distro, path, after)
-            return before, after, f"{distro}:{path}", True, None
-        raise RuntimeError(f"Unsupported WSL target: {target}")
+        distro, path, style, requires_priv = self._resolve_wsl_target(target)
+        before = self.wsl.read_file(distro, path)
+        after = self._mutate_shell_content(before, key=key, value=value, action=action, style=style)
+
+        if apply_changes:
+            writer = self.wsl.write_file_with_privilege if requires_priv else self.wsl.write_file
+            writer(distro, path, after)
+
+        return before, after, f"{distro}:{path}", requires_priv, None
 
     def _update_powershell_file(
         self,

--- a/env_inspector_core/service.py
+++ b/env_inspector_core/service.py
@@ -680,7 +680,13 @@ class EnvInspectorService:
 
     def _restore_dotenv_target(self, *, target: str, text: str, scope_roots: list[Path]) -> None:
         scoped = parse_scoped_dotenv_target(target, roots=scope_roots)
-        safe_path = self._validate_path_in_roots(scoped.path, list(scoped.roots), label="restore dotenv path")
+
+        candidate_abs = os.path.abspath(os.path.normpath(str(scoped.path)))
+        allowed_roots_abs = [os.path.abspath(os.path.normpath(str(root))) for root in scope_roots]
+        if not any(os.path.commonpath([candidate_abs, root_abs]) == root_abs for root_abs in allowed_roots_abs):
+            raise RuntimeError(f"restore dotenv path is outside approved roots: {candidate_abs}")
+
+        safe_path = Path(candidate_abs).resolve(strict=False)
         safe_path.parent.mkdir(parents=True, exist_ok=True)
         safe_path.write_text(text, encoding="utf-8")
 

--- a/env_inspector_core/service.py
+++ b/env_inspector_core/service.py
@@ -59,6 +59,8 @@ from .storage import AuditLogger, BackupManager
 
 
 class EnvInspectorService:
+    _LINUX_ETC_ENV_PATH = "/etc/environment"
+
     def __init__(self, state_dir: Path | None = None, backup_retention: int = DEFAULT_BACKUP_RETENTION) -> None:
         self.state_dir = Path(state_dir or (Path.cwd() / ".env-inspector-state"))
         self.backup_mgr = BackupManager(self.state_dir / "backups", retention=backup_retention)
@@ -117,6 +119,13 @@ class EnvInspectorService:
             raise RuntimeError(f"PowerShell profile path is outside expected root: {profile}")
         return profile
 
+    @classmethod
+    def _linux_etc_environment_path(cls) -> Path:
+        path = Path(cls._LINUX_ETC_ENV_PATH)
+        if path.as_posix() != cls._LINUX_ETC_ENV_PATH:
+            raise RuntimeError(f"Unexpected /etc/environment resolution: {path}")
+        return path
+
     def list_contexts(self) -> list[str]:
         contexts = [self.runtime_context]
         if self.wsl.available():
@@ -133,20 +142,8 @@ class EnvInspectorService:
             distros = [d for d in distros if d.lower() != current]
         return distros
 
-    def list_records(
-        self,
-        *,
-        root: str | Path | None = None,
-        context: str | None = None,
-        source: list[str] | None = None,
-        wsl_path: str | None = None,
-        distro: str | None = None,
-        scan_depth: int = DEFAULT_SCAN_DEPTH,
-        include_raw_secrets: bool = False,
-    ) -> list[dict[str, Any]]:
+    def _collect_host_rows(self, root_path: Path, scan_depth: int) -> list[EnvRecord]:
         rows: list[EnvRecord] = []
-
-        root_path = resolve_scan_root(root or Path.cwd())
         rows.extend(collect_process_records(context=self.runtime_context))
         rows.extend(collect_dotenv_records(root_path, max_depth=scan_depth, context=self.runtime_context))
 
@@ -161,28 +158,64 @@ class EnvInspectorService:
         else:
             rows.extend(collect_linux_records(context=self.runtime_context))
 
-        if self.wsl.available():
+        return rows
+
+    def _collect_wsl_rows(
+        self,
+        *,
+        scan_depth: int,
+        distro: str | None,
+        wsl_path: str | None,
+    ) -> list[EnvRecord]:
+        rows: list[EnvRecord] = []
+        if not self.wsl.available():
+            return rows
+
+        try:
+            exclude_distros: set[str] | None = None
+            if self.runtime_context == "linux" and self.current_wsl_distro:
+                exclude_distros = {self.current_wsl_distro}
+            rows.extend(collect_wsl_records(self.wsl, include_etc=True, exclude_distros=exclude_distros))
+        except Exception:
+            pass
+
+        if distro and wsl_path:
             try:
-                exclude_distros: set[str] | None = None
-                if self.runtime_context == "linux" and self.current_wsl_distro:
-                    exclude_distros = {self.current_wsl_distro}
-                rows.extend(collect_wsl_records(self.wsl, include_etc=True, exclude_distros=exclude_distros))
+                rows.extend(collect_wsl_dotenv_records(self.wsl, distro=distro, root_path=wsl_path, max_depth=scan_depth))
             except Exception:
                 pass
 
-            if distro and wsl_path:
-                try:
-                    rows.extend(collect_wsl_dotenv_records(self.wsl, distro=distro, root_path=wsl_path, max_depth=scan_depth))
-                except Exception:
-                    pass
+        return rows
 
+    @staticmethod
+    def _apply_row_filters(
+        rows: list[EnvRecord],
+        *,
+        source: list[str] | None,
+        context: str | None,
+    ) -> list[EnvRecord]:
         if source:
             source_set = set(source)
             rows = [r for r in rows if r.source_type in source_set]
-
         if context:
             rows = [r for r in rows if r.context == context]
+        return rows
 
+    def list_records(
+        self,
+        *,
+        root: str | Path | None = None,
+        context: str | None = None,
+        source: list[str] | None = None,
+        wsl_path: str | None = None,
+        distro: str | None = None,
+        scan_depth: int = DEFAULT_SCAN_DEPTH,
+        include_raw_secrets: bool = False,
+    ) -> list[dict[str, Any]]:
+        root_path = resolve_scan_root(root or Path.cwd())
+        rows = self._collect_host_rows(root_path, scan_depth)
+        rows.extend(self._collect_wsl_rows(scan_depth=scan_depth, distro=distro, wsl_path=wsl_path))
+        rows = self._apply_row_filters(rows, source=source, context=context)
         rows.sort(key=lambda r: (r.name.lower(), r.context, r.source_type, r.source_path))
 
         payload: list[dict[str, Any]] = []
@@ -215,9 +248,7 @@ class EnvInspectorService:
         return "\n".join(diff)
 
     def _write_linux_etc_environment_with_privilege(self, text: str) -> None:
-        path = Path("/etc/environment").resolve(strict=False)
-        if str(path) != "/etc/environment":
-            raise RuntimeError(f"Unexpected /etc/environment resolution: {path}")
+        path = self._linux_etc_environment_path()
         try:
             path.write_text(text, encoding="utf-8")
             return
@@ -225,7 +256,7 @@ class EnvInspectorService:
             pass
 
         proc = subprocess.run(
-            ["sudo", "-n", "tee", str(path)],
+            ["sudo", "-n", "tee", self._LINUX_ETC_ENV_PATH],
             input=text.encode("utf-8"),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -243,26 +274,12 @@ class EnvInspectorService:
 
     def available_targets(self, records: list[EnvRecord], context: str | None = None) -> list[str]:
         targets: set[str] = set()
-        for r in records:
-            if context and r.context != context:
+        for record in records:
+            if context and record.context != context:
                 continue
-            if r.source_type == SOURCE_DOTENV:
-                targets.add(f"dotenv:{r.source_path}")
-            elif r.source_type == SOURCE_LINUX_BASHRC:
-                targets.add("linux:bashrc")
-            elif r.source_type == SOURCE_LINUX_ETC_ENV:
-                targets.add("linux:etc_environment")
-            elif r.source_type == SOURCE_WSL_DOTENV:
-                targets.add(f"wsl_dotenv:{r.source_path}")
-            elif r.source_type == SOURCE_WSL_BASHRC:
-                targets.add(f"wsl:{r.source_id}:bashrc")
-            elif r.source_type == SOURCE_WSL_ETC_ENV:
-                targets.add(f"wsl:{r.source_id}:etc_environment")
-            elif r.source_type == SOURCE_POWERSHELL_PROFILE:
-                if "Program Files" in r.source_path:
-                    targets.add("powershell:all_users")
-                else:
-                    targets.add("powershell:current_user")
+            mapped_target = self._record_target(record)
+            if mapped_target:
+                targets.add(mapped_target)
         if self.win_provider is not None:
             targets.add("windows:user")
             targets.add("windows:machine")
@@ -270,6 +287,26 @@ class EnvInspectorService:
             targets.add("linux:bashrc")
             targets.add("linux:etc_environment")
         return sorted(targets)
+
+    @staticmethod
+    def _record_target(record: EnvRecord) -> str | None:
+        if record.source_type == SOURCE_DOTENV:
+            return f"dotenv:{record.source_path}"
+        if record.source_type == SOURCE_LINUX_BASHRC:
+            return "linux:bashrc"
+        if record.source_type == SOURCE_LINUX_ETC_ENV:
+            return "linux:etc_environment"
+        if record.source_type == SOURCE_WSL_DOTENV:
+            return f"wsl_dotenv:{record.source_path}"
+        if record.source_type == SOURCE_WSL_BASHRC:
+            return f"wsl:{record.source_id}:bashrc"
+        if record.source_type == SOURCE_WSL_ETC_ENV:
+            return f"wsl:{record.source_id}:etc_environment"
+        if record.source_type == SOURCE_POWERSHELL_PROFILE:
+            if "Program Files" in record.source_path:
+                return "powershell:all_users"
+            return "powershell:current_user"
+        return None
 
     def _registry_write(
         self,
@@ -305,6 +342,104 @@ class EnvInspectorService:
             return all_users
         raise RuntimeError(f"Unsupported PowerShell target: {target}")
 
+    def _update_dotenv_file(
+        self,
+        *,
+        target: str,
+        key: str,
+        value: str | None,
+        action: str,
+        apply_changes: bool,
+        scope_roots: list[Path],
+    ) -> tuple[str, str, str | None, bool, str | None]:
+        scoped = parse_scoped_dotenv_target(target, roots=scope_roots)
+        path = self._validate_path_in_roots(scoped.path, list(scoped.roots), label="dotenv target path")
+        before = path.read_text(encoding="utf-8", errors="ignore") if path.exists() else ""
+        after = upsert_key_value(before, key, value or "", quote=False) if action == "set" else remove_key_value(before, key)
+        if apply_changes:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(after, encoding="utf-8")
+        return before, after, str(path), False, None
+
+    def _update_linux_file(
+        self,
+        *,
+        target: str,
+        key: str,
+        value: str | None,
+        action: str,
+        apply_changes: bool,
+    ) -> tuple[str, str, str | None, bool, str | None]:
+        if target == "linux:bashrc":
+            path = Path.home() / ".bashrc"
+            before = path.read_text(encoding="utf-8", errors="ignore") if path.exists() else ""
+            after = upsert_export(before, key, value or "") if action == "set" else remove_export(before, key)
+            if apply_changes:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(after, encoding="utf-8")
+            return before, after, str(path), False, None
+        if target == "linux:etc_environment":
+            path = self._linux_etc_environment_path()
+            before = path.read_text(encoding="utf-8", errors="ignore") if path.exists() else ""
+            after = upsert_key_value(before, key, value or "", quote=False) if action == "set" else remove_key_value(before, key)
+            if apply_changes:
+                self._write_linux_etc_environment_with_privilege(after)
+            return before, after, self._LINUX_ETC_ENV_PATH, True, None
+        raise RuntimeError(f"Unsupported Linux target: {target}")
+
+    def _update_wsl_file(
+        self,
+        *,
+        target: str,
+        key: str,
+        value: str | None,
+        action: str,
+        apply_changes: bool,
+    ) -> tuple[str, str, str | None, bool, str | None]:
+        if target.startswith("wsl_dotenv:"):
+            raw = target[len("wsl_dotenv:") :]
+            distro, path = raw.split(":", 1)
+            before = self.wsl.read_file(distro, path)
+            after = upsert_key_value(before, key, value or "", quote=False) if action == "set" else remove_key_value(before, key)
+            if apply_changes:
+                self.wsl.write_file(distro, path, after)
+            return before, after, f"{distro}:{path}", False, None
+        if target.startswith("wsl:") and target.endswith(":bashrc"):
+            distro = target.split(":", 2)[1]
+            path = "~/.bashrc"
+            before = self.wsl.read_file(distro, path)
+            after = upsert_export(before, key, value or "") if action == "set" else remove_export(before, key)
+            if apply_changes:
+                self.wsl.write_file(distro, path, after)
+            return before, after, f"{distro}:{path}", False, None
+        if target.startswith("wsl:") and target.endswith(":etc_environment"):
+            distro = target.split(":", 2)[1]
+            path = self._LINUX_ETC_ENV_PATH
+            before = self.wsl.read_file(distro, path)
+            after = upsert_key_value(before, key, value or "", quote=False) if action == "set" else remove_key_value(before, key)
+            if apply_changes:
+                self.wsl.write_file_with_privilege(distro, path, after)
+            return before, after, f"{distro}:{path}", True, None
+        raise RuntimeError(f"Unsupported WSL target: {target}")
+
+    def _update_powershell_file(
+        self,
+        *,
+        target: str,
+        key: str,
+        value: str | None,
+        action: str,
+        apply_changes: bool,
+    ) -> tuple[str, str, str | None, bool, str | None]:
+        path = self._powershell_profile_path(target)
+        before = path.read_text(encoding="utf-8", errors="ignore") if path.exists() else ""
+        after = upsert_powershell_env(before, key, value or "") if action == "set" else remove_powershell_env(before, key)
+        if apply_changes:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(after, encoding="utf-8")
+        requires_priv = "all_users" in target
+        return before, after, str(path), requires_priv, None
+
     def _file_update(
         self,
         target: str,
@@ -316,73 +451,38 @@ class EnvInspectorService:
         scope_roots: list[Path],
     ) -> tuple[str, str, str | None, bool, str | None]:
         if target.startswith("dotenv:"):
-            scoped = parse_scoped_dotenv_target(target, roots=scope_roots)
-            path = self._validate_path_in_roots(scoped.path, list(scoped.roots), label="dotenv target path")
-            before = path.read_text(encoding="utf-8", errors="ignore") if path.exists() else ""
-            after = upsert_key_value(before, key, value or "", quote=False) if action == "set" else remove_key_value(before, key)
-            if apply_changes:
-                path.parent.mkdir(parents=True, exist_ok=True)
-                path.write_text(after, encoding="utf-8")
-            return before, after, str(path), False, None
-
-        if target == "linux:bashrc":
-            path = Path.home() / ".bashrc"
-            before = path.read_text(encoding="utf-8", errors="ignore") if path.exists() else ""
-            after = upsert_export(before, key, value or "") if action == "set" else remove_export(before, key)
-            if apply_changes:
-                path.parent.mkdir(parents=True, exist_ok=True)
-                path.write_text(after, encoding="utf-8")
-            return before, after, str(path), False, None
-
-        if target == "linux:etc_environment":
-            path = Path("/etc/environment")
-            before = path.read_text(encoding="utf-8", errors="ignore") if path.exists() else ""
-            after = upsert_key_value(before, key, value or "", quote=False) if action == "set" else remove_key_value(before, key)
-            if apply_changes:
-                self._write_linux_etc_environment_with_privilege(after)
-            return before, after, str(path), True, None
-
-        if target.startswith("wsl_dotenv:"):
-            raw = target[len("wsl_dotenv:") :]
-            distro, path = raw.split(":", 1)
-            before = self.wsl.read_file(distro, path)
-            after = upsert_key_value(before, key, value or "", quote=False) if action == "set" else remove_key_value(before, key)
-            if apply_changes:
-                self.wsl.write_file(distro, path, after)
-            return before, after, f"{distro}:{path}", False, None
-
-        if target.startswith("wsl:") and target.endswith(":bashrc"):
-            distro = target.split(":", 2)[1]
-            path = "~/.bashrc"
-            before = self.wsl.read_file(distro, path)
-            after = upsert_export(before, key, value or "") if action == "set" else remove_export(before, key)
-            if apply_changes:
-                self.wsl.write_file(distro, path, after)
-            return before, after, f"{distro}:{path}", False, None
-
-        if target.startswith("wsl:") and target.endswith(":etc_environment"):
-            distro = target.split(":", 2)[1]
-            path = "/etc/environment"
-            before = self.wsl.read_file(distro, path)
-            after = upsert_key_value(before, key, value or "", quote=False) if action == "set" else remove_key_value(before, key)
-            if apply_changes:
-                self.wsl.write_file_with_privilege(distro, path, after)
-            return before, after, f"{distro}:{path}", True, None
-
-        if target.startswith("powershell:"):
-            path = self._powershell_profile_path(target)
-            before = path.read_text(encoding="utf-8", errors="ignore") if path.exists() else ""
-            after = (
-                upsert_powershell_env(before, key, value or "")
-                if action == "set"
-                else remove_powershell_env(before, key)
+            return self._update_dotenv_file(
+                target=target,
+                key=key,
+                value=value,
+                action=action,
+                apply_changes=apply_changes,
+                scope_roots=scope_roots,
             )
-            if apply_changes:
-                path.parent.mkdir(parents=True, exist_ok=True)
-                path.write_text(after, encoding="utf-8")
-            requires_priv = "all_users" in target
-            return before, after, str(path), requires_priv, None
-
+        if target.startswith("linux:"):
+            return self._update_linux_file(
+                target=target,
+                key=key,
+                value=value,
+                action=action,
+                apply_changes=apply_changes,
+            )
+        if target.startswith("wsl"):
+            return self._update_wsl_file(
+                target=target,
+                key=key,
+                value=value,
+                action=action,
+                apply_changes=apply_changes,
+            )
+        if target.startswith("powershell:"):
+            return self._update_powershell_file(
+                target=target,
+                key=key,
+                value=value,
+                action=action,
+                apply_changes=apply_changes,
+            )
         raise RuntimeError(f"Unsupported target: {target}")
 
     def _plan_target_operation(
@@ -578,6 +678,74 @@ class EnvInspectorService:
             return [str(p) for p in self.backup_mgr.list_backups(target)]
         return [str(p) for p in self.backup_mgr.list_all_backups()]
 
+    def _restore_dotenv_target(self, *, target: str, text: str, scope_roots: list[Path]) -> None:
+        scoped = parse_scoped_dotenv_target(target, roots=scope_roots)
+        safe_path = self._validate_path_in_roots(scoped.path, list(scoped.roots), label="restore dotenv path")
+        safe_path.parent.mkdir(parents=True, exist_ok=True)
+        safe_path.write_text(text, encoding="utf-8")
+
+    def _restore_linux_target(self, *, target: str, text: str) -> None:
+        if target == "linux:bashrc":
+            path_out = Path.home() / ".bashrc"
+            path_out.parent.mkdir(parents=True, exist_ok=True)
+            path_out.write_text(text, encoding="utf-8")
+            return
+        if target == "linux:etc_environment":
+            self._write_linux_etc_environment_with_privilege(text)
+            return
+        raise RuntimeError(f"Unsupported Linux restore target: {target}")
+
+    def _restore_wsl_target(self, *, target: str, text: str) -> None:
+        if target.startswith("wsl_dotenv:"):
+            raw = target[len("wsl_dotenv:") :]
+            distro, pth = raw.split(":", 1)
+            self.wsl.write_file(distro, pth, text)
+            return
+        if target.startswith("wsl:") and target.endswith(":bashrc"):
+            distro = target.split(":", 2)[1]
+            self.wsl.write_file(distro, "~/.bashrc", text)
+            return
+        if target.startswith("wsl:") and target.endswith(":etc_environment"):
+            distro = target.split(":", 2)[1]
+            self.wsl.write_file_with_privilege(distro, self._LINUX_ETC_ENV_PATH, text)
+            return
+        raise RuntimeError(f"Unsupported WSL restore target: {target}")
+
+    def _restore_powershell_target(self, *, target: str, text: str) -> None:
+        profile = self._validated_powershell_restore_path(target)
+        profile.parent.mkdir(parents=True, exist_ok=True)
+        profile.write_text(text, encoding="utf-8")
+
+    def _restore_windows_registry_target(self, *, target: str, text: str) -> None:
+        if self.win_provider is None:
+            raise RuntimeError("Windows provider unavailable for registry restore")
+        data = json.loads(text)
+        scope = WindowsRegistryProvider.USER_SCOPE if target == "windows:user" else WindowsRegistryProvider.MACHINE_SCOPE
+        current = self.win_provider.list_scope(scope)
+        for key in list(current.keys()):
+            if key not in data:
+                self.win_provider.remove_scope_value(scope, key)
+        for key, value in data.items():
+            self.win_provider.set_scope_value(scope, key, str(value))
+
+    def _restore_target(self, *, target: str, text: str, scope_roots: list[Path]) -> None:
+        if target.startswith("dotenv:"):
+            self._restore_dotenv_target(target=target, text=text, scope_roots=scope_roots)
+            return
+        if target in {"linux:bashrc", "linux:etc_environment"}:
+            self._restore_linux_target(target=target, text=text)
+            return
+        if target.startswith("wsl"):
+            self._restore_wsl_target(target=target, text=text)
+            return
+        if target in {"powershell:current_user", "powershell:all_users"}:
+            self._restore_powershell_target(target=target, text=text)
+            return
+        if target in {"windows:user", "windows:machine"}:
+            self._restore_windows_registry_target(target=target, text=text)
+            return
+        raise RuntimeError(f"Unsupported restore target: {target}")
+
     def restore_backup(
         self,
         *,
@@ -593,55 +761,7 @@ class EnvInspectorService:
             target = payload["target"]
             text = payload["text"]
 
-            if target.startswith("dotenv:"):
-                scoped = parse_scoped_dotenv_target(target, roots=resolved_scope_roots)
-                safe_path = scoped.path.resolve(strict=False)
-                in_scope = False
-                for root in resolved_scope_roots:
-                    root_resolved = root.resolve(strict=False)
-                    if self._is_path_within(safe_path, root_resolved):
-                        in_scope = True
-                        break
-                if not in_scope:
-                    raise RuntimeError(f"restore dotenv path is outside approved roots: {safe_path}")
-                safe_path.parent.mkdir(parents=True, exist_ok=True)
-                safe_path.write_text(text, encoding="utf-8")
-            elif target == "linux:bashrc":
-                path_out = Path.home() / ".bashrc"
-                path_out.parent.mkdir(parents=True, exist_ok=True)
-                path_out.write_text(text, encoding="utf-8")
-            elif target == "linux:etc_environment":
-                self._write_linux_etc_environment_with_privilege(text)
-            elif target.startswith("wsl_dotenv:"):
-                raw = target[len("wsl_dotenv:") :]
-                distro, pth = raw.split(":", 1)
-                self.wsl.write_file(distro, pth, text)
-            elif target.startswith("wsl:") and target.endswith(":bashrc"):
-                distro = target.split(":", 2)[1]
-                self.wsl.write_file(distro, "~/.bashrc", text)
-            elif target.startswith("wsl:") and target.endswith(":etc_environment"):
-                distro = target.split(":", 2)[1]
-                self.wsl.write_file_with_privilege(distro, "/etc/environment", text)
-            elif target in {"powershell:current_user", "powershell:all_users"}:
-                profile = self._validated_powershell_restore_path(target)
-                profile.parent.mkdir(parents=True, exist_ok=True)
-                profile.write_text(text, encoding="utf-8")
-            elif target in {"windows:user", "windows:machine"}:
-                # For registry backups (json snapshot), apply key-by-key best effort.
-                if self.win_provider is None:
-                    raise RuntimeError("Windows provider unavailable for registry restore")
-                data = json.loads(text)
-                scope = (
-                    WindowsRegistryProvider.USER_SCOPE if target == "windows:user" else WindowsRegistryProvider.MACHINE_SCOPE
-                )
-                current = self.win_provider.list_scope(scope)
-                for key in list(current.keys()):
-                    if key not in data:
-                        self.win_provider.remove_scope_value(scope, key)
-                for key, value in data.items():
-                    self.win_provider.set_scope_value(scope, key, str(value))
-            else:
-                raise RuntimeError(f"Unsupported restore target: {target}")
+            self._restore_target(target=target, text=text, scope_roots=resolved_scope_roots)
 
             result = OperationResult(
                 operation_id=operation_id,
@@ -667,3 +787,4 @@ class EnvInspectorService:
 
         self.audit.log(result)
         return result.to_dict()
+

--- a/release-notes/v1.0.0.md
+++ b/release-notes/v1.0.0.md
@@ -1,24 +1,24 @@
-## Env Inspector v1.0.0
+# Env Inspector v1.0.0
 
-### Highlights
+## Highlights
 
 - Cross-platform environment variable inspector/editor with GUI + CLI.
 - Multi-target set/remove with diff previews before apply.
 - Built-in backup/restore with audit logging in `./.env-inspector-state/`.
 
-### Platform Support
+## Platform Support
 
 - Windows process + registry + PowerShell profile sources.
 - WSL distro bridge support (`~/.bashrc`, `/etc/environment`, WSL dotenv scanning).
 - Native Linux support (`~/.bashrc`, `/etc/environment`) with deterministic sudo fallback behavior.
 
-### Security and Reliability
+## Security and Reliability
 
 - Secret masking defaults in UI/exports/audit pathways.
 - Scoped local dotenv write policy (`cwd` by default, optional `--root` allowlist extension).
 - Safe write flows with per-target backups and restore support.
 
-### Release Assets
+## Release Assets
 
 - `env-inspector.exe`
 - `env-inspector.exe.sha256`

--- a/release-notes/v1.0.0.md
+++ b/release-notes/v1.0.0.md
@@ -1,21 +1,25 @@
 ## Env Inspector v1.0.0
 
 ### Highlights
+
 - Cross-platform environment variable inspector/editor with GUI + CLI.
 - Multi-target set/remove with diff previews before apply.
 - Built-in backup/restore with audit logging in `./.env-inspector-state/`.
 
 ### Platform Support
+
 - Windows process + registry + PowerShell profile sources.
 - WSL distro bridge support (`~/.bashrc`, `/etc/environment`, WSL dotenv scanning).
 - Native Linux support (`~/.bashrc`, `/etc/environment`) with deterministic sudo fallback behavior.
 
 ### Security and Reliability
+
 - Secret masking defaults in UI/exports/audit pathways.
 - Scoped local dotenv write policy (`cwd` by default, optional `--root` allowlist extension).
 - Safe write flows with per-target backups and restore support.
 
 ### Release Assets
+
 - `env-inspector.exe`
 - `env-inspector.exe.sha256`
 

--- a/scripts/quality/assert_coverage_100.py
+++ b/scripts/quality/assert_coverage_100.py
@@ -9,6 +9,13 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_HELPER_ROOT = _SCRIPT_DIR if (_SCRIPT_DIR / "security_helpers.py").exists() else _SCRIPT_DIR.parent
+if str(_HELPER_ROOT) not in sys.path:
+    sys.path.insert(0, str(_HELPER_ROOT))
+
+from security_helpers import safe_output_path_in_workspace
+
 
 @dataclass
 class CoverageStats:
@@ -53,7 +60,7 @@ def parse_named_path(value: str) -> tuple[str, Path]:
 
 
 def parse_coverage_xml(name: str, path: Path) -> CoverageStats:
-    text = path.read_text(encoding="utf-8")
+    text = path.read_text(encoding="utf-8")  # codeql[py/path-injection] CI-controlled local coverage input
     lines_valid_match = _XML_LINES_VALID_RE.search(text)
     lines_covered_match = _XML_LINES_COVERED_RE.search(text)
 
@@ -79,7 +86,7 @@ def parse_lcov(name: str, path: Path) -> CoverageStats:
     total = 0
     covered = 0
 
-    for raw in path.read_text(encoding="utf-8").splitlines():
+    for raw in path.read_text(encoding="utf-8").splitlines():  # codeql[py/path-injection] CI-controlled local coverage input
         line = raw.strip()
         if line.startswith("LF:"):
             total += int(line.split(":", 1)[1])
@@ -139,19 +146,6 @@ def _render_md(payload: dict) -> str:
     return "\n".join(lines) + "\n"
 
 
-def _safe_output_path(raw: str, fallback: str, base: Path | None = None) -> Path:
-    root = (base or Path.cwd()).resolve()
-    candidate = Path((raw or "").strip() or fallback).expanduser()
-    if not candidate.is_absolute():
-        candidate = root / candidate
-    resolved = candidate.resolve(strict=False)
-    try:
-        resolved.relative_to(root)
-    except ValueError as exc:
-        raise ValueError(f"Output path escapes workspace root: {candidate}") from exc
-    return resolved
-
-
 def main() -> int:
     args = _parse_args()
 
@@ -186,8 +180,8 @@ def main() -> int:
     }
 
     try:
-        out_json = _safe_output_path(args.out_json, "coverage-100/coverage.json")
-        out_md = _safe_output_path(args.out_md, "coverage-100/coverage.md")
+        out_json = safe_output_path_in_workspace(args.out_json, "coverage-100/coverage.json")
+        out_md = safe_output_path_in_workspace(args.out_md, "coverage-100/coverage.md")
     except ValueError as exc:
         print(str(exc), file=sys.stderr)
         return 1

--- a/scripts/quality/assert_coverage_100.py
+++ b/scripts/quality/assert_coverage_100.py
@@ -14,7 +14,7 @@ _HELPER_ROOT = _SCRIPT_DIR if (_SCRIPT_DIR / "security_helpers.py").exists() els
 if str(_HELPER_ROOT) not in sys.path:
     sys.path.insert(0, str(_HELPER_ROOT))
 
-from security_helpers import safe_output_path_in_workspace
+from security_helpers import safe_input_file_path_in_workspace, safe_output_path_in_workspace
 
 
 @dataclass
@@ -58,14 +58,7 @@ def parse_named_path(value: str) -> tuple[str, Path]:
         raise ValueError(f"Invalid input '{value}'. Expected format: name=path")
     name = match.group("name").strip()
     raw_path = match.group("path").strip()
-    candidate = Path(raw_path).expanduser().resolve(strict=False)
-    workspace_root = Path.cwd().resolve()
-    try:
-        candidate.relative_to(workspace_root)
-    except ValueError as exc:
-        raise ValueError(f"Coverage input path must stay inside workspace: {candidate}") from exc
-    if not candidate.exists() or not candidate.is_file():
-        raise ValueError(f"Coverage input file does not exist: {candidate}")
+    candidate = safe_input_file_path_in_workspace(raw_path)
     return name, candidate
 
 
@@ -207,3 +200,5 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
+
+

--- a/scripts/quality/assert_coverage_100.py
+++ b/scripts/quality/assert_coverage_100.py
@@ -56,11 +56,21 @@ def parse_named_path(value: str) -> tuple[str, Path]:
     match = _PAIR_RE.match(value.strip())
     if not match:
         raise ValueError(f"Invalid input '{value}'. Expected format: name=path")
-    return match.group("name").strip(), Path(match.group("path").strip())
+    name = match.group("name").strip()
+    raw_path = match.group("path").strip()
+    candidate = Path(raw_path).expanduser().resolve(strict=False)
+    workspace_root = Path.cwd().resolve()
+    try:
+        candidate.relative_to(workspace_root)
+    except ValueError as exc:
+        raise ValueError(f"Coverage input path must stay inside workspace: {candidate}") from exc
+    if not candidate.exists() or not candidate.is_file():
+        raise ValueError(f"Coverage input file does not exist: {candidate}")
+    return name, candidate
 
 
 def parse_coverage_xml(name: str, path: Path) -> CoverageStats:
-    text = path.read_text(encoding="utf-8")  # codeql[py/path-injection] CI-controlled local coverage input
+    text = path.read_text(encoding="utf-8")  # lgtm [py/path-injection]
     lines_valid_match = _XML_LINES_VALID_RE.search(text)
     lines_covered_match = _XML_LINES_COVERED_RE.search(text)
 
@@ -86,7 +96,7 @@ def parse_lcov(name: str, path: Path) -> CoverageStats:
     total = 0
     covered = 0
 
-    for raw in path.read_text(encoding="utf-8").splitlines():  # codeql[py/path-injection] CI-controlled local coverage input
+    for raw in path.read_text(encoding="utf-8").splitlines():  # lgtm [py/path-injection]
         line = raw.strip()
         if line.startswith("LF:"):
             total += int(line.split(":", 1)[1])

--- a/scripts/quality/check_codacy_zero.py
+++ b/scripts/quality/check_codacy_zero.py
@@ -65,30 +65,26 @@ def _request_json(
     return payload
 
 
+def _walk_nodes(payload: Any) -> list[Any]:
+    stack: list[Any] = [payload]
+    nodes: list[Any] = []
+    while stack:
+        node = stack.pop()
+        nodes.append(node)
+        if isinstance(node, dict):
+            stack.extend(node.values())
+        elif isinstance(node, list):
+            stack.extend(node)
+    return nodes
+
+
 def extract_total_open(payload: Any) -> int | None:
-    if isinstance(payload, dict):
-        for key, value in payload.items():
+    for node in _walk_nodes(payload):
+        if not isinstance(node, dict):
+            continue
+        for key, value in node.items():
             if key in TOTAL_KEYS and isinstance(value, (int, float)):
                 return int(value)
-
-        # common pagination structures
-        for key in ("pagination", "page", "meta"):
-            nested = payload.get(key)
-            total = extract_total_open(nested)
-            if total is not None:
-                return total
-
-        for value in payload.values():
-            total = extract_total_open(value)
-            if total is not None:
-                return total
-
-    if isinstance(payload, list):
-        for item in payload:
-            total = extract_total_open(item)
-            if total is not None:
-                return total
-
     return None
 
 
@@ -194,3 +190,4 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
+

--- a/scripts/quality/check_codacy_zero.py
+++ b/scripts/quality/check_codacy_zero.py
@@ -14,7 +14,7 @@ _HELPER_ROOT = _SCRIPT_DIR if (_SCRIPT_DIR / "security_helpers.py").exists() els
 if str(_HELPER_ROOT) not in sys.path:
     sys.path.insert(0, str(_HELPER_ROOT))
 
-from security_helpers import encode_identifier, request_json_https
+from security_helpers import encode_identifier, request_json_https, safe_output_path_in_workspace
 
 
 TOTAL_KEYS = {"total", "totalItems", "total_items", "count", "hits", "open_issues"}
@@ -111,19 +111,6 @@ def _render_md(payload: dict) -> str:
     return "\n".join(lines) + "\n"
 
 
-def _safe_output_path(raw: str, fallback: str, base: Path | None = None) -> Path:
-    root = (base or Path.cwd()).resolve()
-    candidate = Path((raw or "").strip() or fallback).expanduser()
-    if not candidate.is_absolute():
-        candidate = root / candidate
-    resolved = candidate.resolve(strict=False)
-    try:
-        resolved.relative_to(root)
-    except ValueError as exc:
-        raise ValueError(f"Output path escapes workspace root: {candidate}") from exc
-    return resolved
-
-
 def main() -> int:
     import os
 
@@ -191,8 +178,8 @@ def main() -> int:
     }
 
     try:
-        out_json = _safe_output_path(args.out_json, "codacy-zero/codacy.json")
-        out_md = _safe_output_path(args.out_md, "codacy-zero/codacy.md")
+        out_json = safe_output_path_in_workspace(args.out_json, "codacy-zero/codacy.json")
+        out_md = safe_output_path_in_workspace(args.out_md, "codacy-zero/codacy.md")
     except ValueError as exc:
         print(str(exc), file=sys.stderr)
         return 1

--- a/scripts/quality/check_deepscan_zero.py
+++ b/scripts/quality/check_deepscan_zero.py
@@ -13,7 +13,7 @@ _HELPER_ROOT = _SCRIPT_DIR if (_SCRIPT_DIR / "security_helpers.py").exists() els
 if str(_HELPER_ROOT) not in sys.path:
     sys.path.insert(0, str(_HELPER_ROOT))
 
-from security_helpers import request_json_https, split_validated_https_url
+from security_helpers import request_json_https, safe_output_path_in_workspace, split_validated_https_url
 
 TOTAL_KEYS = {"total", "totalItems", "total_items", "count", "hits", "open_issues"}
 
@@ -79,19 +79,6 @@ def _render_md(payload: dict) -> str:
     return "\n".join(lines) + "\n"
 
 
-def _safe_output_path(raw: str, fallback: str, base: Path | None = None) -> Path:
-    root = (base or Path.cwd()).resolve()
-    candidate = Path((raw or "").strip() or fallback).expanduser()
-    if not candidate.is_absolute():
-        candidate = root / candidate
-    resolved = candidate.resolve(strict=False)
-    try:
-        resolved.relative_to(root)
-    except ValueError as exc:
-        raise ValueError(f"Output path escapes workspace root: {candidate}") from exc
-    return resolved
-
-
 def main() -> int:
     import os
 
@@ -138,8 +125,8 @@ def main() -> int:
     }
 
     try:
-        out_json = _safe_output_path(args.out_json, "deepscan-zero/deepscan.json")
-        out_md = _safe_output_path(args.out_md, "deepscan-zero/deepscan.md")
+        out_json = safe_output_path_in_workspace(args.out_json, "deepscan-zero/deepscan.json")
+        out_md = safe_output_path_in_workspace(args.out_md, "deepscan-zero/deepscan.md")
     except ValueError as exc:
         print(str(exc), file=sys.stderr)
         return 1

--- a/scripts/quality/check_quality_secrets.py
+++ b/scripts/quality/check_quality_secrets.py
@@ -8,6 +8,13 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_HELPER_ROOT = _SCRIPT_DIR if (_SCRIPT_DIR / "security_helpers.py").exists() else _SCRIPT_DIR.parent
+if str(_HELPER_ROOT) not in sys.path:
+    sys.path.insert(0, str(_HELPER_ROOT))
+
+from security_helpers import safe_output_path_in_workspace
+
 DEFAULT_REQUIRED_SECRETS = [
     "SONAR_TOKEN",
     "CODACY_API_TOKEN",
@@ -86,19 +93,6 @@ def _render_md(payload: dict) -> str:
     return "\n".join(lines) + "\n"
 
 
-def _safe_output_path(raw: str, fallback: str, base: Path | None = None) -> Path:
-    root = (base or Path.cwd()).resolve()
-    candidate = Path((raw or "").strip() or fallback).expanduser()
-    if not candidate.is_absolute():
-        candidate = root / candidate
-    resolved = candidate.resolve(strict=False)
-    try:
-        resolved.relative_to(root)
-    except ValueError as exc:
-        raise ValueError(f"Output path escapes workspace root: {candidate}") from exc
-    return resolved
-
-
 def main() -> int:
     args = _parse_args()
     required_secrets = _dedupe(DEFAULT_REQUIRED_SECRETS + list(args.required_secret or []))
@@ -117,8 +111,8 @@ def main() -> int:
     }
 
     try:
-        out_json = _safe_output_path(args.out_json, "quality-secrets/secrets.json")
-        out_md = _safe_output_path(args.out_md, "quality-secrets/secrets.md")
+        out_json = safe_output_path_in_workspace(args.out_json, "quality-secrets/secrets.json")
+        out_md = safe_output_path_in_workspace(args.out_md, "quality-secrets/secrets.md")
     except ValueError as exc:
         print(str(exc), file=sys.stderr)
         return 1

--- a/scripts/quality/check_required_checks.py
+++ b/scripts/quality/check_required_checks.py
@@ -4,13 +4,22 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 import time
-import urllib.parse
-import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_HELPER_ROOT = _SCRIPT_DIR if (_SCRIPT_DIR / "security_helpers.py").exists() else _SCRIPT_DIR.parent
+if str(_HELPER_ROOT) not in sys.path:
+    sys.path.insert(0, str(_HELPER_ROOT))
+
+from security_helpers import encode_identifier, request_json_https, safe_output_path_in_workspace
+
+GITHUB_API_HOST = "api.github.com"
+_SHA_RE = re.compile(r"^[0-9a-fA-F]{7,64}$")
 
 
 def _parse_args() -> argparse.Namespace:
@@ -25,20 +34,60 @@ def _parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def _api_get(repo: str, path: str, token: str) -> dict[str, Any]:
-    url = f"https://api.github.com/repos/{repo}/{path.lstrip('/')}"
-    req = urllib.request.Request(
-        url,
+def _parse_repo(raw: str) -> tuple[str, str]:
+    text = (raw or "").strip()
+    if "/" not in text:
+        raise ValueError("Repo must be in owner/repo format.")
+    owner, repo = text.split("/", 1)
+    return (
+        encode_identifier(owner, field_name="GitHub owner"),
+        encode_identifier(repo, field_name="GitHub repo"),
+    )
+
+
+def _parse_sha(raw: str) -> str:
+    sha = (raw or "").strip()
+    if not _SHA_RE.fullmatch(sha):
+        raise ValueError("Commit SHA must be a 7-64 char hex string.")
+    return sha.lower()
+
+
+def _github_headers(token: str) -> dict[str, str]:
+    return {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "reframe-quality-zero-gate",
+    }
+
+
+def _api_get_check_runs(*, owner: str, repo: str, sha: str, token: str) -> dict[str, Any]:
+    payload, _headers = request_json_https(
+        host=GITHUB_API_HOST,
+        path=f"/repos/{owner}/{repo}/commits/{sha}/check-runs",
         headers={
-            "Accept": "application/vnd.github+json",
-            "Authorization": f"Bearer {token}",
-            "X-GitHub-Api-Version": "2022-11-28",
-            "User-Agent": "reframe-quality-zero-gate",
+            **_github_headers(token),
+        },
+        query={"per_page": "100"},
+        method="GET",
+    )
+    if not isinstance(payload, dict):
+        raise RuntimeError("Unexpected GitHub check-runs response payload.")
+    return payload
+
+
+def _api_get_status(*, owner: str, repo: str, sha: str, token: str) -> dict[str, Any]:
+    payload, _headers = request_json_https(
+        host=GITHUB_API_HOST,
+        path=f"/repos/{owner}/{repo}/commits/{sha}/status",
+        headers={
+            **_github_headers(token),
         },
         method="GET",
     )
-    with urllib.request.urlopen(req, timeout=30) as resp:
-        return json.loads(resp.read().decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise RuntimeError("Unexpected GitHub status response payload.")
+    return payload
 
 
 def _collect_contexts(check_runs_payload: dict[str, Any], status_payload: dict[str, Any]) -> dict[str, dict[str, str]]:
@@ -121,19 +170,6 @@ def _render_md(payload: dict) -> str:
     return "\n".join(lines) + "\n"
 
 
-def _safe_output_path(raw: str, fallback: str, base: Path | None = None) -> Path:
-    root = (base or Path.cwd()).resolve()
-    candidate = Path((raw or "").strip() or fallback).expanduser()
-    if not candidate.is_absolute():
-        candidate = root / candidate
-    resolved = candidate.resolve(strict=False)
-    try:
-        resolved.relative_to(root)
-    except ValueError as exc:
-        raise ValueError(f"Output path escapes workspace root: {candidate}") from exc
-    return resolved
-
-
 def main() -> int:
     args = _parse_args()
     token = (os.environ.get("GITHUB_TOKEN", "") or os.environ.get("GH_TOKEN", "")).strip()
@@ -143,20 +179,25 @@ def main() -> int:
         raise SystemExit("At least one --required-context is required")
     if not token:
         raise SystemExit("GITHUB_TOKEN or GH_TOKEN is required")
+    try:
+        owner_slug, repo_slug = _parse_repo(args.repo)
+        sha = _parse_sha(args.sha)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
 
     deadline = time.time() + max(args.timeout_seconds, 1)
 
     final_payload: dict[str, Any] | None = None
     while time.time() <= deadline:
-        check_runs = _api_get(args.repo, f"commits/{args.sha}/check-runs?per_page=100", token)
-        statuses = _api_get(args.repo, f"commits/{args.sha}/status", token)
+        check_runs = _api_get_check_runs(owner=owner_slug, repo=repo_slug, sha=sha, token=token)
+        statuses = _api_get_status(owner=owner_slug, repo=repo_slug, sha=sha, token=token)
         contexts = _collect_contexts(check_runs, statuses)
         status, missing, failed = _evaluate(required, contexts)
 
         final_payload = {
             "status": status,
             "repo": args.repo,
-            "sha": args.sha,
+            "sha": sha,
             "required": required,
             "missing": missing,
             "failed": failed,
@@ -177,8 +218,8 @@ def main() -> int:
         raise SystemExit("No payload collected")
 
     try:
-        out_json = _safe_output_path(args.out_json, "quality-zero-gate/required-checks.json")
-        out_md = _safe_output_path(args.out_md, "quality-zero-gate/required-checks.md")
+        out_json = safe_output_path_in_workspace(args.out_json, "quality-zero-gate/required-checks.json")
+        out_md = safe_output_path_in_workspace(args.out_md, "quality-zero-gate/required-checks.md")
     except ValueError as exc:
         print(str(exc), file=sys.stderr)
         return 1

--- a/scripts/quality/check_sentry_zero.py
+++ b/scripts/quality/check_sentry_zero.py
@@ -63,6 +63,65 @@ def _hits_from_headers(headers: dict[str, str]) -> int | None:
         return None
 
 
+def _collect_projects(args: argparse.Namespace, env: dict[str, str]) -> list[str]:
+    projects = [p for p in args.project if p]
+    if projects:
+        return projects
+
+    resolved: list[str] = []
+    for env_name in ("SENTRY_PROJECT_BACKEND", "SENTRY_PROJECT_WEB"):
+        value = str(env.get(env_name, "")).strip()
+        if value:
+            resolved.append(value)
+    return resolved
+
+
+def _missing_config_findings(token: str, org: str, projects: list[str]) -> list[str]:
+    findings: list[str] = []
+    if not token:
+        findings.append("SENTRY_AUTH_TOKEN is missing.")
+    if not org:
+        findings.append("SENTRY_ORG is missing.")
+    if not projects:
+        findings.append("No Sentry projects configured (SENTRY_PROJECT_BACKEND/SENTRY_PROJECT_WEB).")
+    return findings
+
+
+def _scan_projects(org: str, projects: list[str], token: str) -> tuple[str, list[dict[str, Any]], list[str], list[str]]:
+    mode = "strict"
+    project_results: list[dict[str, Any]] = []
+    findings: list[str] = []
+    failures: list[str] = []
+
+    for project in projects:
+        try:
+            issues, headers = _request_project_issues(org, project, token)
+            unresolved = _hits_from_headers(headers)
+            if unresolved is None:
+                unresolved = len(issues)
+                if unresolved >= 1:
+                    failures.append(
+                        f"Sentry project {project} returned unresolved issues but no X-Hits header for exact totals."
+                    )
+            if unresolved != 0:
+                failures.append(f"Sentry project {project} has {unresolved} unresolved issues (expected 0).")
+            project_results.append({"project": project, "unresolved": unresolved})
+        except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                mode = "skipped"
+                findings.append(f"Sentry project {project} not found (HTTP 404). Skipping project.")
+                continue
+            failures.append(f"Sentry API request failed for project {project}: HTTP {exc.code}")
+            mode = "error"
+            break
+        except Exception as exc:  # pragma: no cover - network/runtime surface
+            failures.append(f"Sentry API request failed for project {project}: {exc}")
+            mode = "error"
+            break
+
+    return mode, project_results, findings, failures
+
+
 def _render_md(payload: dict) -> str:
     lines = [
         "# Sentry Zero Gate",
@@ -97,58 +156,20 @@ def main() -> int:
     args = _parse_args()
     token = (args.token or os.environ.get("SENTRY_AUTH_TOKEN", "")).strip()
     org = (args.org or os.environ.get("SENTRY_ORG", "")).strip()
+    projects = _collect_projects(args, os.environ)
 
-    projects = [p for p in args.project if p]
-    if not projects:
-        for env_name in ("SENTRY_PROJECT_BACKEND", "SENTRY_PROJECT_WEB"):
-            value = str(os.environ.get(env_name, "")).strip()
-            if value:
-                projects.append(value)
-
-    findings: list[str] = []
-    failures: list[str] = []
+    findings = _missing_config_findings(token, org, projects)
     project_results: list[dict[str, Any]] = []
     mode = "strict"
-
-    if not token:
-        findings.append("SENTRY_AUTH_TOKEN is missing.")
-    if not org:
-        findings.append("SENTRY_ORG is missing.")
-    if not projects:
-        findings.append("No Sentry projects configured (SENTRY_PROJECT_BACKEND/SENTRY_PROJECT_WEB).")
 
     if findings:
         status = "pass"
         mode = "skipped"
     else:
-        for project in projects:
-            try:
-                issues, headers = _request_project_issues(org, project, token)
-                unresolved = _hits_from_headers(headers)
-                if unresolved is None:
-                    unresolved = len(issues)
-                    if unresolved >= 1:
-                        failures.append(
-                            f"Sentry project {project} returned unresolved issues but no X-Hits header for exact totals."
-                        )
-                if unresolved != 0:
-                    failures.append(f"Sentry project {project} has {unresolved} unresolved issues (expected 0).")
-                project_results.append({"project": project, "unresolved": unresolved})
-            except urllib.error.HTTPError as exc:
-                if exc.code == 404:
-                    mode = "skipped"
-                    findings.append(f"Sentry project {project} not found (HTTP 404). Skipping project.")
-                    continue
-                failures.append(f"Sentry API request failed for project {project}: HTTP {exc.code}")
-                mode = "error"
-                break
-            except Exception as exc:  # pragma: no cover - network/runtime surface
-                failures.append(f"Sentry API request failed for project {project}: {exc}")
-                mode = "error"
-                break
-
-        status = "pass" if not failures else "fail"
+        mode, project_results, runtime_findings, failures = _scan_projects(org, projects, token)
+        findings.extend(runtime_findings)
         findings.extend(failures)
+        status = "pass" if not failures else "fail"
 
     payload = {
         "status": status,

--- a/scripts/quality/check_sentry_zero.py
+++ b/scripts/quality/check_sentry_zero.py
@@ -14,7 +14,7 @@ _HELPER_ROOT = _SCRIPT_DIR if (_SCRIPT_DIR / "security_helpers.py").exists() els
 if str(_HELPER_ROOT) not in sys.path:
     sys.path.insert(0, str(_HELPER_ROOT))
 
-from security_helpers import encode_identifier, request_json_https
+from security_helpers import encode_identifier, request_json_https, safe_output_path_in_workspace
 
 SENTRY_API_HOST = "sentry.io"
 
@@ -91,19 +91,6 @@ def _render_md(payload: dict) -> str:
     return "\n".join(lines) + "\n"
 
 
-def _safe_output_path(raw: str, fallback: str, base: Path | None = None) -> Path:
-    root = (base or Path.cwd()).resolve()
-    candidate = Path((raw or "").strip() or fallback).expanduser()
-    if not candidate.is_absolute():
-        candidate = root / candidate
-    resolved = candidate.resolve(strict=False)
-    try:
-        resolved.relative_to(root)
-    except ValueError as exc:
-        raise ValueError(f"Output path escapes workspace root: {candidate}") from exc
-    return resolved
-
-
 def main() -> int:
     import os
 
@@ -173,8 +160,8 @@ def main() -> int:
     }
 
     try:
-        out_json = _safe_output_path(args.out_json, "sentry-zero/sentry.json")
-        out_md = _safe_output_path(args.out_md, "sentry-zero/sentry.md")
+        out_json = safe_output_path_in_workspace(args.out_json, "sentry-zero/sentry.json")
+        out_md = safe_output_path_in_workspace(args.out_md, "sentry-zero/sentry.md")
     except ValueError as exc:
         print(str(exc), file=sys.stderr)
         return 1

--- a/scripts/quality/check_sonar_zero.py
+++ b/scripts/quality/check_sonar_zero.py
@@ -16,7 +16,7 @@ _HELPER_ROOT = _SCRIPT_DIR if (_SCRIPT_DIR / "security_helpers.py").exists() els
 if str(_HELPER_ROOT) not in sys.path:
     sys.path.insert(0, str(_HELPER_ROOT))
 
-from security_helpers import normalize_https_url
+from security_helpers import normalize_https_url, safe_output_path_in_workspace
 
 SONAR_API_BASE = "https://sonarcloud.io"
 
@@ -70,19 +70,6 @@ def _render_md(payload: dict) -> str:
     else:
         lines.append("- None")
     return "\n".join(lines) + "\n"
-
-
-def _safe_output_path(raw: str, fallback: str, base: Path | None = None) -> Path:
-    root = (base or Path.cwd()).resolve()
-    candidate = Path((raw or "").strip() or fallback).expanduser()
-    if not candidate.is_absolute():
-        candidate = root / candidate
-    resolved = candidate.resolve(strict=False)
-    try:
-        resolved.relative_to(root)
-    except ValueError as exc:
-        raise ValueError(f"Output path escapes workspace root: {candidate}") from exc
-    return resolved
 
 
 def main() -> int:
@@ -147,8 +134,8 @@ def main() -> int:
     }
 
     try:
-        out_json = _safe_output_path(args.out_json, "sonar-zero/sonar.json")
-        out_md = _safe_output_path(args.out_md, "sonar-zero/sonar.md")
+        out_json = safe_output_path_in_workspace(args.out_json, "sonar-zero/sonar.json")
+        out_md = safe_output_path_in_workspace(args.out_md, "sonar-zero/sonar.md")
     except ValueError as exc:
         print(str(exc), file=sys.stderr)
         return 1

--- a/scripts/security_helpers.py
+++ b/scripts/security_helpers.py
@@ -6,6 +6,7 @@ import json
 import re
 import urllib.error
 import urllib.parse
+from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse, urlunparse
 
@@ -176,3 +177,16 @@ def request_json_https(
         )
 
     return json.loads(raw_body), response_headers
+
+
+def safe_output_path_in_workspace(raw: str, fallback: str, base: Path | None = None) -> Path:
+    root = (base or Path.cwd()).resolve()
+    candidate = Path((raw or "").strip() or fallback).expanduser()  # codeql[py/path-injection] constrained to workspace
+    if not candidate.is_absolute():
+        candidate = root / candidate
+    resolved = candidate.resolve(strict=False)
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise ValueError(f"Output path escapes workspace root: {candidate}") from exc
+    return resolved

--- a/scripts/security_helpers.py
+++ b/scripts/security_helpers.py
@@ -25,36 +25,49 @@ def _parse_https_url(raw_url: str):
     return parsed
 
 
+def _normalized_hosts(values: set[str] | None) -> set[str]:
+    if not values:
+        return set()
+    return {value.lower().strip(".") for value in values if value.strip(".")}
+
+
+def _hostname_matches_suffix(hostname: str, suffixes: set[str]) -> bool:
+    return any(hostname == suffix or hostname.endswith(f".{suffix}") for suffix in suffixes)
+
+
 def _validate_hostname_allowlists(
     hostname: str,
     *,
     allowed_hosts: set[str] | None = None,
     allowed_host_suffixes: set[str] | None = None,
 ) -> None:
-    if allowed_hosts is not None and hostname not in {host.lower().strip(".") for host in allowed_hosts}:
+    exact_hosts = _normalized_hosts(allowed_hosts)
+    if exact_hosts and hostname not in exact_hosts:
         raise ValueError(f"URL host is not in allowlist: {hostname}")
 
-    if allowed_host_suffixes is None:
-        return
-
-    suffixes = {suffix.lower().strip(".") for suffix in allowed_host_suffixes if suffix.strip(".")}
-    if suffixes and not any(hostname == suffix or hostname.endswith(f".{suffix}") for suffix in suffixes):
+    suffixes = _normalized_hosts(allowed_host_suffixes)
+    if suffixes and not _hostname_matches_suffix(hostname, suffixes):
         raise ValueError(f"URL host is not in suffix allowlist: {hostname}")
 
 
-def _reject_local_targets(hostname: str) -> None:
+def _is_local_or_private_ip(hostname: str) -> bool:
     try:
         ip_value = ipaddress.ip_address(hostname)
     except ValueError:
-        ip_value = None
+        return False
 
-    if ip_value is not None and (
-        ip_value.is_private
-        or ip_value.is_loopback
-        or ip_value.is_link_local
-        or ip_value.is_reserved
-        or ip_value.is_multicast
-    ):
+    checks = (
+        ip_value.is_private,
+        ip_value.is_loopback,
+        ip_value.is_link_local,
+        ip_value.is_reserved,
+        ip_value.is_multicast,
+    )
+    return any(checks)
+
+
+def _reject_local_targets(hostname: str) -> None:
+    if _is_local_or_private_ip(hostname):
         raise ValueError(f"Private or local addresses are not allowed: {hostname}")
 
     if hostname in {"localhost", "localhost.localdomain"}:

--- a/scripts/security_helpers.py
+++ b/scripts/security_helpers.py
@@ -14,6 +14,53 @@ from urllib.parse import urlparse, urlunparse
 _IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 
 
+def _parse_https_url(raw_url: str):
+    parsed = urlparse((raw_url or "").strip())
+    if parsed.scheme != "https":
+        raise ValueError(f"Only https URLs are allowed: {raw_url!r}")
+    if not parsed.hostname:
+        raise ValueError(f"URL is missing a hostname: {raw_url!r}")
+    if parsed.username or parsed.password:
+        raise ValueError(f"URL credentials are not allowed: {raw_url!r}")
+    return parsed
+
+
+def _validate_hostname_allowlists(
+    hostname: str,
+    *,
+    allowed_hosts: set[str] | None = None,
+    allowed_host_suffixes: set[str] | None = None,
+) -> None:
+    if allowed_hosts is not None and hostname not in {host.lower().strip(".") for host in allowed_hosts}:
+        raise ValueError(f"URL host is not in allowlist: {hostname}")
+
+    if allowed_host_suffixes is None:
+        return
+
+    suffixes = {suffix.lower().strip(".") for suffix in allowed_host_suffixes if suffix.strip(".")}
+    if suffixes and not any(hostname == suffix or hostname.endswith(f".{suffix}") for suffix in suffixes):
+        raise ValueError(f"URL host is not in suffix allowlist: {hostname}")
+
+
+def _reject_local_targets(hostname: str) -> None:
+    try:
+        ip_value = ipaddress.ip_address(hostname)
+    except ValueError:
+        ip_value = None
+
+    if ip_value is not None and (
+        ip_value.is_private
+        or ip_value.is_loopback
+        or ip_value.is_link_local
+        or ip_value.is_reserved
+        or ip_value.is_multicast
+    ):
+        raise ValueError(f"Private or local addresses are not allowed: {hostname}")
+
+    if hostname in {"localhost", "localhost.localdomain"}:
+        raise ValueError("Localhost URLs are not allowed.")
+
+
 def normalize_https_url(
     raw_url: str,
     *,
@@ -31,38 +78,14 @@ def normalize_https_url(
     - optional hostname suffix allowlist.
     """
 
-    parsed = urlparse((raw_url or "").strip())
-    if parsed.scheme != "https":
-        raise ValueError(f"Only https URLs are allowed: {raw_url!r}")
-    if not parsed.hostname:
-        raise ValueError(f"URL is missing a hostname: {raw_url!r}")
-    if parsed.username or parsed.password:
-        raise ValueError(f"URL credentials are not allowed: {raw_url!r}")
-
+    parsed = _parse_https_url(raw_url)
     hostname = parsed.hostname.lower().strip(".")
-    if allowed_hosts is not None and hostname not in {host.lower().strip(".") for host in allowed_hosts}:
-        raise ValueError(f"URL host is not in allowlist: {hostname}")
-    if allowed_host_suffixes is not None:
-        suffixes = {suffix.lower().strip(".") for suffix in allowed_host_suffixes if suffix.strip(".")}
-        if suffixes and not any(hostname == suffix or hostname.endswith(f".{suffix}") for suffix in suffixes):
-            raise ValueError(f"URL host is not in suffix allowlist: {hostname}")
-
-    try:
-        ip_value = ipaddress.ip_address(hostname)
-    except ValueError:
-        ip_value = None
-
-    if ip_value is not None and (
-        ip_value.is_private
-        or ip_value.is_loopback
-        or ip_value.is_link_local
-        or ip_value.is_reserved
-        or ip_value.is_multicast
-    ):
-        raise ValueError(f"Private or local addresses are not allowed: {hostname}")
-
-    if hostname in {"localhost", "localhost.localdomain"}:
-        raise ValueError("Localhost URLs are not allowed.")
+    _validate_hostname_allowlists(
+        hostname,
+        allowed_hosts=allowed_hosts,
+        allowed_host_suffixes=allowed_host_suffixes,
+    )
+    _reject_local_targets(hostname)
 
     sanitized = parsed._replace(fragment="", params="")
     if strip_query:
@@ -190,3 +213,20 @@ def safe_output_path_in_workspace(raw: str, fallback: str, base: Path | None = N
     except ValueError as exc:
         raise ValueError(f"Output path escapes workspace root: {candidate}") from exc
     return resolved
+
+
+def safe_input_file_path_in_workspace(raw: str, *, base: Path | None = None) -> Path:
+    root = (base or Path.cwd()).resolve()
+    candidate = Path((raw or "").strip()).expanduser()  # codeql[py/path-injection] constrained to workspace
+    if not candidate.is_absolute():
+        candidate = root / candidate
+    resolved = candidate.resolve(strict=False)
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise ValueError(f"Input file path escapes workspace root: {candidate}") from exc
+    if not resolved.exists() or not resolved.is_file():
+        raise ValueError(f"Input file does not exist: {resolved}")
+    return resolved
+
+

--- a/tests/test_backup_and_audit.py
+++ b/tests/test_backup_and_audit.py
@@ -121,3 +121,36 @@ def test_restore_rejects_backup_file_outside_state_directory(tmp_path: Path, mon
 
     assert result["success"] is False
     assert "outside managed backup directory" in (result["error_message"] or "")
+
+def test_restore_dotenv_backup_in_scope_writes_file(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    svc = EnvInspectorService(state_dir=tmp_path / "state")
+
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    env_file = allowed / ".env"
+
+    backup_path = svc.backup_mgr.backup_text(f"dotenv:{env_file}", "A=1\n")
+    result = svc.restore_backup(backup=str(backup_path), scope_roots=[allowed])
+
+    assert result["success"] is True
+    assert env_file.read_text(encoding="utf-8") == "A=1\n"
+
+
+def test_restore_dotenv_backup_rejects_outside_scope(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    svc = EnvInspectorService(state_dir=tmp_path / "state")
+
+    allowed = tmp_path / "allowed"
+    outside = tmp_path.parent / (tmp_path.name + "-outside")
+    allowed.mkdir()
+    outside.mkdir()
+    env_file = outside / ".env"
+
+    backup_path = svc.backup_mgr.backup_text(f"dotenv:{env_file}", "A=1\n")
+    result = svc.restore_backup(backup=str(backup_path), scope_roots=[allowed])
+
+    assert result["success"] is False
+    assert "outside approved roots" in (result["error_message"] or "")
+
+

--- a/tests/test_quality_assert_coverage.py
+++ b/tests/test_quality_assert_coverage.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.quality import assert_coverage_100 as coverage_mod
+from scripts import security_helpers as sec
+
+
+def test_parse_named_path_accepts_workspace_file(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    coverage_file = tmp_path / "coverage.xml"
+    coverage_file.write_text("<coverage lines-valid=\"1\" lines-covered=\"1\" />\n", encoding="utf-8")
+
+    name, path = coverage_mod.parse_named_path("python=coverage.xml")
+
+    assert name == "python"
+    assert path == coverage_file.resolve(strict=False)
+
+
+def test_parse_named_path_rejects_missing_format():
+    with pytest.raises(ValueError, match="Expected format"):
+        coverage_mod.parse_named_path("python")
+
+
+def test_parse_named_path_rejects_empty_name_format(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    coverage_file = tmp_path / "coverage.xml"
+    coverage_file.write_text("<coverage lines-valid=\"1\" lines-covered=\"1\" />\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Expected format"):
+        coverage_mod.parse_named_path("=coverage.xml")
+
+
+def test_parse_named_path_rejects_workspace_escape(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    outside = tmp_path.parent / "outside-coverage.xml"
+    outside.write_text("<coverage lines-valid=\"1\" lines-covered=\"1\" />\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="escapes workspace root"):
+        coverage_mod.parse_named_path(f"python={outside}")
+
+
+def test_parse_named_path_rejects_missing_file(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(ValueError, match="Input file does not exist"):
+        coverage_mod.parse_named_path("python=missing.xml")
+
+
+def test_safe_input_file_path_in_workspace_allows_relative_file(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    data = tmp_path / "data.txt"
+    data.write_text("ok\n", encoding="utf-8")
+
+    resolved = sec.safe_input_file_path_in_workspace("data.txt")
+
+    assert resolved == data.resolve(strict=False)
+
+
+def test_safe_input_file_path_in_workspace_rejects_escape(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    outside = tmp_path.parent / "leak.txt"
+    outside.write_text("nope\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="escapes workspace root"):
+        sec.safe_input_file_path_in_workspace(str(outside))
+
+

--- a/tests/test_quality_branch_coverage.py
+++ b/tests/test_quality_branch_coverage.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from types import SimpleNamespace
 import urllib.error
 
-import pytest
 
 from scripts.quality import check_codacy_zero as codacy_mod
 from scripts.quality import check_sentry_zero as sentry_mod

--- a/tests/test_quality_branch_coverage.py
+++ b/tests/test_quality_branch_coverage.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+import urllib.error
+
+import pytest
+
+from scripts.quality import check_codacy_zero as codacy_mod
+from scripts.quality import check_sentry_zero as sentry_mod
+
+
+def test_codacy_walk_nodes_and_extract_total_open():
+    payload = {"outer": [{"nested": {"open_issues": 7}}, {"other": "x"}]}
+
+    nodes = codacy_mod._walk_nodes(payload)
+
+    assert payload in nodes
+    assert codacy_mod.extract_total_open(payload) == 7
+    assert codacy_mod.extract_total_open({"outer": [{"nested": "value"}]}) is None
+
+
+def test_codacy_main_returns_error_for_invalid_output_path(tmp_path: Path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    args = SimpleNamespace(
+        provider="gh",
+        owner="Prekzursil",
+        repo="env-inspector",
+        token="",
+        out_json=str(tmp_path.parent / "escaped.json"),
+        out_md="reports/codacy.md",
+    )
+    monkeypatch.setattr(codacy_mod, "_parse_args", lambda: args)
+
+    rc = codacy_mod.main()
+
+    assert rc == 1
+    assert "escapes workspace root" in capsys.readouterr().err
+
+
+def test_sentry_collect_projects_prefers_args_and_env_fallback():
+    args_with_projects = SimpleNamespace(project=["backend", "web"])
+    args_without_projects = SimpleNamespace(project=[])
+
+    assert sentry_mod._collect_projects(args_with_projects, {}) == ["backend", "web"]
+    assert sentry_mod._collect_projects(
+        args_without_projects,
+        {"SENTRY_PROJECT_BACKEND": "backend", "SENTRY_PROJECT_WEB": "web"},
+    ) == ["backend", "web"]
+
+
+def test_sentry_scan_projects_covers_header_fallback_and_failures(monkeypatch):
+    def _fake_request_project_issues(org: str, project: str, token: str):
+        return [{"id": "1"}], {}
+
+    monkeypatch.setattr(sentry_mod, "_request_project_issues", _fake_request_project_issues)
+
+    mode, project_results, findings, failures = sentry_mod._scan_projects("org", ["proj"], "token")
+
+    assert mode == "strict"
+    assert project_results == [{"project": "proj", "unresolved": 1}]
+    assert findings == []
+    assert any("no X-Hits" in item for item in failures)
+    assert any("expected 0" in item for item in failures)
+
+
+def test_sentry_scan_projects_handles_http_404_and_http_500(monkeypatch):
+    def _raise_404(org: str, project: str, token: str):
+        raise urllib.error.HTTPError(url="https://sentry.io", code=404, msg="Not Found", hdrs=None, fp=None)
+
+    monkeypatch.setattr(sentry_mod, "_request_project_issues", _raise_404)
+    mode_404, project_results_404, findings_404, failures_404 = sentry_mod._scan_projects("org", ["proj"], "token")
+
+    assert mode_404 == "skipped"
+    assert project_results_404 == []
+    assert failures_404 == []
+    assert findings_404 and "HTTP 404" in findings_404[0]
+
+    def _raise_500(org: str, project: str, token: str):
+        raise urllib.error.HTTPError(url="https://sentry.io", code=500, msg="Err", hdrs=None, fp=None)
+
+    monkeypatch.setattr(sentry_mod, "_request_project_issues", _raise_500)
+    mode_500, project_results_500, findings_500, failures_500 = sentry_mod._scan_projects("org", ["proj"], "token")
+
+    assert mode_500 == "error"
+    assert project_results_500 == []
+    assert findings_500 == []
+    assert failures_500 and "HTTP 500" in failures_500[0]
+
+
+def test_sentry_main_strict_mode_pass_and_fail(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    args = SimpleNamespace(
+        org="my-org",
+        project=["proj"],
+        token="tok",
+        out_json="reports/sentry.json",
+        out_md="reports/sentry.md",
+    )
+    monkeypatch.setattr(sentry_mod, "_parse_args", lambda: args)
+    monkeypatch.setattr(
+        sentry_mod,
+        "_scan_projects",
+        lambda org, projects, token: ("strict", [{"project": "proj", "unresolved": 0}], [], []),
+    )
+
+    assert sentry_mod.main() == 0
+    assert (tmp_path / "reports" / "sentry.json").exists()
+
+    monkeypatch.setattr(
+        sentry_mod,
+        "_scan_projects",
+        lambda org, projects, token: ("error", [{"project": "proj", "unresolved": 1}], [], ["failure"]),
+    )
+    assert sentry_mod.main() == 1

--- a/tests/test_quality_script_outputs.py
+++ b/tests/test_quality_script_outputs.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from pathlib import Path
+
+from scripts.quality import assert_coverage_100 as coverage_mod
+from scripts.quality import check_codacy_zero as codacy_mod
+from scripts.quality import check_deepscan_zero as deepscan_mod
+from scripts.quality import check_sentry_zero as sentry_mod
+
+
+def test_parse_coverage_xml_reads_standard_attributes(tmp_path: Path):
+    xml_path = tmp_path / "coverage.xml"
+    xml_path.write_text('<coverage lines-valid="2" lines-covered="1"/>\n', encoding="utf-8")
+
+    stats = coverage_mod.parse_coverage_xml("python", xml_path)
+
+    assert stats.total == 2
+    assert stats.covered == 1
+
+
+def test_parse_lcov_reads_totals(tmp_path: Path):
+    lcov_path = tmp_path / "coverage.lcov"
+    lcov_path.write_text("LF:2\nLH:1\n", encoding="utf-8")
+
+    stats = coverage_mod.parse_lcov("python", lcov_path)
+
+    assert stats.total == 2
+    assert stats.covered == 1
+
+
+def test_assert_coverage_main_writes_outputs(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    xml_path = tmp_path / "coverage.xml"
+    xml_path.write_text('<coverage lines-valid="1" lines-covered="1"/>\n', encoding="utf-8")
+
+    args = SimpleNamespace(
+        xml=[f"python={xml_path}"],
+        lcov=[],
+        min_percent=100.0,
+        out_json="reports/coverage.json",
+        out_md="reports/coverage.md",
+    )
+    monkeypatch.setattr(coverage_mod, "_parse_args", lambda: args)
+
+    rc = coverage_mod.main()
+
+    assert rc == 0
+    assert (tmp_path / "reports" / "coverage.json").exists()
+    assert (tmp_path / "reports" / "coverage.md").exists()
+
+
+def test_codacy_main_writes_outputs_without_token(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("CODACY_API_TOKEN", raising=False)
+    args = SimpleNamespace(
+        provider="gh",
+        owner="Prekzursil",
+        repo="env-inspector",
+        token="",
+        out_json="reports/codacy.json",
+        out_md="reports/codacy.md",
+    )
+    monkeypatch.setattr(codacy_mod, "_parse_args", lambda: args)
+
+    rc = codacy_mod.main()
+
+    assert rc == 1
+    assert (tmp_path / "reports" / "codacy.json").exists()
+    assert (tmp_path / "reports" / "codacy.md").exists()
+
+
+def test_deepscan_main_writes_outputs_without_inputs(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("DEEPSCAN_API_TOKEN", raising=False)
+    monkeypatch.delenv("DEEPSCAN_OPEN_ISSUES_URL", raising=False)
+    args = SimpleNamespace(
+        token="",
+        out_json="reports/deepscan.json",
+        out_md="reports/deepscan.md",
+    )
+    monkeypatch.setattr(deepscan_mod, "_parse_args", lambda: args)
+
+    rc = deepscan_mod.main()
+
+    assert rc == 1
+    assert (tmp_path / "reports" / "deepscan.json").exists()
+    assert (tmp_path / "reports" / "deepscan.md").exists()
+
+
+def test_sentry_main_writes_outputs_in_skipped_mode(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("SENTRY_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("SENTRY_ORG", raising=False)
+    monkeypatch.delenv("SENTRY_PROJECT_BACKEND", raising=False)
+    monkeypatch.delenv("SENTRY_PROJECT_WEB", raising=False)
+    args = SimpleNamespace(
+        org="",
+        project=[],
+        token="",
+        out_json="reports/sentry.json",
+        out_md="reports/sentry.md",
+    )
+    monkeypatch.setattr(sentry_mod, "_parse_args", lambda: args)
+
+    rc = sentry_mod.main()
+
+    assert rc == 0
+    assert (tmp_path / "reports" / "sentry.json").exists()
+    assert (tmp_path / "reports" / "sentry.md").exists()

--- a/tests/test_security_helpers.py
+++ b/tests/test_security_helpers.py
@@ -106,3 +106,27 @@ def test_request_json_https_http_error(monkeypatch):
             headers={"Accept": "application/json"},
         )
     assert exc_info.value.code == 403
+
+def test_safe_output_path_in_workspace_allows_relative_path(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    resolved = sec.safe_output_path_in_workspace("reports/out.json", "fallback.json")
+
+    assert resolved == (tmp_path / "reports" / "out.json").resolve(strict=False)
+
+
+def test_safe_output_path_in_workspace_rejects_workspace_escape(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    outside = tmp_path.parent / "escaped.json"
+
+    with pytest.raises(ValueError, match="escapes workspace root"):
+        sec.safe_output_path_in_workspace(str(outside), "fallback.json")
+
+
+def test_validate_hostname_allowlists_accepts_none_suffixes():
+    sec._validate_hostname_allowlists("api.codacy.com", allowed_host_suffixes=None)
+
+
+def test_validate_hostname_allowlists_rejects_mismatched_suffix():
+    with pytest.raises(ValueError, match="suffix allowlist"):
+        sec._validate_hostname_allowlists("api.codacy.com", allowed_host_suffixes={"example.com"})

--- a/tests/test_service_coverage_branches.py
+++ b/tests/test_service_coverage_branches.py
@@ -173,7 +173,7 @@ def test_restore_helpers_cover_dispatch_and_registry(tmp_path: Path, monkeypatch
     assert (fake_home / ".bashrc").read_text(encoding="utf-8") == "export A=1\n"
 
     etc_calls: list[str] = []
-    monkeypatch.setattr(svc, "_write_linux_etc_environment_with_privilege", lambda text: etc_calls.append(text))
+    monkeypatch.setattr(svc, "_write_linux_etc_environment_with_privilege", etc_calls.append)
     svc._restore_linux_target(target="linux:etc_environment", text="A=1\n")
     assert etc_calls == ["A=1\n"]
 

--- a/tests/test_service_coverage_branches.py
+++ b/tests/test_service_coverage_branches.py
@@ -223,3 +223,26 @@ def test_restore_helpers_cover_dispatch_and_registry(tmp_path: Path, monkeypatch
 
     with pytest.raises(RuntimeError, match="Unsupported restore target"):
         svc._restore_target(target="custom:target", text="x", scope_roots=[])
+
+
+def test_restore_dotenv_target_rejects_outside_scope(tmp_path: Path, monkeypatch):
+    svc = EnvInspectorService(state_dir=tmp_path / "state")
+    allowed = tmp_path / "allowed"
+    outside = tmp_path.parent / (tmp_path.name + "-outside")
+    env_path = outside / ".env"
+    allowed.mkdir(parents=True, exist_ok=True)
+    outside.mkdir(parents=True, exist_ok=True)
+
+    class _Scoped:
+        def __init__(self, path: Path):
+            self.path = path
+            self.roots = [allowed]
+
+    monkeypatch.setattr(service_module, "parse_scoped_dotenv_target", lambda target, roots: _Scoped(env_path))
+
+    with pytest.raises(RuntimeError, match="outside approved roots"):
+        svc._restore_dotenv_target(
+            target=f"dotenv:{env_path}",
+            text="A=1\n",
+            scope_roots=[allowed],
+        )

--- a/tests/test_service_coverage_branches.py
+++ b/tests/test_service_coverage_branches.py
@@ -128,6 +128,15 @@ def test_update_helpers_cover_dispatch_and_error_branches(monkeypatch, tmp_path:
     with pytest.raises(RuntimeError, match="Unsupported WSL target"):
         svc._update_wsl_file(target="wsl:Ubuntu:profile", key="A", value="1", action="set", apply_changes=False)
 
+    with pytest.raises(RuntimeError, match="Unsupported WSL dotenv target path"):
+        svc._update_wsl_file(
+            target="wsl_dotenv:Ubuntu:/home/user/../outside.env",
+            key="A",
+            value="1",
+            action="set",
+            apply_changes=False,
+        )
+
     profile = tmp_path / "profile.ps1"
     monkeypatch.setattr(EnvInspectorService, "_powershell_profile_path", lambda _self, _target: profile)
     _before, _after, out_path, _requires_priv, _ = svc._update_powershell_file(

--- a/tests/test_service_coverage_branches.py
+++ b/tests/test_service_coverage_branches.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from env_inspector_core.constants import (
+    SOURCE_DOTENV,
+    SOURCE_LINUX_BASHRC,
+    SOURCE_LINUX_ETC_ENV,
+    SOURCE_POWERSHELL_PROFILE,
+    SOURCE_WSL_BASHRC,
+    SOURCE_WSL_DOTENV,
+    SOURCE_WSL_ETC_ENV,
+)
+from env_inspector_core.models import EnvRecord
+from env_inspector_core.service import EnvInspectorService
+import env_inspector_core.service as service_module
+
+
+def _record(source_type: str, source_path: str, *, context: str = "linux", source_id: str = "Ubuntu") -> EnvRecord:
+    return EnvRecord(
+        source_type=source_type,
+        source_id=source_id,
+        source_path=source_path,
+        context=context,
+        name="API_TOKEN",
+        value="value",
+        is_secret=False,
+        is_persistent=True,
+        is_mutable=True,
+        precedence_rank=1,
+        writable=True,
+        requires_privilege=False,
+    )
+
+
+def test_collect_wsl_rows_uses_linux_exclusion_and_dotenv(monkeypatch, tmp_path: Path):
+    svc = EnvInspectorService(state_dir=tmp_path / "state")
+    svc.runtime_context = "linux"
+    svc.current_wsl_distro = "Ubuntu"
+    monkeypatch.setattr(svc.wsl, "available", lambda: True)
+
+    calls: dict[str, object] = {}
+
+    def _fake_collect_wsl_records(wsl, include_etc: bool, exclude_distros):
+        calls["exclude"] = exclude_distros
+        return [_record(SOURCE_WSL_BASHRC, "~/.bashrc", context="wsl:Debian", source_id="Debian")]
+
+    def _fake_collect_wsl_dotenv_records(wsl, distro: str, root_path: str, max_depth: int):
+        calls["dotenv"] = (distro, root_path, max_depth)
+        return [_record(SOURCE_WSL_DOTENV, "Debian:/home/user/.env", context="wsl:Debian", source_id="Debian")]
+
+    monkeypatch.setattr(service_module, "collect_wsl_records", _fake_collect_wsl_records)
+    monkeypatch.setattr(service_module, "collect_wsl_dotenv_records", _fake_collect_wsl_dotenv_records)
+
+    rows = svc._collect_wsl_rows(scan_depth=3, distro="Debian", wsl_path="/home/user")
+
+    assert calls["exclude"] == {"Ubuntu"}
+    assert calls["dotenv"] == ("Debian", "/home/user", 3)
+    assert len(rows) == 2
+
+
+def test_collect_wsl_rows_swallows_collection_errors(monkeypatch, tmp_path: Path):
+    svc = EnvInspectorService(state_dir=tmp_path / "state")
+    monkeypatch.setattr(svc.wsl, "available", lambda: True)
+    monkeypatch.setattr(service_module, "collect_wsl_records", lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("boom")))
+    monkeypatch.setattr(service_module, "collect_wsl_dotenv_records", lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("boom")))
+
+    rows = svc._collect_wsl_rows(scan_depth=2, distro="Ubuntu", wsl_path="/home/user")
+
+    assert rows == []
+
+
+def test_available_targets_maps_all_known_sources_and_filters_context(tmp_path: Path):
+    svc = EnvInspectorService(state_dir=tmp_path / "state")
+    svc.win_provider = object()
+    records = [
+        _record(SOURCE_DOTENV, str(tmp_path / ".env"), context="linux"),
+        _record(SOURCE_LINUX_BASHRC, str(tmp_path / ".bashrc"), context="linux"),
+        _record(SOURCE_LINUX_ETC_ENV, "/etc/environment", context="linux"),
+        _record(SOURCE_WSL_DOTENV, "Ubuntu:/home/u/.env", context="linux", source_id="Ubuntu"),
+        _record(SOURCE_WSL_BASHRC, "~/.bashrc", context="linux", source_id="Ubuntu"),
+        _record(SOURCE_WSL_ETC_ENV, "/etc/environment", context="linux", source_id="Ubuntu"),
+        _record(SOURCE_POWERSHELL_PROFILE, r"C:\Program Files\PowerShell\7\profile.ps1", context="linux"),
+        _record(SOURCE_POWERSHELL_PROFILE, r"C:\Users\me\Documents\PowerShell\profile.ps1", context="linux"),
+        _record(SOURCE_DOTENV, "ignored.env", context="wsl:Ubuntu"),
+    ]
+
+    targets = svc.available_targets(records, context="linux")
+
+    assert "dotenv:" + str(tmp_path / ".env") in targets
+    assert "linux:bashrc" in targets
+    assert "linux:etc_environment" in targets
+    assert "wsl_dotenv:Ubuntu:/home/u/.env" in targets
+    assert "wsl:Ubuntu:bashrc" in targets
+    assert "wsl:Ubuntu:etc_environment" in targets
+    assert "powershell:all_users" in targets
+    assert "powershell:current_user" in targets
+    assert "windows:user" in targets and "windows:machine" in targets
+    assert "dotenv:ignored.env" not in targets
+    assert svc._record_target(_record("unknown_source", "x")) is None
+
+def test_registry_write_requires_provider(tmp_path: Path):
+    svc = EnvInspectorService(state_dir=tmp_path / "state")
+    svc.win_provider = None
+
+    with pytest.raises(RuntimeError, match="registry provider unavailable"):
+        svc._registry_write("windows:user", "A", "1", "set", apply_changes=False)
+
+
+def test_update_helpers_cover_dispatch_and_error_branches(monkeypatch, tmp_path: Path):
+    svc = EnvInspectorService(state_dir=tmp_path / "state")
+
+    with pytest.raises(RuntimeError, match="Unsupported Linux target"):
+        svc._update_linux_file(target="linux:unknown", key="A", value="1", action="set", apply_changes=False)
+
+    wsl_writes: list[tuple[str, str, str]] = []
+    monkeypatch.setattr(svc.wsl, "read_file", lambda distro, path: "")
+    monkeypatch.setattr(
+        svc.wsl,
+        "write_file_with_privilege",
+        lambda distro, path, text: wsl_writes.append((distro, path, text)),
+    )
+    svc._update_wsl_file(target="wsl:Ubuntu:etc_environment", key="A", value="1", action="set", apply_changes=True)
+    assert wsl_writes and wsl_writes[0][0] == "Ubuntu"
+
+    with pytest.raises(RuntimeError, match="Unsupported WSL target"):
+        svc._update_wsl_file(target="wsl:Ubuntu:profile", key="A", value="1", action="set", apply_changes=False)
+
+    profile = tmp_path / "profile.ps1"
+    monkeypatch.setattr(EnvInspectorService, "_powershell_profile_path", lambda _self, _target: profile)
+    _before, _after, out_path, _requires_priv, _ = svc._update_powershell_file(
+        target="powershell:current_user",
+        key="A",
+        value="1",
+        action="set",
+        apply_changes=True,
+    )
+    assert out_path == str(profile)
+    assert "$env:A" in profile.read_text(encoding="utf-8")
+
+    monkeypatch.setattr(
+        svc,
+        "_update_wsl_file",
+        lambda **kwargs: ("before", "after", "wsl", False, None),
+    )
+    monkeypatch.setattr(
+        svc,
+        "_update_powershell_file",
+        lambda **kwargs: ("before", "after", "ps", False, None),
+    )
+    assert svc._file_update("wsl:Ubuntu:bashrc", "A", "1", "set", apply_changes=False, scope_roots=[])[2] == "wsl"
+    assert svc._file_update("powershell:current_user", "A", "1", "set", apply_changes=False, scope_roots=[])[2] == "ps"
+
+
+def test_restore_helpers_cover_dispatch_and_registry(tmp_path: Path, monkeypatch):
+    svc = EnvInspectorService(state_dir=tmp_path / "state")
+    fake_home = tmp_path / "home"
+    fake_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(service_module.Path, "home", lambda: fake_home)
+
+    svc._restore_linux_target(target="linux:bashrc", text="export A=1\n")
+    assert (fake_home / ".bashrc").read_text(encoding="utf-8") == "export A=1\n"
+
+    etc_calls: list[str] = []
+    monkeypatch.setattr(svc, "_write_linux_etc_environment_with_privilege", lambda text: etc_calls.append(text))
+    svc._restore_linux_target(target="linux:etc_environment", text="A=1\n")
+    assert etc_calls == ["A=1\n"]
+
+    with pytest.raises(RuntimeError, match="Unsupported Linux restore target"):
+        svc._restore_linux_target(target="linux:unknown", text="x")
+
+    wsl_calls: list[tuple[str, str, str]] = []
+    monkeypatch.setattr(
+        svc.wsl,
+        "write_file_with_privilege",
+        lambda distro, path, text: wsl_calls.append((distro, path, text)),
+    )
+    svc._restore_wsl_target(target="wsl:Ubuntu:etc_environment", text="A=1\n")
+    assert wsl_calls == [("Ubuntu", "/etc/environment", "A=1\n")]
+
+    with pytest.raises(RuntimeError, match="Unsupported WSL restore target"):
+        svc._restore_wsl_target(target="wsl:Ubuntu:unknown", text="x")
+
+    profile = tmp_path / "ps-profile.ps1"
+    monkeypatch.setattr(EnvInspectorService, "_validated_powershell_restore_path", lambda _self, _target: profile)
+    svc._restore_powershell_target(target="powershell:current_user", text="$env:A=\"1\"\n")
+    assert profile.read_text(encoding="utf-8") == "$env:A=\"1\"\n"
+
+    svc.win_provider = None
+    with pytest.raises(RuntimeError, match="provider unavailable"):
+        svc._restore_windows_registry_target(target="windows:user", text="{}")
+
+    class _FakeWinProvider:
+        def __init__(self):
+            self.removed: list[tuple[str, str]] = []
+            self.sets: list[tuple[str, str, str]] = []
+
+        def list_scope(self, scope: str):
+            return {"KEEP": "1", "DROP": "2"}
+
+        def remove_scope_value(self, scope: str, key: str):
+            self.removed.append((scope, key))
+
+        def set_scope_value(self, scope: str, key: str, value: str):
+            self.sets.append((scope, key, value))
+
+    fake = _FakeWinProvider()
+    svc.win_provider = fake
+    svc._restore_windows_registry_target(target="windows:user", text="{\"KEEP\":\"1\",\"NEW\":\"3\"}")
+    assert fake.removed and fake.removed[0][1] == "DROP"
+    assert any(key == "NEW" for _scope, key, _value in fake.sets)
+
+    calls: list[str] = []
+    monkeypatch.setattr(svc, "_restore_linux_target", lambda **kwargs: calls.append("linux"))
+    monkeypatch.setattr(svc, "_restore_powershell_target", lambda **kwargs: calls.append("powershell"))
+    monkeypatch.setattr(svc, "_restore_windows_registry_target", lambda **kwargs: calls.append("windows"))
+    svc._restore_target(target="linux:bashrc", text="x", scope_roots=[])
+    svc._restore_target(target="powershell:current_user", text="x", scope_roots=[])
+    svc._restore_target(target="windows:user", text="x", scope_roots=[])
+    assert calls == ["linux", "powershell", "windows"]
+
+    with pytest.raises(RuntimeError, match="Unsupported restore target"):
+        svc._restore_target(target="custom:target", text="x", scope_roots=[])

--- a/tests/test_service_path_guards.py
+++ b/tests/test_service_path_guards.py
@@ -122,3 +122,18 @@ def test_linux_etc_environment_path_guard_non_windows_branch(tmp_path: Path, mon
     resolved = EnvInspectorService._linux_etc_environment_path()
 
     assert resolved.as_posix() == r"\etc\environment"
+
+
+def test_restore_wsl_dotenv_backup_rejects_path_traversal(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    svc = EnvInspectorService(state_dir=tmp_path / "state")
+
+    calls: list[tuple[str, str, str]] = []
+    monkeypatch.setattr(svc.wsl, "write_file", lambda distro, path, text: calls.append((distro, path, text)))
+
+    backup_path = svc.backup_mgr.backup_text("wsl_dotenv:Ubuntu:/home/user/../outside.env", "A=1\n")
+    result = svc.restore_backup(backup=str(backup_path))
+
+    assert result["success"] is False
+    assert "Unsupported WSL dotenv target path" in (result["error_message"] or "")
+    assert calls == []

--- a/tests/test_service_path_guards.py
+++ b/tests/test_service_path_guards.py
@@ -53,12 +53,17 @@ def test_validated_powershell_restore_path_all_users_rejects_outside_root(tmp_pa
         svc._validated_powershell_restore_path("powershell:all_users")
 
 
-def test_linux_etc_environment_path_guard_raises_on_unexpected_mapping(tmp_path: Path, monkeypatch):
+def test_linux_etc_environment_path_guard_handles_platform_semantics(tmp_path: Path, monkeypatch):
     _ = EnvInspectorService(state_dir=tmp_path / "state")
-    monkeypatch.setattr(EnvInspectorService, "_LINUX_ETC_ENV_PATH", "\\\\etc\\environment")
+    monkeypatch.setattr(EnvInspectorService, "_LINUX_ETC_ENV_PATH", r"\etc\environment")
 
+    monkeypatch.setattr(service_module.os, "name", "nt", raising=False)
     with pytest.raises(RuntimeError, match="Unexpected /etc/environment resolution"):
         EnvInspectorService._linux_etc_environment_path()
+
+    monkeypatch.setattr(service_module.os, "name", "posix", raising=False)
+    resolved = EnvInspectorService._linux_etc_environment_path()
+    assert resolved.as_posix() == r"\etc\environment"
 
 
 def test_restore_dotenv_path_checks_continue_until_matching_root(tmp_path: Path, monkeypatch):
@@ -107,3 +112,13 @@ def test_restore_wsl_bashrc_backup_uses_wsl_write_file(tmp_path: Path, monkeypat
     assert result["success"] is True
     assert calls == [("Ubuntu", "~/.bashrc", "export A='1'\n")]
 
+
+
+def test_linux_etc_environment_path_guard_non_windows_branch(tmp_path: Path, monkeypatch):
+    _ = EnvInspectorService(state_dir=tmp_path / "state")
+    monkeypatch.setattr(service_module.os, "name", "posix", raising=False)
+    monkeypatch.setattr(EnvInspectorService, "_LINUX_ETC_ENV_PATH", r"\etc\environment")
+
+    resolved = EnvInspectorService._linux_etc_environment_path()
+
+    assert resolved.as_posix() == r"\etc\environment"

--- a/tests/test_service_path_guards.py
+++ b/tests/test_service_path_guards.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from env_inspector_core.service import EnvInspectorService
+import env_inspector_core.service as service_module
+
+
+def test_is_path_within_returns_false_for_unrelated_roots(tmp_path: Path):
+    svc = EnvInspectorService(state_dir=tmp_path / "state")
+    assert svc._is_path_within(tmp_path / "outside" / ".env", tmp_path / "allowed") is False
+
+
+def test_validate_path_in_roots_raises_for_outside_path(tmp_path: Path):
+    svc = EnvInspectorService(state_dir=tmp_path / "state")
+    outside = tmp_path.parent / (tmp_path.name + "-outside") / ".env"
+    outside.parent.mkdir(parents=True, exist_ok=True)
+
+    with pytest.raises(RuntimeError, match="outside approved roots"):
+        svc._validate_path_in_roots(outside, [tmp_path / "allowed"], label="dotenv target")
+
+
+def test_validated_powershell_restore_path_rejects_unsupported_target(tmp_path: Path):
+    svc = EnvInspectorService(state_dir=tmp_path / "state")
+
+    with pytest.raises(RuntimeError, match="Unsupported PowerShell target"):
+        svc._validated_powershell_restore_path("powershell:unsupported")
+
+
+def test_validated_powershell_restore_path_current_user_success(tmp_path: Path, monkeypatch):
+    svc = EnvInspectorService(state_dir=tmp_path / "state")
+    fake_home = tmp_path / "home"
+    fake_home.mkdir(parents=True, exist_ok=True)
+    fake_profile = fake_home / "Documents" / "PowerShell" / "Microsoft.PowerShell_profile.ps1"
+
+    monkeypatch.setattr(service_module.Path, "home", lambda: fake_home)
+    monkeypatch.setattr(EnvInspectorService, "_powershell_profile_path", lambda _self, _target: fake_profile)
+
+    resolved = svc._validated_powershell_restore_path("powershell:current_user")
+
+    assert resolved == fake_profile.resolve(strict=False)
+
+
+def test_validated_powershell_restore_path_all_users_rejects_outside_root(tmp_path: Path, monkeypatch):
+    svc = EnvInspectorService(state_dir=tmp_path / "state")
+    bad_profile = tmp_path / "not-program-files" / "profile.ps1"
+
+    monkeypatch.setattr(EnvInspectorService, "_powershell_profile_path", lambda _self, _target: bad_profile)
+
+    with pytest.raises(RuntimeError, match="outside expected root"):
+        svc._validated_powershell_restore_path("powershell:all_users")
+
+
+def test_linux_etc_environment_path_guard_raises_on_unexpected_mapping(tmp_path: Path, monkeypatch):
+    _ = EnvInspectorService(state_dir=tmp_path / "state")
+    monkeypatch.setattr(EnvInspectorService, "_LINUX_ETC_ENV_PATH", "\\\\etc\\environment")
+
+    with pytest.raises(RuntimeError, match="Unexpected /etc/environment resolution"):
+        EnvInspectorService._linux_etc_environment_path()
+
+
+def test_restore_dotenv_path_checks_continue_until_matching_root(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    svc = EnvInspectorService(state_dir=tmp_path / "state")
+
+    outside_root = tmp_path.parent / (tmp_path.name + "-outside")
+    fail_root = tmp_path.parent / (tmp_path.name + "-fail")
+    outside_root.mkdir(parents=True, exist_ok=True)
+    fail_root.mkdir(parents=True, exist_ok=True)
+    env_file = outside_root / ".env"
+
+    monkeypatch.setattr(svc, "_effective_scope_roots", lambda _scope_roots=None: [fail_root, outside_root])
+
+    backup_path = svc.backup_mgr.backup_text(f"dotenv:{env_file}", "A=1\n")
+    result = svc.restore_backup(backup=str(backup_path), scope_roots=[outside_root])
+
+    assert result["success"] is True
+    assert env_file.read_text(encoding="utf-8") == "A=1\n"
+
+
+def test_restore_wsl_dotenv_backup_uses_wsl_write_file(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    svc = EnvInspectorService(state_dir=tmp_path / "state")
+
+    calls: list[tuple[str, str, str]] = []
+    monkeypatch.setattr(svc.wsl, "write_file", lambda distro, path, text: calls.append((distro, path, text)))
+
+    backup_path = svc.backup_mgr.backup_text("wsl_dotenv:Ubuntu:/home/user/.env", "A=1\n")
+    result = svc.restore_backup(backup=str(backup_path))
+
+    assert result["success"] is True
+    assert calls == [("Ubuntu", "/home/user/.env", "A=1\n")]
+
+
+def test_restore_wsl_bashrc_backup_uses_wsl_write_file(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    svc = EnvInspectorService(state_dir=tmp_path / "state")
+
+    calls: list[tuple[str, str, str]] = []
+    monkeypatch.setattr(svc.wsl, "write_file", lambda distro, path, text: calls.append((distro, path, text)))
+
+    backup_path = svc.backup_mgr.backup_text("wsl:Ubuntu:bashrc", "export A='1'\n")
+    result = svc.restore_backup(backup=str(backup_path))
+
+    assert result["success"] is True
+    assert calls == [("Ubuntu", "~/.bashrc", "export A='1'\n")]
+


### PR DESCRIPTION
## Summary
- harden workflow security posture for static analyzers (pinned action refs, job-level permissions, validated dispatch tag handling)
- remove GitHub API partial-SSRF flow by switching required-check polling to fixed-host validated requests
- centralize workspace-scoped output path validation in `scripts/security_helpers.py`
- re-validate file write targets in service restore/update flows to tighten path safety
- apply broad markdown spacing normalization to reduce Codacy current-issue baseline

## Verification
- `make verify PYTHON=python3`
- `python3 -m py_compile scripts/security_helpers.py scripts/quality/*.py`
- `pytest -q -s tests/test_quality_http_builders.py tests/test_security_helpers.py tests/test_backup_and_audit.py tests/test_cli.py tests/test_entrypoint.py`

## Follow-up Intent
- drive Sonar/CodeQL/Codacy issue counts to 0 from this branch and merge when all required contexts are green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added planned stable CLI surface and GUI behaviors (multi-target selection, diff previews, backup/restore) and expanded restore/target support.

* **Documentation**
  * Expanded branch-protection guidance, agent operating model, risk/verification policies, templates, release plan, and onboarding docs.

* **Chores**
  * Centralized workspace-safe path handling and URL validation; updated CI/workflow release tag logic and permissions; improved release notes formatting.

* **Tests**
  * Added extensive unit/integration tests for backups, path guards, quality checks, and service restore/update flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->