### PR TITLE
fix: narrow env path open failures

### DIFF
--- a/env_inspector_gui/path_actions.py
+++ b/env_inspector_gui/path_actions.py
@@ -34,7 +34,7 @@ def open_source_path(
 
     try:
         _open_path(source_path, open_uri=open_uri)
-    except Exception as exc:
+    except (OSError, RuntimeError, ValueError) as exc:
         return False, str(exc)
 
     return True, None


### PR DESCRIPTION
## Summary
- narrow the path-opening failure handler to expected local path/opening exceptions
- keep the GUI path action behavior unchanged while clearing the broad-exception smell
- preserve the restored push-parity quality surface on `main`

## Verification
- `python -m pytest -q tests/test_gui_controller.py tests/test_service_path_guards.py tests/test_cli.py`
- `python -m pylint --disable=C env_inspector_gui/path_actions.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling specificity to provide more accurate error reporting and improved system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->