### PR TITLE
fix: trim first env codacy issue batch

### DIFF
--- a/.github/workflows/codecov-analytics.yml
+++ b/.github/workflows/codecov-analytics.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-codecov-analytics.yml@d3aabc77c858e27cb7ade824e9fbf3dd9203f256
+    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-codecov-analytics.yml@e6d4ce5145e76f65491dfa651d492f5ff3961f41
     with:
       repo_slug: ${{ github.repository }}
       event_name: ${{ github.event_name }}

--- a/.github/workflows/quality-zero-gate.yml
+++ b/.github/workflows/quality-zero-gate.yml
@@ -14,7 +14,7 @@ jobs:
   aggregate-gate:
     permissions:
       contents: read
-    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-quality-zero-gate.yml@d3aabc77c858e27cb7ade824e9fbf3dd9203f256
+    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-quality-zero-gate.yml@e6d4ce5145e76f65491dfa651d492f5ff3961f41
     with:
       repo_slug: ${{ github.repository }}
       event_name: ${{ github.event_name }}

--- a/.github/workflows/quality-zero-platform.yml
+++ b/.github/workflows/quality-zero-platform.yml
@@ -20,6 +20,10 @@ jobs:
     with:
       repo_slug: ${{ github.repository }}
       event_name: ${{ github.event_name }}
+      branch_name: ${{ github.head_ref || github.ref_name }}
+      pull_request_number: ${{ github.event.pull_request.number || '' }}
+      pull_request_author: ${{ github.event.pull_request.user.login || '' }}
+      pull_request_head_ref: ${{ github.event.pull_request.head.ref || github.head_ref || '' }}
       sha: ${{ github.event.pull_request.head.sha || github.sha }}
       platform_repository: Prekzursil/quality-zero-platform
       platform_ref: main

--- a/.github/workflows/quality-zero-platform.yml
+++ b/.github/workflows/quality-zero-platform.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-scanner-matrix.yml@d3aabc77c858e27cb7ade824e9fbf3dd9203f256
+    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-scanner-matrix.yml@e6d4ce5145e76f65491dfa651d492f5ff3961f41
     with:
       repo_slug: ${{ github.repository }}
       event_name: ${{ github.event_name }}

--- a/env_inspector_gui/controller_actions.py
+++ b/env_inspector_gui/controller_actions.py
@@ -7,7 +7,7 @@ from env_inspector_core.models import EnvRecord
 
 from .dialogs import BackupPickerDialog
 from .path_actions import open_source_path
-from .secret_policy import resolve_copy_payload, resolve_load_value
+from .secret_policy import is_record_secret, resolve_copy_payload, resolve_load_value
 
 APP_NAME = "Env Inspector"
 MSG_SELECT_ROW_FIRST = "Select a row first."
@@ -47,6 +47,7 @@ class EnvInspectorControllerActionsMixin:
             return
 
         rec = row.record
