### PR TITLE
fix: avoid PR-context gate failures on main pushes

### DIFF
--- a/.github/workflows/codacy-zero.yml
+++ b/.github/workflows/codacy-zero.yml
@@ -1,8 +1,6 @@
 name: Codacy Zero
 
 on:
-  push:
-    branches: [main, master]
   pull_request:
     branches: [main, master]
   workflow_dispatch:

--- a/.github/workflows/deepscan-zero.yml
+++ b/.github/workflows/deepscan-zero.yml
@@ -1,8 +1,6 @@
 name: DeepScan Zero
 
 on:
-  push:
-    branches: [main, master]
   pull_request:
     branches: [main, master]
   workflow_dispatch:

--- a/.github/workflows/quality-zero-gate.yml
+++ b/.github/workflows/quality-zero-gate.yml
@@ -1,8 +1,6 @@
 name: Quality Zero Gate
 
 on:
-  push:
-    branches: [main, master]
   pull_request:
     branches: [main, master]
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- scope `Codacy Zero`, `DeepScan Zero`, and `Quality Zero Gate` to `pull_request` and `workflow_dispatch`
- remove `push` trigger from those workflows because they depend on PR-only external contexts (`Codacy Static Code Analysis`, `DeepScan`)

## Root Cause
After PR #24 merged, main push commit `6b505f4` showed:
- `Codacy Zero` timed out and failed: missing `Codacy Static Code Analysis`
- `DeepScan Zero` timed out and failed: missing `DeepScan`
- `Quality Zero Gate` blocked waiting on those failed contexts

These three workflows are context-assertion gates designed for PR commits, not direct main pushes.

## Verification
- `make SHELL="C:/Program Files/Git/bin/sh.exe" verify`
- `python -c "import glob, py_compile; files=['env_inspector.py', *glob.glob('env_inspector_core/*.py'), *glob.glob('env_inspector_gui/*.py'), *glob.glob('tests/*.py'), *glob.glob('scripts/quality/*.py'), 'scripts/security_helpers.py']; [py_compile.compile(f, doraise=True) for f in files]; print(f'compiled {len(files)} files')"`
- `pytest -q -s`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows configuration to remove push event triggers on main and master branches. Workflows now activate only on pull request events and manual dispatch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->