### PR TITLE
docs: prepare v2.0.0 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [2.0.0] - 2026-03-04
 
-### Added
+### Added (2.0.0)
 
 - **Phase 3: KPI Instrumentation**
   - Weekly KPI digest workflow (`.github/workflows/kpi-weekly-digest.yml`) tracking lead time, cycle time, rework rate, queue failure rate, and evidence completeness.
@@ -32,7 +32,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - PR validation workflow (`.github/workflows/ci.yml`) running compile + pytest on Ubuntu and Windows (Python 3.12).
 - Details panel actions: Copy Name, Copy Value, Copy Name=Value, Copy Source Path, Open Source.
 
-### Changed
+### Changed (2.0.0)
 
 - Context switch now performs a full refresh with busy indicator and temporary action disable/enable cycle.
 - Table columns are sortable and sort state persists across refreshes and app restarts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- No changes yet.
+
+### Changed
+
+- No changes yet.
+
+## [2.0.0] - 2026-03-04
+
+### Added
+
 - **Phase 3: KPI Instrumentation**
   - Weekly KPI digest workflow (`.github/workflows/kpi-weekly-digest.yml`) tracking lead time, cycle time, rework rate, queue failure rate, and evidence completeness.
   - Branch protection policy documentation (`.github/BRANCH_PROTECTION.md`) with human approval requirements and status checks.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 Desktop + CLI utility for inspecting and editing environment variables across Windows, WSL, and Linux contexts.
 
+## Project status
+
+- Maintenance mode (starting with v2.0.0): critical fixes and hotfixes only.
+
 ## Why this tool exists
 
 Environment values often live in multiple places at once: process env, shell profiles, registry, `.env` files, and WSL distro files. Env Inspector gives one view across those sources and a safer write flow with previews, backups, and audit logging.


### PR DESCRIPTION
## Summary
- prepare `v2.0.0` release metadata
- move current `Unreleased` changelog entries into `## [2.0.0] - 2026-03-04`
- reset `Unreleased` section scaffold
- add README maintenance-mode note

## Verification (local)
- `make SHELL="C:/Program Files/Git/bin/sh.exe" verify`
- `python -c "import glob, py_compile; files=['env_inspector.py', *glob.glob('env_inspector_core/*.py'), *glob.glob('env_inspector_gui/*.py'), *glob.glob('tests/*.py'), *glob.glob('scripts/quality/*.py'), 'scripts/security_helpers.py']; [py_compile.compile(f, doraise=True) for f in files]; print(f'compiled {len(files)} files')"`
- `pytest -q -s`
- `python -m pytest -q -s --cov=tests --cov-report=xml:coverage/python-coverage.xml`
- `python scripts/quality/assert_coverage_100.py --xml "python=coverage/python-coverage.xml" --min-percent 100`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added v2.0.0 release notes documenting new features including KPI instrumentation, Fleet Baseline Lite packaging, GUI package enhancements, and details panel actions (Copy Name, Copy Value, Copy Source Path, Open Source).
  * Updated project status to maintenance mode starting with v2.0.0, limiting updates to critical fixes and hotfixes only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->