### PR TITLE
fix: unblock branch-protection-audit workflow parsing

### DIFF
--- a/.github/workflows/branch-protection-audit.yml
+++ b/.github/workflows/branch-protection-audit.yml
@@ -6,7 +6,6 @@ on:
     - cron: '30 6 * * 1'
 
 permissions:
-  administration: read
   contents: read
   issues: write
 


### PR DESCRIPTION
## Summary
- fix workflow-file parsing failure introduced on main by removing unsupported `permissions.administration` key in `.github/workflows/branch-protection-audit.yml`
- preserve the stale-issue auto-close and integration-limitation handling logic from PR #23

## Root Cause
`permissions.administration: read` is not a valid GitHub Actions workflow permission key, causing immediate workflow-file failure (`.github/workflows/branch-protection-audit.yml` run failure on main).

## Verification
- `make SHELL="C:/Program Files/Git/bin/sh.exe" verify`
- `python -c "import glob, py_compile; files=['env_inspector.py', *glob.glob('env_inspector_core/*.py'), *glob.glob('env_inspector_gui/*.py'), *glob.glob('tests/*.py'), *glob.glob('scripts/quality/*.py'), 'scripts/security_helpers.py']; [py_compile.compile(f, doraise=True) for f in files]; print(f'compiled {len(files)} files')"`
- `pytest -q -s`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restricted GitHub Actions workflow permissions for improved security by removing unnecessary administrative access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->