+        record_is_secret = is_record_secret(rec)
         self.key_text.set(rec.name)
 
         loaded, raw = resolve_load_value(
@@ -59,7 +60,7 @@ class EnvInspectorControllerActionsMixin:
 
         if loaded is not None:
             self.value_text.set(loaded)
-            if rec.is_secret and not raw:
+            if record_is_secret and not raw:
                 self._set_status(f"Loaded masked value for: {rec.name}")
             else:
                 self._set_status(f"Loaded value for: {rec.name}")
@@ -88,6 +89,7 @@ class EnvInspectorControllerActionsMixin:
             self._show_select_row_required()
             return
 
+        record_is_secret = is_record_secret(rec)
         payload, raw = resolve_copy_payload(
             rec,
             show_secrets=bool(self.show_secrets.get()),
@@ -99,7 +101,7 @@ class EnvInspectorControllerActionsMixin:
 
         self.tk.clipboard_clear()
         self.tk.clipboard_append(payload)
-        if rec.is_secret and not raw:
+        if record_is_secret and not raw:
             self._set_status(f"Copied masked value for: {rec.name}")
         else:
             self._set_status(f"Copied value for: {rec.name}")
@@ -110,6 +112,7 @@ class EnvInspectorControllerActionsMixin:
             self._show_select_row_required()
             return
 
+        record_is_secret = is_record_secret(rec)
         payload, raw = resolve_copy_payload(
             rec,
             show_secrets=bool(self.show_secrets.get()),
@@ -121,7 +124,7 @@ class EnvInspectorControllerActionsMixin:
 
         self.tk.clipboard_clear()
         self.tk.clipboard_append(payload)
-        if rec.is_secret and not raw:
+        if record_is_secret and not raw:
             self._set_status(f"Copied masked pair for: {rec.name}")
         else:
             self._set_status(f"Copied pair: {rec.name}=...")

--- a/env_inspector_gui/secret_policy.py
+++ b/env_inspector_gui/secret_policy.py
@@ -1,14 +1,18 @@
 from __future__ import absolute_import, division
 
-from typing import Tuple
-from collections.abc import Callable
+from typing import Callable, Optional, Tuple
 
 from env_inspector_core.models import EnvRecord
 from env_inspector_core.secrets import mask_value
 
 
+def is_record_secret(record: EnvRecord) -> bool:
+    return bool(getattr(record, "is_secret", False))
+
+
 def build_visible_value(record: EnvRecord, *, show_secrets: bool) -> str:
-    if show_secrets or not record.is_secret:
+    record_is_secret = is_record_secret(record)
+    if show_secrets or not record_is_secret:
         return record.value
     return mask_value(record.value)
 
@@ -33,8 +37,9 @@ def resolve_copy_payload(
     confirm_raw: Callable[[], bool],
     as_pair: bool,
 ) -> Tuple[str, bool]:
-    use_raw = show_secrets or not record.is_secret
-    if record.is_secret and not show_secrets:
+    record_is_secret = is_record_secret(record)
+    use_raw = show_secrets or not record_is_secret
+    if record_is_secret and not show_secrets:
         use_raw = confirm_raw()
 
     value = record.value if use_raw else mask_value(record.value)
@@ -47,8 +52,9 @@ def resolve_load_value(
     *,
     show_secrets: bool,
     confirm_raw: Callable[[], bool],
-) -> Tuple[str | None, bool]:
-    if show_secrets or not record.is_secret:
+) -> Tuple[Optional[str], bool]:
+    record_is_secret = is_record_secret(record)
+    if show_secrets or not record_is_secret:
         return record.value, True
 
     if confirm_raw():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division
 import argparse
 import json
 import unittest
-from typing import Any, Dict, List, cast
+from typing import Dict, List, cast
 
 import env_inspector_core.cli as cli_mod
 from env_inspector_core.cli import build_parser, run_cli

--- a/tests/test_gui_controller.py
+++ b/tests/test_gui_controller.py
@@ -21,8 +21,8 @@ class _Var:
 
 class _View:
     def __init__(self) -> None:
-        self.enabled_states: list[bool] = []
-        self.busy_states: list[bool] = []
+        self.enabled_states: List[bool] = []
+        self.busy_states: List[bool] = []
 
     def set_mutation_actions_enabled(self, enabled: bool) -> None:
         self.enabled_states.append(enabled)

--- a/tests/test_quality_codacy_deepscan_branches.py
+++ b/tests/test_quality_codacy_deepscan_branches.py
@@ -4,7 +4,7 @@ from email.message import Message
 import secrets
 import sys
 import unittest
-from typing import NoReturn
+from typing import List, NoReturn, Optional, Tuple
 import urllib.error
 
 import pytest
@@ -212,7 +212,7 @@ def test_codacy_fetch_open_issues_handles_http_and_request_errors(monkeypatch):
 def test_codacy_query_open_issues_fallback_and_last_error(monkeypatch):
     monkeypatch.setattr(codacy_mod, "_provider_candidates", lambda _preferred: ["gh", "github"])
 
-    responses = [
+    responses: List[Tuple[bool, Optional[int], List[str], Optional[Exception]]] = [
         (False, None, [], _http_error(404)),
         (True, 0, [], None),
     ]
@@ -263,7 +263,7 @@ def test_deepscan_resolve_and_fetch_open_issues_paths(monkeypatch):
     case.assertEqual(path, "/api/projects/1/issues/open")
     case.assertEqual(query, {"scope": "pull-request"})
 
-    findings = []
+    findings: List[str] = []
     monkeypatch.setattr(
         deepscan_mod,
         "_request_json",

--- a/tests/test_service_path_guards.py
+++ b/tests/test_service_path_guards.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division
 
 from pathlib import Path
+from typing import Dict, List, Tuple
 
 import pytest
 
@@ -91,7 +92,7 @@ def test_restore_wsl_dotenv_backup_uses_wsl_write_file(tmp_path: Path, monkeypat
     monkeypatch.chdir(tmp_path)
     svc = EnvInspectorService(state_dir=tmp_path / "state")
 
-    calls: list[tuple[str, str, str]] = []
+    calls: List[Tuple[str, str, str]] = []
     monkeypatch.setattr(svc.wsl, "write_file", lambda distro, path, text: calls.append((distro, path, text)))
 
     backup_path = svc.backup_mgr.backup_text("wsl_dotenv:Ubuntu:/home/user/.env", "A=1\n")
@@ -104,7 +105,7 @@ def test_restore_wsl_bashrc_backup_uses_wsl_write_file(tmp_path: Path, monkeypat
     monkeypatch.chdir(tmp_path)
     svc = EnvInspectorService(state_dir=tmp_path / "state")
 
-    calls: list[tuple[str, str, str]] = []
+    calls: List[Tuple[str, str, str]] = []
     monkeypatch.setattr(svc.wsl, "write_file", lambda distro, path, text: calls.append((distro, path, text)))
 
     backup_path = svc.backup_mgr.backup_text("wsl:Ubuntu:bashrc", "export A='1'\n")
@@ -126,7 +127,7 @@ def test_restore_wsl_dotenv_backup_rejects_path_traversal(tmp_path: Path, monkey
     monkeypatch.chdir(tmp_path)
     svc = EnvInspectorService(state_dir=tmp_path / "state")
 
-    calls: list[tuple[str, str, str]] = []
+    calls: List[Tuple[str, str, str]] = []
     monkeypatch.setattr(svc.wsl, "write_file", lambda distro, path, text: calls.append((distro, path, text)))
 
     backup_path = svc.backup_mgr.backup_text("wsl_dotenv:Ubuntu:/home/user/../outside.env", "A=1\n")
@@ -162,7 +163,7 @@ def test_restore_powershell_target_all_users_uses_program_files_root(tmp_path: P
     svc = EnvInspectorService(state_dir=tmp_path / "state")
     profile = tmp_path / "program_files" / "PowerShell" / "7" / "profile.ps1"
 
-    writes: dict[str, object] = {}
+    writes: Dict[str, object] = {}
     monkeypatch.setattr(EnvInspectorService, "_validated_powershell_restore_path", lambda _self, _target: profile)
     monkeypatch.setattr(
         svc,


### PR DESCRIPTION
## Summary\n- trim the first low-risk Codacy cleanup batch on top of current main\n- normalize a set of Python 3.8-compatible typing annotations in tests and secret-policy helpers\n- keep the change set behavior-neutral while we separate real Codacy debt from provider/push-parity drift\n\n## Verification\n- python -m compileall -q env_inspector.py env_inspector_core env_inspector_gui tests scripts/quality\n- python -m pytest -q tests/test_gui_controller.py tests/test_service_path_guards.py tests/test_quality_codacy_deepscan_branches.py tests/test_cli.py\n- python -m pytest -q\n\n## Remaining follow-up after this first batch\n- current main Codacy dashboard still reports 13 issues across secret-policy/controller typing, tests, and one view complexity finding\n- current main DeepScan Zero push failure is provider/context drift (missing native DeepScan status on push) and likely needs the repo wrapper refreshed to the controller revision that landed the push-safe fix\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enhanced search value builder for improved record discovery.

* **Refactor**
  * Centralized secret detection logic across operations for consistent handling of sensitive values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->