### PR TITLE
fix: default verify to python3 in clean environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: verify compile test
 
-PYTHON ?= python
+PYTHON ?= python3
 
 verify: compile test
 


### PR DESCRIPTION
## Summary\n- default the canonical Makefile verification flow to python3 instead of python\n- make the repo's own make verify command work in clean Linux/WSL environments without relying on a python shim\n\n## Verification\n- make verify