### PR TITLE
fix: close remaining Sonar findings on mainline

### DIFF
--- a/.github/workflows/env-inspector-exe-release.yml
+++ b/.github/workflows/env-inspector-exe-release.yml
@@ -58,23 +58,24 @@ jobs:
 
       - name: Resolve release tag
         id: release_tag
-        shell: pwsh
-        env:
-          GH_REF_TYPE: ${{ github.ref_type }}
-          GH_REF_NAME: ${{ github.ref_name }}
-          GH_EVENT_NAME: ${{ github.event_name }}
-          INPUT_TAG: ${{ inputs.tag }}
-        run: |
-          $tag = ""
-          if ($env:GH_REF_TYPE -eq "tag") {
-            $tag = $env:GH_REF_NAME
-          } elseif ($env:GH_EVENT_NAME -eq "workflow_dispatch" -and $env:INPUT_TAG -ne "") {
-            if ($env:INPUT_TAG -notmatch '^v[0-9]+(\.[0-9]+)*([-.][0-9A-Za-z]+)*$') {
-              throw "Invalid tag format. Expected semantic-style tag such as v1.0.0."
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const semverTag = /^v[0-9]+(\.[0-9]+)*([-.][0-9A-Za-z]+)*$/;
+            let tag = "";
+            if ((context.ref || "").startsWith("refs/tags/")) {
+              tag = context.ref.slice("refs/tags/".length);
+            } else if (context.eventName === "workflow_dispatch") {
+              const inputTag = (context.payload?.inputs?.tag || "").trim();
+              if (inputTag) {
+                if (!semverTag.test(inputTag)) {
+                  core.setFailed("Invalid tag format. Expected semantic-style tag such as v1.0.0.");
+                  return;
+                }
+                tag = inputTag;
+              }
             }
-            $tag = $env:INPUT_TAG
-          }
-          "tag=$tag" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+            core.setOutput("tag", tag);
 
       - name: Create or update release
         if: ${{ steps.release_tag.outputs.tag != '' }}

--- a/.github/workflows/quality-zero-gate.yml
+++ b/.github/workflows/quality-zero-gate.yml
@@ -7,6 +7,8 @@ on:
     branches: [main, master]
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   secrets-preflight:
     name: Quality Secrets Preflight

--- a/docs/plans/2026-03-03-main-zero-readiness.md
+++ b/docs/plans/2026-03-03-main-zero-readiness.md
@@ -1,0 +1,14 @@
+# Main Zero Readiness (2026-03-03)
+
+## Environment
+- Workspace: `C:\Users\prekzursil\Desktop\workspace\env-inspector-main-zero`
+- Branch: `fix/main-zero`
+- Git binary: `C:\Program Files\Git\cmd\git.exe`
+- GitHub CLI binary: `C:\Program Files\GitHub CLI\gh.exe`
+- Auth: `gh auth status` reports active account `Prekzursil` via `GH_TOKEN`.
+- Python: `3.14.3`
+- GNU Make: `4.4.1`
+
+## Control Plane Decision
+- `gh` is available in this VM via installed binary path even though it is not globally on PATH.
+- Execution proceeds with explicit binary paths for deterministic commands.

--- a/docs/plans/2026-03-03-main-zero-readiness.md
+++ b/docs/plans/2026-03-03-main-zero-readiness.md
@@ -11,5 +11,7 @@
 - GNU Make: `4.4.1`
 
 ## Control Plane Decision
+
 - `gh` is available in this VM via installed binary path even though it is not globally on PATH.
 - Execution proceeds with explicit binary paths for deterministic commands.
+

--- a/docs/plans/2026-03-03-main-zero-readiness.md
+++ b/docs/plans/2026-03-03-main-zero-readiness.md
@@ -1,6 +1,7 @@
 # Main Zero Readiness (2026-03-03)
 
 ## Environment
+
 - Workspace: `C:\Users\prekzursil\Desktop\workspace\env-inspector-main-zero`
 - Branch: `fix/main-zero`
 - Git binary: `C:\Program Files\Git\cmd\git.exe`

--- a/env_inspector_core/service.py
+++ b/env_inspector_core/service.py
@@ -107,6 +107,25 @@ class EnvInspectorService:
                 return resolved_path
         raise RuntimeError(f"{label} is outside approved roots: {resolved_path}")
 
+    @staticmethod
+    def _write_text_file(path: Path, text: str, *, ensure_parent: bool) -> None:
+        if ensure_parent:
+            path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8", newline="") as handle:
+            handle.write(text)
+
+    def _write_scoped_text_file(
+        self,
+        *,
+        candidate_path: Path,
+        allowed_roots: list[Path] | tuple[Path, ...],
+        text: str,
+        label: str,
+    ) -> Path:
+        safe_path = self._validate_path_in_roots(candidate_path, list(allowed_roots), label=label)
+        self._write_text_file(safe_path, text, ensure_parent=True)
+        return safe_path
+
     def _validated_powershell_restore_path(self, target: str) -> Path:
         if target not in {"powershell:current_user", "powershell:all_users"}:
             raise RuntimeError(f"Unsupported PowerShell target: {target}")
@@ -248,11 +267,16 @@ class EnvInspectorService:
         return "\n".join(diff)
 
     def _write_linux_etc_environment_with_privilege(self, text: str) -> None:
-        path = self._linux_etc_environment_path()
+        if self._LINUX_ETC_ENV_PATH != "/etc/environment":
+            raise RuntimeError(f"Unexpected /etc/environment resolution: {self._LINUX_ETC_ENV_PATH}")
+        path = Path("/etc/environment")
         try:
-            path.write_text(text, encoding="utf-8")
+            self._write_text_file(path, text, ensure_parent=False)
             return
         except PermissionError:
+            pass
+        except OSError:
+            # Non-POSIX hosts can raise FileNotFoundError for this fixed path; still attempt sudo fallback.
             pass
 
         proc = subprocess.run(
@@ -361,8 +385,12 @@ class EnvInspectorService:
         before = path.read_text(encoding="utf-8", errors="ignore") if path.exists() else ""
         after = upsert_key_value(before, key, value or "", quote=False) if action == "set" else remove_key_value(before, key)
         if apply_changes:
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(after, encoding="utf-8")
+            self._write_scoped_text_file(
+                candidate_path=scoped.path,
+                allowed_roots=scoped.roots,
+                text=after,
+                label="dotenv target path",
+            )
         return before, after, str(path), False, None
 
     @staticmethod
@@ -544,6 +572,27 @@ class EnvInspectorService:
             return self._registry_write(target, key, value, action, apply_changes=apply_changes)
         return self._file_update(target, key, value, action, apply_changes=apply_changes, scope_roots=scope_roots)
 
+    def _validate_target_for_operation(self, target: str, *, scope_roots: list[Path]) -> None:
+        if target in {
+            "windows:user",
+            "windows:machine",
+            "linux:bashrc",
+            "linux:etc_environment",
+            "powershell:current_user",
+            "powershell:all_users",
+        }:
+            return
+        if target.startswith("dotenv:"):
+            parse_scoped_dotenv_target(target, roots=scope_roots)
+            return
+        if target.startswith("wsl_dotenv:"):
+            self._parse_wsl_dotenv_target(target)
+            return
+        if target.startswith("wsl:"):
+            self._resolve_wsl_target(target)
+            return
+        raise RuntimeError(f"Unsupported target: {target}")
+
     def _apply(
         self,
         action: str,
@@ -566,6 +615,7 @@ class EnvInspectorService:
             backup_path: str | None = None
             diff_preview = ""
             try:
+                self._validate_target_for_operation(target, scope_roots=resolved_scope_roots)
                 before, after, _, _, _ = self._plan_target_operation(
                     target=target,
                     key=key,
@@ -725,23 +775,12 @@ class EnvInspectorService:
 
     def _restore_dotenv_target(self, *, target: str, text: str, scope_roots: list[Path]) -> None:
         scoped = parse_scoped_dotenv_target(target, roots=scope_roots)
-        candidate_abs = os.path.realpath(os.path.normpath(str(scoped.path)))
-        allowed_roots_abs = [os.path.realpath(os.path.normpath(str(root))) for root in scope_roots]
-
-        allowed = False
-        for root_abs in allowed_roots_abs:
-            root_prefix = root_abs if root_abs.endswith(os.sep) else root_abs + os.sep
-            if candidate_abs == root_abs or candidate_abs.startswith(root_prefix):
-                allowed = True
-                break
-
-        if not allowed:
-            raise RuntimeError(f"restore dotenv path is outside approved roots: {candidate_abs}")
-
-        safe_path = Path(candidate_abs)
-        safe_path.parent.mkdir(parents=True, exist_ok=True)
-        with safe_path.open("w", encoding="utf-8", newline="") as handle:
-            handle.write(text)
+        self._write_scoped_text_file(
+            candidate_path=scoped.path,
+            allowed_roots=scoped.roots,
+            text=text,
+            label="restore dotenv path",
+        )
 
     def _restore_linux_target(self, *, target: str, text: str) -> None:
         if target == "linux:bashrc":
@@ -771,8 +810,12 @@ class EnvInspectorService:
 
     def _restore_powershell_target(self, *, target: str, text: str) -> None:
         profile = self._validated_powershell_restore_path(target)
-        profile.parent.mkdir(parents=True, exist_ok=True)
-        profile.write_text(text, encoding="utf-8")
+        if target == "powershell:current_user":
+            allowed_roots = [Path.home().resolve(strict=False)]
+        else:
+            allowed_roots = [Path(r"C:\Program Files").resolve(strict=False)]
+        safe_profile = self._validate_path_in_roots(profile, allowed_roots, label="PowerShell restore target")
+        self._write_text_file(safe_profile, text, ensure_parent=True)
 
     def _restore_windows_registry_target(self, *, target: str, text: str) -> None:
         if self.win_provider is None:

--- a/tests/test_linux_support.py
+++ b/tests/test_linux_support.py
@@ -110,21 +110,27 @@ def test_linux_etc_environment_write_uses_sudo_fallback(tmp_path: Path, monkeypa
     etc_env = tmp_path / "etc_environment"
     etc_env.write_text("A=1\n", encoding="utf-8")
 
+    real_exists = Path.exists
+    real_open = Path.open
     real_read_text = Path.read_text
-    real_write_text = Path.write_text
 
     def fake_read_text(self: Path, *args, **kwargs):
         if self == Path("/etc/environment"):
             return etc_env.read_text(encoding="utf-8")
         return real_read_text(self, *args, **kwargs)
 
+    def fake_exists(self: Path):
+        if self == Path("/etc/environment"):
+            return True
+        return real_exists(self)
+
     writes: list[str] = []
 
-    def fake_write_text(self: Path, text: str, *args, **kwargs):
+    def fake_open(self: Path, *args, **kwargs):
         if self == Path("/etc/environment"):
             raise PermissionError("denied")
         writes.append(str(self))
-        return real_write_text(self, text, *args, **kwargs)
+        return real_open(self, *args, **kwargs)
 
     class Proc:
         returncode = 0
@@ -137,8 +143,9 @@ def test_linux_etc_environment_write_uses_sudo_fallback(tmp_path: Path, monkeypa
         etc_env.write_text("A=2\n", encoding="utf-8")
         return Proc()
 
+    monkeypatch.setattr(Path, "exists", fake_exists)
+    monkeypatch.setattr(Path, "open", fake_open)
     monkeypatch.setattr(Path, "read_text", fake_read_text)
-    monkeypatch.setattr(Path, "write_text", fake_write_text)
     monkeypatch.setattr(service_module.subprocess, "run", fake_run)
 
     result = svc.set_key(key="A", value="2", targets=["linux:etc_environment"])
@@ -174,26 +181,33 @@ def test_linux_etc_environment_write_reports_permission_failure(tmp_path: Path, 
     etc_env = tmp_path / "etc_environment"
     etc_env.write_text("A=1\n", encoding="utf-8")
 
+    real_exists = Path.exists
+    real_open = Path.open
     real_read_text = Path.read_text
-    real_write_text = Path.write_text
 
     def fake_read_text(self: Path, *args, **kwargs):
         if self == Path("/etc/environment"):
             return etc_env.read_text(encoding="utf-8")
         return real_read_text(self, *args, **kwargs)
 
-    def fake_write_text(self: Path, text: str, *args, **kwargs):
+    def fake_exists(self: Path):
+        if self == Path("/etc/environment"):
+            return True
+        return real_exists(self)
+
+    def fake_open(self: Path, *args, **kwargs):
         if self == Path("/etc/environment"):
             raise PermissionError("denied")
-        return real_write_text(self, text, *args, **kwargs)
+        return real_open(self, *args, **kwargs)
 
     class Proc:
         returncode = 1
         stdout = b""
         stderr = b"sudo auth failed"
 
+    monkeypatch.setattr(Path, "exists", fake_exists)
+    monkeypatch.setattr(Path, "open", fake_open)
     monkeypatch.setattr(Path, "read_text", fake_read_text)
-    monkeypatch.setattr(Path, "write_text", fake_write_text)
     monkeypatch.setattr(service_module.subprocess, "run", lambda *_args, **_kwargs: Proc())
 
     result = svc.set_key(key="A", value="2", targets=["linux:etc_environment"])

--- a/tests/test_linux_support.py
+++ b/tests/test_linux_support.py
@@ -28,6 +28,35 @@ def _record(source_type: str, context: str, name: str, value: str, precedence: i
     )
 
 
+def _patch_linux_etc_environment_denied(monkeypatch: pytest.MonkeyPatch, etc_env: Path) -> list[str]:
+    real_exists = Path.exists
+    real_open = Path.open
+    real_read_text = Path.read_text
+    target = Path("/etc/environment")
+    writes: list[str] = []
+
+    def fake_read_text(self: Path, *args, **kwargs):
+        if self == target:
+            return etc_env.read_text(encoding="utf-8")
+        return real_read_text(self, *args, **kwargs)
+
+    def fake_exists(self: Path):
+        if self == target:
+            return True
+        return real_exists(self)
+
+    def fake_open(self: Path, *args, **kwargs):
+        if self == target:
+            raise PermissionError("denied")
+        writes.append(str(self))
+        return real_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "exists", fake_exists)
+    monkeypatch.setattr(Path, "open", fake_open)
+    monkeypatch.setattr(Path, "read_text", fake_read_text)
+    return writes
+
+
 def test_collect_linux_records_reads_bashrc_and_etc_environment(tmp_path: Path):
     bashrc = tmp_path / ".bashrc"
     etc_env = tmp_path / "etc_environment"
@@ -110,27 +139,7 @@ def test_linux_etc_environment_write_uses_sudo_fallback(tmp_path: Path, monkeypa
     etc_env = tmp_path / "etc_environment"
     etc_env.write_text("A=1\n", encoding="utf-8")
 
-    real_exists = Path.exists
-    real_open = Path.open
-    real_read_text = Path.read_text
-
-    def fake_read_text(self: Path, *args, **kwargs):
-        if self == Path("/etc/environment"):
-            return etc_env.read_text(encoding="utf-8")
-        return real_read_text(self, *args, **kwargs)
-
-    def fake_exists(self: Path):
-        if self == Path("/etc/environment"):
-            return True
-        return real_exists(self)
-
-    writes: list[str] = []
-
-    def fake_open(self: Path, *args, **kwargs):
-        if self == Path("/etc/environment"):
-            raise PermissionError("denied")
-        writes.append(str(self))
-        return real_open(self, *args, **kwargs)
+    writes = _patch_linux_etc_environment_denied(monkeypatch, etc_env)
 
     class Proc:
         returncode = 0
@@ -143,9 +152,6 @@ def test_linux_etc_environment_write_uses_sudo_fallback(tmp_path: Path, monkeypa
         etc_env.write_text("A=2\n", encoding="utf-8")
         return Proc()
 
-    monkeypatch.setattr(Path, "exists", fake_exists)
-    monkeypatch.setattr(Path, "open", fake_open)
-    monkeypatch.setattr(Path, "read_text", fake_read_text)
     monkeypatch.setattr(service_module.subprocess, "run", fake_run)
 
     result = svc.set_key(key="A", value="2", targets=["linux:etc_environment"])
@@ -181,33 +187,13 @@ def test_linux_etc_environment_write_reports_permission_failure(tmp_path: Path, 
     etc_env = tmp_path / "etc_environment"
     etc_env.write_text("A=1\n", encoding="utf-8")
 
-    real_exists = Path.exists
-    real_open = Path.open
-    real_read_text = Path.read_text
-
-    def fake_read_text(self: Path, *args, **kwargs):
-        if self == Path("/etc/environment"):
-            return etc_env.read_text(encoding="utf-8")
-        return real_read_text(self, *args, **kwargs)
-
-    def fake_exists(self: Path):
-        if self == Path("/etc/environment"):
-            return True
-        return real_exists(self)
-
-    def fake_open(self: Path, *args, **kwargs):
-        if self == Path("/etc/environment"):
-            raise PermissionError("denied")
-        return real_open(self, *args, **kwargs)
+    _patch_linux_etc_environment_denied(monkeypatch, etc_env)
 
     class Proc:
         returncode = 1
         stdout = b""
         stderr = b"sudo auth failed"
 
-    monkeypatch.setattr(Path, "exists", fake_exists)
-    monkeypatch.setattr(Path, "open", fake_open)
-    monkeypatch.setattr(Path, "read_text", fake_read_text)
     monkeypatch.setattr(service_module.subprocess, "run", lambda *_args, **_kwargs: Proc())
 
     result = svc.set_key(key="A", value="2", targets=["linux:etc_environment"])

--- a/tests/test_service_coverage_branches.py
+++ b/tests/test_service_coverage_branches.py
@@ -192,7 +192,10 @@ def test_restore_helpers_cover_dispatch_and_registry(tmp_path: Path, monkeypatch
     with pytest.raises(RuntimeError, match="Unsupported WSL restore target"):
         svc._restore_wsl_target(target="wsl:Ubuntu:unknown", text="x")
 
-    profile = tmp_path / "ps-profile.ps1"
+    fake_home = tmp_path / "home"
+    fake_home.mkdir(parents=True, exist_ok=True)
+    profile = fake_home / "Documents" / "PowerShell" / "ps-profile.ps1"
+    monkeypatch.setattr(service_module.Path, "home", lambda: fake_home)
     monkeypatch.setattr(EnvInspectorService, "_validated_powershell_restore_path", lambda _self, _target: profile)
     svc._restore_powershell_target(target="powershell:current_user", text="$env:A=\"1\"\n")
     assert profile.read_text(encoding="utf-8") == "$env:A=\"1\"\n"

--- a/tests/test_service_path_guards.py
+++ b/tests/test_service_path_guards.py
@@ -66,6 +66,14 @@ def test_linux_etc_environment_path_guard_handles_platform_semantics(tmp_path: P
     assert resolved.as_posix() == r"\etc\environment"
 
 
+def test_write_linux_etc_environment_with_privilege_rejects_non_fixed_path(tmp_path: Path, monkeypatch):
+    svc = EnvInspectorService(state_dir=tmp_path / "state")
+    monkeypatch.setattr(EnvInspectorService, "_LINUX_ETC_ENV_PATH", r"\etc\environment")
+
+    with pytest.raises(RuntimeError, match="Unexpected /etc/environment resolution"):
+        svc._write_linux_etc_environment_with_privilege("A=1\n")
+
+
 def test_restore_dotenv_path_checks_continue_until_matching_root(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     svc = EnvInspectorService(state_dir=tmp_path / "state")
@@ -137,3 +145,46 @@ def test_restore_wsl_dotenv_backup_rejects_path_traversal(tmp_path: Path, monkey
     assert result["success"] is False
     assert "Unsupported WSL dotenv target path" in (result["error_message"] or "")
     assert calls == []
+
+def test_validate_target_for_operation_rejects_unknown_target(tmp_path: Path):
+    svc = EnvInspectorService(state_dir=tmp_path / "state")
+
+    with pytest.raises(RuntimeError, match="Unsupported target"):
+        svc._validate_target_for_operation("custom:target", scope_roots=[tmp_path])
+
+
+def test_validate_target_for_operation_rejects_dotenv_outside_scope(tmp_path: Path):
+    svc = EnvInspectorService(state_dir=tmp_path / "state")
+    allowed = tmp_path / "allowed"
+    allowed.mkdir(parents=True, exist_ok=True)
+    outside = tmp_path.parent / (tmp_path.name + "-outside")
+    outside.mkdir(parents=True, exist_ok=True)
+
+    with pytest.raises(Exception, match="outside approved roots"):
+        svc._validate_target_for_operation(f"dotenv:{outside / '.env'}", scope_roots=[allowed])
+
+def test_validate_target_for_operation_accepts_wsl_variants(tmp_path: Path):
+    svc = EnvInspectorService(state_dir=tmp_path / "state")
+
+    svc._validate_target_for_operation("wsl_dotenv:Ubuntu:/home/user/.env", scope_roots=[tmp_path])
+    svc._validate_target_for_operation("wsl:Ubuntu:bashrc", scope_roots=[tmp_path])
+
+
+def test_restore_powershell_target_all_users_uses_program_files_root(tmp_path: Path, monkeypatch):
+    svc = EnvInspectorService(state_dir=tmp_path / "state")
+    profile = Path(r"C:\Program Files\PowerShell\7\profile.ps1")
+
+    writes: dict[str, object] = {}
+    monkeypatch.setattr(EnvInspectorService, "_validated_powershell_restore_path", lambda _self, _target: profile)
+    monkeypatch.setattr(
+        svc,
+        "_write_text_file",
+        lambda path, text, ensure_parent: writes.update({"path": path, "text": text, "ensure_parent": ensure_parent}),
+    )
+
+    svc._restore_powershell_target(target="powershell:all_users", text="$env:A='1'\n")
+
+    assert writes["path"] == profile.resolve(strict=False)
+    assert writes["text"] == "$env:A='1'\n"
+    assert writes["ensure_parent"] is True
+

--- a/tests/test_service_path_guards.py
+++ b/tests/test_service_path_guards.py
@@ -172,10 +172,15 @@ def test_validate_target_for_operation_accepts_wsl_variants(tmp_path: Path):
 
 def test_restore_powershell_target_all_users_uses_program_files_root(tmp_path: Path, monkeypatch):
     svc = EnvInspectorService(state_dir=tmp_path / "state")
-    profile = Path(r"C:\Program Files\PowerShell\7\profile.ps1")
+    profile = tmp_path / "program_files" / "PowerShell" / "7" / "profile.ps1"
 
     writes: dict[str, object] = {}
     monkeypatch.setattr(EnvInspectorService, "_validated_powershell_restore_path", lambda _self, _target: profile)
+    monkeypatch.setattr(
+        svc,
+        "_validate_path_in_roots",
+        lambda candidate, roots, label: writes.update({"validated": candidate, "roots": roots, "label": label}) or candidate,
+    )
     monkeypatch.setattr(
         svc,
         "_write_text_file",
@@ -184,7 +189,10 @@ def test_restore_powershell_target_all_users_uses_program_files_root(tmp_path: P
 
     svc._restore_powershell_target(target="powershell:all_users", text="$env:A='1'\n")
 
-    assert writes["path"] == profile.resolve(strict=False)
+    assert writes["validated"] == profile
+    assert "Program Files" in str(writes["roots"][0])
+    assert writes["label"] == "PowerShell restore target"
+    assert writes["path"] == profile
     assert writes["text"] == "$env:A='1'\n"
     assert writes["ensure_parent"] is True
 


### PR DESCRIPTION
## Summary
This PR continues post-#21 zero-issue remediation by addressing remaining Sonar code-scanning findings on `main` and tightening workflow safety.

### What changed
- Hardened `EnvInspectorService` path handling with sink-adjacent validated write helpers.
- Added pre-validation of mutation targets before `_plan_target_operation` in `_apply`.
- Hardened restore flows for dotenv and PowerShell targets.
- Updated Linux `/etc/environment` direct-write fallback behavior for deterministic cross-host behavior.
- Replaced shell-based release-tag resolution with pinned `actions/github-script` logic in release workflow.
- Added workflow-level `permissions: {}` default in `quality-zero-gate.yml`.
- Added/updated tests covering new branches and guard paths.
- Added VM readiness note: `docs/plans/2026-03-03-main-zero-readiness.md`.

## Verification
Local commands run:
- `python -m pytest -q -s` -> `124 passed`
- `python -m py_compile ...` -> `compiled 57 files`
- `make SHELL='C:/Program Files/Git/bin/bash.exe' verify` -> pass
- `diff-cover` against `origin/main` -> `100%` diff coverage

## Notes
- Existing unrelated local dirty file `.github/PULL_REQUEST_TEMPLATE.md` was not modified by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release and quality-gate workflows for more robust tag handling and stricter permissions.
  * Hardened path validation and file-write behavior to reduce risk when applying environment changes.
* **Tests**
  * Expanded test coverage for path guards, target validation, and write scenarios.
* **Documentation**
  * Added a Main Zero Readiness plan documenting environment and execution decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->