### PR TITLE
fix: remove repo-level Codacy exclusions

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,11 +1,4 @@
 ---
 engines:
-  bandit:
-    exclude_paths:
-      - "tests/**"
-  lizard:
-    exclude_paths:
-      - "env_inspector_core/providers.py"
-      - "env_inspector_core/service.py"
   pylintpython3:
     python_version: 3

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -22,6 +22,8 @@ def test_main_print_secrets_rejects_invalid_root(tmp_path: Path, monkeypatch, ca
     monkeypatch.chdir(workspace)
 
     class _ForbiddenService:
+        """Guard service proving invalid roots fail before service construction."""
+
         def __init__(self, *args, **kwargs):  # pragma: no cover - should not be reached
             """Init."""
             raise AssertionError("EnvInspectorService should not be created for invalid --root")
@@ -57,6 +59,8 @@ def test_legacy_print_secrets_uses_workspace_root_for_listing(tmp_path: Path, mo
         return [{"is_secret": secret_flag, "source_type": "dotenv", "source_id": ".env", "name": "API_TOKEN"}]
 
     class _Service:
+        """Minimal service stub that returns the captured secret rows."""
+
         list_records = staticmethod(_list_records)
 
     monkeypatch.setattr(env_inspector, "EnvInspectorService", _Service)
@@ -83,6 +87,8 @@ def test_legacy_print_secrets_skips_non_secret_rows(tmp_path: Path, monkeypatch,
         return [{"is_secret": False, "source_type": "dotenv", "source_id": ".env", "name": "PUBLIC_VAR"}]
 
     class _Service:
+        """Minimal service stub that only yields non-secret rows."""
+
         list_records = staticmethod(_list_records)
 
     monkeypatch.setattr(env_inspector, "EnvInspectorService", _Service)
@@ -103,6 +109,8 @@ def test_legacy_print_secrets_rejects_nested_subdirectory_root(tmp_path: Path, m
     monkeypatch.chdir(workspace)
 
     class _ForbiddenService:
+        """Guard service proving nested roots fail before service construction."""
+
         def __init__(self, *args, **kwargs):  # pragma: no cover - should not be reached
             """Init."""
             raise AssertionError("EnvInspectorService should not be created for unsupported nested root")

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -23,6 +23,7 @@ def test_main_print_secrets_rejects_invalid_root(tmp_path: Path, monkeypatch, ca
 
     class _ForbiddenService:
         def __init__(self, *args, **kwargs):  # pragma: no cover - should not be reached
+            """Init."""
             raise AssertionError("EnvInspectorService should not be created for invalid --root")
 
     monkeypatch.setattr(env_inspector, "EnvInspectorService", _ForbiddenService)
@@ -50,6 +51,7 @@ def test_legacy_print_secrets_uses_workspace_root_for_listing(tmp_path: Path, mo
     captured = {}
 
     def _list_records(**kwargs):
+        """List records."""
         secret_flag = bool(1)
         captured.update(kwargs)
         return [{"is_secret": secret_flag, "source_type": "dotenv", "source_id": ".env", "name": "API_TOKEN"}]
@@ -77,6 +79,7 @@ def test_legacy_print_secrets_skips_non_secret_rows(tmp_path: Path, monkeypatch,
     monkeypatch.chdir(workspace)
 
     def _list_records(**_kwargs):
+        """List records."""
         return [{"is_secret": False, "source_type": "dotenv", "source_id": ".env", "name": "PUBLIC_VAR"}]
 
     class _Service:
@@ -101,6 +104,7 @@ def test_legacy_print_secrets_rejects_nested_subdirectory_root(tmp_path: Path, m
 
     class _ForbiddenService:
         def __init__(self, *args, **kwargs):  # pragma: no cover - should not be reached
+            """Init."""
             raise AssertionError("EnvInspectorService should not be created for unsupported nested root")
 
     monkeypatch.setattr(env_inspector, "EnvInspectorService", _ForbiddenService)

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -66,6 +66,27 @@ def test_legacy_print_secrets_uses_workspace_root_for_listing(tmp_path: Path, mo
     case.assertIn("API_TOKEN", out)
 
 
+def test_legacy_print_secrets_skips_non_secret_rows(tmp_path: Path, monkeypatch, capsys):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    monkeypatch.chdir(workspace)
+
+    def _list_records(**_kwargs):
+        return [{"is_secret": False, "source_type": "dotenv", "source_id": ".env", "name": "PUBLIC_VAR"}]
+
+    class _Service:
+        list_records = staticmethod(_list_records)
+
+    monkeypatch.setattr(env_inspector, "EnvInspectorService", _Service)
+
+    code = env_inspector._legacy_print_secrets(str(workspace))
+
+    case = _case()
+    case.assertEqual(code, 0)
+    case.assertEqual(capsys.readouterr().out, "")
+
+
 def test_legacy_print_secrets_rejects_nested_subdirectory_root(tmp_path: Path, monkeypatch, capsys):
     workspace = tmp_path / "workspace"
     nested = workspace / "nested"

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -9,10 +9,12 @@ from env_inspector_core.path_policy import PathPolicyError
 
 
 def _case() -> unittest.TestCase:
+    """Return a tiny unittest helper instance for assertion-style checks."""
     return unittest.TestCase()
 
 
 def test_main_print_secrets_rejects_invalid_root(tmp_path: Path, monkeypatch, capsys):
+    """Main should reject roots outside the current workspace when printing secrets."""
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     outside = tmp_path.parent
@@ -39,6 +41,7 @@ def test_main_print_secrets_rejects_invalid_root(tmp_path: Path, monkeypatch, ca
 
 
 def test_legacy_print_secrets_uses_workspace_root_for_listing(tmp_path: Path, monkeypatch, capsys):
+    """Legacy print-secrets should list secrets from the validated workspace root."""
     workspace = tmp_path / "workspace"
     workspace.mkdir()
 
@@ -67,6 +70,7 @@ def test_legacy_print_secrets_uses_workspace_root_for_listing(tmp_path: Path, mo
 
 
 def test_legacy_print_secrets_skips_non_secret_rows(tmp_path: Path, monkeypatch, capsys):
+    """Legacy print-secrets should not emit rows that are not marked as secrets."""
     workspace = tmp_path / "workspace"
     workspace.mkdir()
 
@@ -88,6 +92,7 @@ def test_legacy_print_secrets_skips_non_secret_rows(tmp_path: Path, monkeypatch,
 
 
 def test_legacy_print_secrets_rejects_nested_subdirectory_root(tmp_path: Path, monkeypatch, capsys):
+    """Legacy print-secrets should reject nested roots even when they are under the workspace."""
     workspace = tmp_path / "workspace"
     nested = workspace / "nested"
     nested.mkdir(parents=True)
@@ -109,6 +114,7 @@ def test_legacy_print_secrets_rejects_nested_subdirectory_root(tmp_path: Path, m
 
 
 def test_resolve_legacy_print_secrets_root_does_not_renormalize_validated_root(tmp_path: Path, monkeypatch):
+    """Validated roots should round-trip through the legacy resolver without drift."""
     workspace = (tmp_path / "workspace").resolve()
     workspace.mkdir()
     monkeypatch.chdir(workspace)
@@ -116,6 +122,7 @@ def test_resolve_legacy_print_secrets_root_does_not_renormalize_validated_root(t
     calls: List[str] = []
 
     def _validated_root(_value):
+        """Return the already validated workspace root for the legacy resolver."""
         calls.append(str(_value))
         return workspace
 
@@ -127,6 +134,7 @@ def test_resolve_legacy_print_secrets_root_does_not_renormalize_validated_root(t
 
 
 def test_resolve_legacy_print_secrets_root_rejects_missing_directory(tmp_path: Path, monkeypatch):
+    """Legacy secret-root resolution should fail when the requested directory is missing."""
     workspace = (tmp_path / "workspace").resolve()
     missing = workspace / "missing"
     workspace.mkdir()

--- a/tests/test_pr54_coverage_branches.py
+++ b/tests/test_pr54_coverage_branches.py
@@ -25,6 +25,7 @@ def test_list_records_rejects_request_and_kwargs(tmp_path: Path) -> None:
 
 
 def test_collect_wsl_rows_rejects_positional_and_unexpected_kwargs() -> None:
+    """Test collect wsl rows rejects positional and unexpected kwargs."""
     with pytest.raises(TypeError, match="collect_wsl_rows accepts keyword arguments only"):
         service_listing_module.collect_wsl_rows("bad-arg")
 
@@ -45,6 +46,7 @@ def test_collect_wsl_rows_rejects_positional_and_unexpected_kwargs() -> None:
 
 
 def test_wsl_dotenv_rows_returns_empty_when_request_is_incomplete() -> None:
+    """Test wsl dotenv rows returns empty when request is incomplete."""
     calls = []
 
     rows = service_listing_module._wsl_dotenv_rows(
@@ -58,9 +60,11 @@ def test_wsl_dotenv_rows_returns_empty_when_request_is_incomplete() -> None:
 
 
 def test_bridge_rows_without_current_linux_distro_uses_no_exclusions() -> None:
+    """Test bridge rows without current linux distro uses no exclusions."""
     calls = []
 
     def _fake_collect(_wsl, include_etc, exclude_distros):
+        """Fake collect."""
         calls.append((include_etc, exclude_distros))
         return []
 
@@ -76,6 +80,7 @@ def test_bridge_rows_without_current_linux_distro_uses_no_exclusions() -> None:
 
 
 def test_apply_row_filters_and_available_targets_cover_falsey_branches(tmp_path: Path) -> None:
+    """Test apply row filters and available targets cover falsey branches."""
     rows = [
         service_module.EnvRecord(
             source_type=SOURCE_DOTENV,
@@ -114,6 +119,7 @@ def test_apply_row_filters_and_available_targets_cover_falsey_branches(tmp_path:
 
 
 def test_write_linux_etc_environment_with_privilege_rejects_invalid_arguments(tmp_path: Path) -> None:
+    """Test write linux etc environment with privilege rejects invalid arguments."""
     target = tmp_path / "environment"
 
     with pytest.raises(TypeError, match="accepts keyword arguments only"):
@@ -130,6 +136,7 @@ def test_write_linux_etc_environment_with_privilege_rejects_invalid_arguments(tm
 
 
 def test_restore_helpers_reject_positional_arguments(tmp_path: Path) -> None:
+    """Test restore helpers reject positional arguments."""
     with pytest.raises(TypeError, match="restore_dotenv_target accepts keyword arguments only"):
         service_restore_module.restore_dotenv_target("bad-arg")
 
@@ -150,10 +157,12 @@ def test_restore_helpers_reject_positional_arguments(tmp_path: Path) -> None:
 
 
 def _scoped_dotenv_target(tmp_path: Path) -> SimpleNamespace:
+    """Scoped dotenv target."""
     return SimpleNamespace(path=tmp_path / ".env", roots=[tmp_path])
 
 
 def _wsl_write_adapter() -> SimpleNamespace:
+    """Wsl write adapter."""
     return SimpleNamespace(
         write_file=lambda *_args: None,
         write_file_with_privilege=lambda *_args: None,
@@ -161,6 +170,7 @@ def _wsl_write_adapter() -> SimpleNamespace:
 
 
 def test_restore_dotenv_target_rejects_unexpected_keyword_arguments(tmp_path: Path) -> None:
+    """Test restore dotenv target rejects unexpected keyword arguments."""
     scoped = _scoped_dotenv_target(tmp_path)
 
     with pytest.raises(TypeError, match="Unexpected keyword argument"):
@@ -175,6 +185,7 @@ def test_restore_dotenv_target_rejects_unexpected_keyword_arguments(tmp_path: Pa
 
 
 def test_restore_linux_target_rejects_unexpected_keyword_arguments() -> None:
+    """Test restore linux target rejects unexpected keyword arguments."""
     with pytest.raises(TypeError, match="Unexpected keyword argument"):
         service_restore_module.restore_linux_target(
             target="linux:bashrc",
@@ -185,6 +196,7 @@ def test_restore_linux_target_rejects_unexpected_keyword_arguments() -> None:
 
 
 def test_restore_wsl_target_rejects_unexpected_keyword_arguments() -> None:
+    """Test restore wsl target rejects unexpected keyword arguments."""
     wsl = _wsl_write_adapter()
 
     with pytest.raises(TypeError, match="Unexpected keyword argument"):
@@ -200,6 +212,7 @@ def test_restore_wsl_target_rejects_unexpected_keyword_arguments() -> None:
 
 
 def test_restore_powershell_target_rejects_unexpected_keyword_arguments(tmp_path: Path) -> None:
+    """Test restore powershell target rejects unexpected keyword arguments."""
     with pytest.raises(TypeError, match="Unexpected keyword argument"):
         service_restore_module.restore_powershell_target(
             target="powershell:current_user",
@@ -211,6 +224,7 @@ def test_restore_powershell_target_rejects_unexpected_keyword_arguments(tmp_path
 
 
 def test_restore_windows_registry_target_rejects_unexpected_keyword_arguments() -> None:
+    """Test restore windows registry target rejects unexpected keyword arguments."""
     with pytest.raises(TypeError, match="Unexpected keyword argument"):
         service_restore_module.restore_windows_registry_target(
             target="windows:user",
@@ -226,6 +240,7 @@ def test_restore_windows_registry_target_rejects_unexpected_keyword_arguments() 
 
 
 def test_restore_target_rejects_unexpected_keyword_arguments(tmp_path: Path) -> None:
+    """Test restore target rejects unexpected keyword arguments."""
     with pytest.raises(TypeError, match="Unexpected keyword argument"):
         service_restore_module.restore_target(
             target="linux:bashrc",
@@ -241,6 +256,7 @@ def test_restore_target_rejects_unexpected_keyword_arguments(tmp_path: Path) -> 
 
 
 def test_coerce_scan_request_covers_positional_branches() -> None:
+    """Test coerce scan request covers positional branches."""
     auth_value = "auth-credential"
     request = sentry_mod.SentryScanRequest(org="my-org", projects=["proj"], token=auth_value)
 
@@ -258,6 +274,7 @@ def test_coerce_scan_request_covers_positional_branches() -> None:
 
 
 def test_resolve_unresolved_count_without_hits_header_and_without_issues() -> None:
+    """Test resolve unresolved count without hits header and without issues."""
     failures: list[str] = []
 
     unresolved = sentry_mod._resolve_unresolved_count([], {}, "proj", failures)
@@ -267,6 +284,7 @@ def test_resolve_unresolved_count_without_hits_header_and_without_issues() -> No
 
 
 def test_check_sentry_zero_script_does_not_duplicate_helper_root(monkeypatch) -> None:
+    """Test check sentry zero script does not duplicate helper root."""
     import runpy
     import sys
 
@@ -296,6 +314,7 @@ def test_check_sentry_zero_script_does_not_duplicate_helper_root(monkeypatch) ->
 
 
 def test_scan_projects_covers_request_object_and_keyword_request_paths(monkeypatch) -> None:
+    """Test scan projects covers request object and keyword request paths."""
     auth_value = "auth-credential"
     monkeypatch.setattr(
         sentry_mod,

--- a/tests/test_pr54_coverage_branches.py
+++ b/tests/test_pr54_coverage_branches.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division
 
 from pathlib import Path
 from types import SimpleNamespace
+from typing import List
 
 import pytest
 
@@ -275,7 +276,7 @@ def test_coerce_scan_request_covers_positional_branches() -> None:
 
 def test_resolve_unresolved_count_without_hits_header_and_without_issues() -> None:
     """Test resolve unresolved count without hits header and without issues."""
-    failures: list[str] = []
+    failures: List[str] = []
 
     unresolved = sentry_mod._resolve_unresolved_count([], {}, "proj", failures)
 

--- a/tests/test_pr54_coverage_branches.py
+++ b/tests/test_pr54_coverage_branches.py
@@ -9,6 +9,7 @@ import env_inspector_core.service as service_module
 import env_inspector_core.service_listing as service_listing_module
 import env_inspector_core.service_privileged as service_privileged_module
 import env_inspector_core.service_restore as service_restore_module
+from env_inspector_core.constants import SOURCE_DOTENV
 from env_inspector_core.service import EnvInspectorService
 from scripts.quality import check_sentry_zero as sentry_mod
 from tests.assertions import ensure
@@ -53,6 +54,58 @@ def test_wsl_dotenv_rows_returns_empty_when_request_is_incomplete() -> None:
 
     ensure(rows == [])
     ensure(calls == [])
+
+
+def test_bridge_rows_without_current_linux_distro_uses_no_exclusions() -> None:
+    calls = []
+
+    rows = service_listing_module._bridge_rows(
+        runtime_context="windows",
+        current_wsl_distro="Ubuntu",
+        wsl=SimpleNamespace(),
+        collect_wsl_records_fn=lambda _wsl, include_etc, exclude_distros: calls.append((include_etc, exclude_distros)) or [],
+    )
+
+    ensure(rows == [])
+    ensure(calls == [(True, None)])
+
+
+def test_apply_row_filters_and_available_targets_cover_falsey_branches(tmp_path: Path) -> None:
+    rows = [
+        service_module.EnvRecord(
+            source_type=SOURCE_DOTENV,
+            source_id="dotenv",
+            source_path=str(tmp_path / ".env"),
+            context="linux",
+            name="A",
+            value="1",
+            is_secret=False,
+            is_persistent=True,
+            is_mutable=True,
+            precedence_rank=1,
+            writable=True,
+            requires_privilege=False,
+        )
+    ]
+
+    ensure(service_listing_module.apply_row_filters(rows, source=None, context=None) == rows)
+
+    unknown_record = service_module.EnvRecord(
+        source_type="unknown",
+        source_id="unknown",
+        source_path="ignored",
+        context="wsl:Ubuntu",
+        name="B",
+        value="2",
+        is_secret=False,
+        is_persistent=True,
+        is_mutable=True,
+        precedence_rank=1,
+        writable=True,
+        requires_privilege=False,
+    )
+
+    ensure(service_listing_module.available_targets([unknown_record], context="wsl:Ubuntu", win_provider_present=False) == [])
 
 
 def test_write_linux_etc_environment_with_privilege_rejects_invalid_arguments(tmp_path: Path) -> None:
@@ -197,6 +250,44 @@ def test_coerce_scan_request_covers_positional_branches() -> None:
 
     with pytest.raises(TypeError, match="Pass a request object or keyword arguments"):
         sentry_mod._coerce_scan_request("only-org")
+
+
+def test_resolve_unresolved_count_without_hits_header_and_without_issues() -> None:
+    failures = []
+
+    unresolved = sentry_mod._resolve_unresolved_count([], {}, "proj", failures)
+
+    ensure(unresolved == 0)
+    ensure(failures == [])
+
+
+def test_check_sentry_zero_script_does_not_duplicate_helper_root(monkeypatch) -> None:
+    import runpy
+    import sys
+
+    helper_root = str(Path(sentry_mod.__file__).resolve().parent.parent)
+    monkeypatch.setattr(sys, "path", [helper_root] + [entry for entry in sys.path if entry != helper_root])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "check_sentry_zero.py",
+            "--out-json",
+            "reports/sentry.json",
+            "--out-md",
+            "reports/sentry.md",
+        ],
+    )
+    monkeypatch.delenv("SENTRY_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("SENTRY_ORG", raising=False)
+    monkeypatch.delenv("SENTRY_PROJECT_BACKEND", raising=False)
+    monkeypatch.delenv("SENTRY_PROJECT_WEB", raising=False)
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(str(Path(sentry_mod.__file__)), run_name="__main__")
+
+    ensure(exc_info.value.code == 0)
+    ensure(sys.path.count(helper_root) == 1)
 
 
 def test_scan_projects_covers_request_object_and_keyword_request_paths(monkeypatch) -> None:

--- a/tests/test_pr54_coverage_branches.py
+++ b/tests/test_pr54_coverage_branches.py
@@ -59,11 +59,15 @@ def test_wsl_dotenv_rows_returns_empty_when_request_is_incomplete() -> None:
 def test_bridge_rows_without_current_linux_distro_uses_no_exclusions() -> None:
     calls = []
 
+    def _fake_collect(_wsl, include_etc, exclude_distros):
+        calls.append((include_etc, exclude_distros))
+        return []
+
     rows = service_listing_module._bridge_rows(
         runtime_context="windows",
         current_wsl_distro="Ubuntu",
         wsl=SimpleNamespace(),
-        collect_wsl_records_fn=lambda _wsl, include_etc, exclude_distros: calls.append((include_etc, exclude_distros)) or [],
+        collect_wsl_records_fn=_fake_collect,
     )
 
     ensure(rows == [])
@@ -253,7 +257,7 @@ def test_coerce_scan_request_covers_positional_branches() -> None:
 
 
 def test_resolve_unresolved_count_without_hits_header_and_without_issues() -> None:
-    failures = []
+    failures: list[str] = []
 
     unresolved = sentry_mod._resolve_unresolved_count([], {}, "proj", failures)
 

--- a/tests/test_pr54_coverage_branches.py
+++ b/tests/test_pr54_coverage_branches.py
@@ -16,6 +16,7 @@ from tests.assertions import ensure
 
 
 def test_list_records_rejects_request_and_kwargs(tmp_path: Path) -> None:
+    """list_records should reject mixing a request object with keyword overrides."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
     request = service_module.ListRecordsRequest(root=tmp_path)
 

--- a/tests/test_service_coverage_branches.py
+++ b/tests/test_service_coverage_branches.py
@@ -307,6 +307,8 @@ def test_restore_helpers_cover_powershell_and_registry(tmp_path: Path, monkeypat
         svc._restore_windows_registry_target(target="windows:user", text="{}")
 
     class _FakeWinProvider:
+        """Minimal Windows provider stub for registry restore guard coverage."""
+
         def __init__(self) -> None:
             """Init."""
             self.removed: List[Tuple[str, str]] = []
@@ -358,6 +360,8 @@ def test_restore_dotenv_target_rejects_outside_scope(tmp_path: Path, monkeypatch
     outside.mkdir(parents=True, exist_ok=True)
 
     class _Scoped:
+        """Scoped target stub exposing the parsed dotenv path for guard checks."""
+
         def __init__(self, path: Path) -> None:
             """Init."""
             self.path = path

--- a/tests/test_service_coverage_branches.py
+++ b/tests/test_service_coverage_branches.py
@@ -79,6 +79,21 @@ def test_collect_wsl_rows_swallows_collection_errors(monkeypatch, tmp_path: Path
     ensure(rows == [])
 
 
+def test_list_records_accepts_request_without_kwargs(monkeypatch, tmp_path: Path) -> None:
+    svc = EnvInspectorService(state_dir=tmp_path / "state")
+    request = service_module.ListRecordsRequest(root=tmp_path, include_raw_secrets=True)
+
+    monkeypatch.setattr(service_module, "resolve_scan_root", lambda root: Path(root))
+    monkeypatch.setattr(svc, "_collect_host_rows", lambda root_path, _scan_depth: [_record(SOURCE_DOTENV, str(root_path / ".env"))])
+    monkeypatch.setattr(svc, "_collect_wsl_rows", lambda **_kwargs: [])
+    monkeypatch.setattr(svc, "_apply_row_filters", lambda rows, source, context: rows)
+
+    rows = svc.list_records(request=request)
+
+    ensure(len(rows) == 1)
+    ensure(rows[0]["source_path"] == str(tmp_path / ".env"))
+
+
 def test_available_targets_maps_all_known_sources_and_filters_context(tmp_path: Path):
     svc = EnvInspectorService(state_dir=tmp_path / "state")
     svc.win_provider = object()
@@ -169,6 +184,61 @@ def test_update_helpers_cover_dispatch_and_error_branches(monkeypatch, tmp_path:
     )
     ensure(svc._file_update("wsl:Ubuntu:bashrc", "A", "1", "set", apply_changes=False, scope_roots=[])[2] == "wsl")
     ensure(svc._file_update("powershell:current_user", "A", "1", "set", apply_changes=False, scope_roots=[])[2] == "ps")
+
+
+def test_update_helpers_preview_paths_skip_writes_when_apply_changes_is_false(monkeypatch, tmp_path: Path) -> None:
+    svc = EnvInspectorService(state_dir=tmp_path / "state")
+
+    monkeypatch.setattr(svc, "_resolve_wsl_target", lambda _target: ("Ubuntu", "~/.bashrc", "export", False))
+    monkeypatch.setattr(svc.wsl, "read_file", lambda distro, path: "export A='1'\n")
+    monkeypatch.setattr(
+        svc.wsl,
+        "write_file",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("write_file should not run")),
+    )
+    monkeypatch.setattr(
+        svc.wsl,
+        "write_file_with_privilege",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("privileged write should not run")),
+    )
+
+    before, after, out_path, requires_priv, _ = svc._update_wsl_file(
+        target="wsl:Ubuntu:bashrc",
+        key="B",
+        value="2",
+        action="set",
+        apply_changes=False,
+    )
+
+    ensure(before == "export A='1'\n")
+    ensure("export B='2'" in after)
+    ensure(out_path == "Ubuntu:~/.bashrc")
+    ensure(requires_priv is False)
+
+    profile = tmp_path / "profile.ps1"
+    monkeypatch.setattr(
+        EnvInspectorService,
+        "_powershell_target_path_and_roots",
+        lambda _self, _target: (profile, [tmp_path], False),
+    )
+    monkeypatch.setattr(
+        svc,
+        "_write_text_file",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("PowerShell write should not run")),
+    )
+
+    before, after, out_path, requires_priv, _ = svc._update_powershell_file(
+        target="powershell:current_user",
+        key="B",
+        value="2",
+        action="set",
+        apply_changes=False,
+    )
+
+    ensure(before == "")
+    ensure("$env:B = '2'" in after)
+    ensure(out_path == str(profile))
+    ensure(requires_priv is False)
 
 
 def test_restore_helpers_cover_linux_and_wsl_targets(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_service_coverage_branches.py
+++ b/tests/test_service_coverage_branches.py
@@ -22,6 +22,7 @@ from tests.assertions import ensure
 
 
 def _record(source_type: str, source_path: str, *, context: str = "linux", source_id: str = "Ubuntu") -> EnvRecord:
+    """Record."""
     return EnvRecord(
         source_type=source_type,
         source_id=source_id,
@@ -39,6 +40,7 @@ def _record(source_type: str, source_path: str, *, context: str = "linux", sourc
 
 
 def test_collect_wsl_rows_uses_linux_exclusion_and_dotenv(monkeypatch, tmp_path: Path) -> None:
+    """Test collect wsl rows uses linux exclusion and dotenv."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
     svc.runtime_context = "linux"
     svc.current_wsl_distro = "Ubuntu"
@@ -47,10 +49,12 @@ def test_collect_wsl_rows_uses_linux_exclusion_and_dotenv(monkeypatch, tmp_path:
     calls: Dict[str, object] = {}
 
     def _fake_collect_wsl_records(wsl, include_etc: bool, exclude_distros) -> List[EnvRecord]:
+        """Fake collect wsl records."""
         calls["exclude"] = exclude_distros
         return [_record(SOURCE_WSL_BASHRC, "~/.bashrc", context="wsl:Debian", source_id="Debian")]
 
     def _fake_collect_wsl_dotenv_records(wsl, distro: str, root_path: str, max_depth: int) -> List[EnvRecord]:
+        """Fake collect wsl dotenv records."""
         calls["dotenv"] = (distro, root_path, max_depth)
         return [_record(SOURCE_WSL_DOTENV, "Debian:/home/user/.env", context="wsl:Debian", source_id="Debian")]
 
@@ -65,10 +69,12 @@ def test_collect_wsl_rows_uses_linux_exclusion_and_dotenv(monkeypatch, tmp_path:
 
 
 def test_collect_wsl_rows_swallows_collection_errors(monkeypatch, tmp_path: Path) -> None:
+    """Test collect wsl rows swallows collection errors."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
     monkeypatch.setattr(svc.wsl, "available", lambda: True)
 
     def _raise_runtime_error(*_args, **_kwargs) -> None:
+        """Raise runtime error."""
         raise RuntimeError("boom")
 
     monkeypatch.setattr(service_module, "collect_wsl_records", _raise_runtime_error)
@@ -80,13 +86,16 @@ def test_collect_wsl_rows_swallows_collection_errors(monkeypatch, tmp_path: Path
 
 
 def test_list_records_accepts_request_without_kwargs(monkeypatch, tmp_path: Path) -> None:
+    """Test list records accepts request without kwargs."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
     request = service_module.ListRecordsRequest(root=tmp_path, include_raw_secrets=True)
 
     def _resolve_scan_root(root):
+        """Resolve scan root."""
         return Path(root)
 
     def _collect_host_rows(root_path, _scan_depth):
+        """Collect host rows."""
         return [_record(SOURCE_DOTENV, str(root_path / ".env"))]
 
     monkeypatch.setattr(service_module, "resolve_scan_root", _resolve_scan_root)
@@ -101,6 +110,7 @@ def test_list_records_accepts_request_without_kwargs(monkeypatch, tmp_path: Path
 
 
 def test_available_targets_maps_all_known_sources_and_filters_context(tmp_path: Path):
+    """Test available targets maps all known sources and filters context."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
     svc.win_provider = object()
     records = [
@@ -131,6 +141,7 @@ def test_available_targets_maps_all_known_sources_and_filters_context(tmp_path: 
 
 
 def test_registry_write_requires_provider(tmp_path: Path):
+    """Test registry write requires provider."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
     svc.win_provider = None
 
@@ -139,6 +150,7 @@ def test_registry_write_requires_provider(tmp_path: Path):
 
 
 def test_update_helpers_cover_dispatch_and_error_branches(monkeypatch, tmp_path: Path):
+    """Test update helpers cover dispatch and error branches."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
 
     with pytest.raises(RuntimeError, match="Unsupported Linux target"):
@@ -193,6 +205,7 @@ def test_update_helpers_cover_dispatch_and_error_branches(monkeypatch, tmp_path:
 
 
 def test_update_helpers_preview_paths_skip_writes_when_apply_changes_is_false(monkeypatch, tmp_path: Path) -> None:
+    """Test update helpers preview paths skip writes when apply changes is false."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
 
     monkeypatch.setattr(svc, "_resolve_wsl_target", lambda _target: ("Ubuntu", "~/.bashrc", "export", False))
@@ -248,6 +261,7 @@ def test_update_helpers_preview_paths_skip_writes_when_apply_changes_is_false(mo
 
 
 def test_restore_helpers_cover_linux_and_wsl_targets(tmp_path: Path, monkeypatch) -> None:
+    """Test restore helpers cover linux and wsl targets."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
     fake_home = tmp_path / "home"
     fake_home.mkdir(parents=True, exist_ok=True)
@@ -278,6 +292,7 @@ def test_restore_helpers_cover_linux_and_wsl_targets(tmp_path: Path, monkeypatch
 
 
 def test_restore_helpers_cover_powershell_and_registry(tmp_path: Path, monkeypatch) -> None:
+    """Test restore helpers cover powershell and registry."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
     fake_home = tmp_path / "home"
     fake_home.mkdir(parents=True, exist_ok=True)
@@ -293,17 +308,21 @@ def test_restore_helpers_cover_powershell_and_registry(tmp_path: Path, monkeypat
 
     class _FakeWinProvider:
         def __init__(self) -> None:
+            """Init."""
             self.removed: List[Tuple[str, str]] = []
             self.sets: List[Tuple[str, str, str]] = []
 
         @staticmethod
         def list_scope(scope: str) -> Dict[str, str]:
+            """List scope."""
             return {"KEEP": "1", "DROP": "2"}
 
         def remove_scope_value(self, scope: str, key: str) -> None:
+            """Remove scope value."""
             self.removed.append((scope, key))
 
         def set_scope_value(self, scope: str, key: str, value: str) -> None:
+            """Set scope value."""
             self.sets.append((scope, key, value))
 
     fake = _FakeWinProvider()
@@ -314,6 +333,7 @@ def test_restore_helpers_cover_powershell_and_registry(tmp_path: Path, monkeypat
 
 
 def test_restore_helpers_cover_dispatch(tmp_path: Path, monkeypatch) -> None:
+    """Test restore helpers cover dispatch."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
     calls: List[str] = []
     monkeypatch.setattr(svc, "_restore_linux_target", lambda **kwargs: calls.append("linux"))
@@ -329,6 +349,7 @@ def test_restore_helpers_cover_dispatch(tmp_path: Path, monkeypatch) -> None:
 
 
 def test_restore_dotenv_target_rejects_outside_scope(tmp_path: Path, monkeypatch) -> None:
+    """Test restore dotenv target rejects outside scope."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
     allowed = tmp_path / "allowed"
     outside = tmp_path.parent / (tmp_path.name + "-outside")
@@ -338,6 +359,7 @@ def test_restore_dotenv_target_rejects_outside_scope(tmp_path: Path, monkeypatch
 
     class _Scoped:
         def __init__(self, path: Path) -> None:
+            """Init."""
             self.path = path
             self.roots = [allowed]
 
@@ -352,6 +374,7 @@ def test_restore_dotenv_target_rejects_outside_scope(tmp_path: Path, monkeypatch
 
 
 def test_registry_write_machine_requires_privilege_and_user_scope(tmp_path: Path):
+    """Test registry write machine requires privilege and user scope."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
 
     import types
@@ -404,6 +427,7 @@ def test_registry_write_machine_requires_privilege_and_user_scope(tmp_path: Path
 
 
 def test_powershell_profile_path_returns_expected_target_paths(tmp_path: Path, monkeypatch):
+    """Test powershell profile path returns expected target paths."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
     current = tmp_path / "current.ps1"
     all_users = tmp_path / "all.ps1"
@@ -417,6 +441,7 @@ def test_powershell_profile_path_returns_expected_target_paths(tmp_path: Path, m
 
 
 def test_validate_wsl_dotenv_path_rejects_empty_and_wrong_filename(tmp_path: Path):
+    """Test validate wsl dotenv path rejects empty and wrong filename."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
 
     with pytest.raises(RuntimeError, match="Unsupported WSL dotenv target path"):
@@ -427,6 +452,7 @@ def test_validate_wsl_dotenv_path_rejects_empty_and_wrong_filename(tmp_path: Pat
 
 
 def test_list_backups_uses_target_filter_when_provided(tmp_path: Path):
+    """Test list backups uses target filter when provided."""
     import unittest
 
     svc = EnvInspectorService(state_dir=tmp_path / "state")
@@ -441,6 +467,7 @@ def test_list_backups_uses_target_filter_when_provided(tmp_path: Path):
 
 
 def test_list_records_raw_builds_env_records_from_payload(tmp_path: Path, monkeypatch):
+    """Test list records raw builds env records from payload."""
     import unittest
 
     svc = EnvInspectorService(state_dir=tmp_path / "state")

--- a/tests/test_service_coverage_branches.py
+++ b/tests/test_service_coverage_branches.py
@@ -83,8 +83,14 @@ def test_list_records_accepts_request_without_kwargs(monkeypatch, tmp_path: Path
     svc = EnvInspectorService(state_dir=tmp_path / "state")
     request = service_module.ListRecordsRequest(root=tmp_path, include_raw_secrets=True)
 
-    monkeypatch.setattr(service_module, "resolve_scan_root", lambda root: Path(root))
-    monkeypatch.setattr(svc, "_collect_host_rows", lambda root_path, _scan_depth: [_record(SOURCE_DOTENV, str(root_path / ".env"))])
+    def _resolve_scan_root(root):
+        return Path(root)
+
+    def _collect_host_rows(root_path, _scan_depth):
+        return [_record(SOURCE_DOTENV, str(root_path / ".env"))]
+
+    monkeypatch.setattr(service_module, "resolve_scan_root", _resolve_scan_root)
+    monkeypatch.setattr(svc, "_collect_host_rows", _collect_host_rows)
     monkeypatch.setattr(svc, "_collect_wsl_rows", lambda **_kwargs: [])
     monkeypatch.setattr(svc, "_apply_row_filters", lambda rows, source, context: rows)
 

--- a/tests/test_service_path_guards.py
+++ b/tests/test_service_path_guards.py
@@ -12,10 +12,12 @@ import env_inspector_core.service_paths as service_paths_module
 from tests.assertions import ensure
 
 def test_is_path_within_returns_false_for_unrelated_roots(tmp_path: Path):
+    """Test is path within returns false for unrelated roots."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
     ensure(svc._is_path_within(tmp_path / "outside" / ".env", tmp_path / "allowed") is False)
 
 def test_validate_path_in_roots_raises_for_outside_path(tmp_path: Path):
+    """Test validate path in roots raises for outside path."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
     outside = tmp_path.parent / (tmp_path.name + "-outside") / ".env"
     outside.parent.mkdir(parents=True, exist_ok=True)
@@ -24,12 +26,14 @@ def test_validate_path_in_roots_raises_for_outside_path(tmp_path: Path):
         svc._validate_path_in_roots(outside, [tmp_path / "allowed"], label="dotenv target")
 
 def test_validated_powershell_restore_path_rejects_unsupported_target(tmp_path: Path):
+    """Test validated powershell restore path rejects unsupported target."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
 
     with pytest.raises(RuntimeError, match="Unsupported PowerShell target"):
         svc._validated_powershell_restore_path("powershell:unsupported")
 
 def test_validated_powershell_restore_path_current_user_success(tmp_path: Path, monkeypatch):
+    """Test validated powershell restore path current user success."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
     fake_home = tmp_path / "home"
     fake_home.mkdir(parents=True, exist_ok=True)
@@ -43,6 +47,7 @@ def test_validated_powershell_restore_path_current_user_success(tmp_path: Path, 
     ensure(resolved == fake_profile.resolve(strict=False))
 
 def test_validated_powershell_restore_path_all_users_rejects_outside_root(tmp_path: Path, monkeypatch):
+    """Test validated powershell restore path all users rejects outside root."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
     bad_profile = tmp_path / "not-program-files" / "profile.ps1"
 
@@ -52,6 +57,7 @@ def test_validated_powershell_restore_path_all_users_rejects_outside_root(tmp_pa
         svc._validated_powershell_restore_path("powershell:all_users")
 
 def test_linux_etc_environment_path_guard_handles_platform_semantics(tmp_path: Path, monkeypatch):
+    """Test linux etc environment path guard handles platform semantics."""
     _ = EnvInspectorService(state_dir=tmp_path / "state")
     monkeypatch.setattr(EnvInspectorService, "_LINUX_ETC_ENV_PATH", r"\etc\environment")
 
@@ -64,6 +70,7 @@ def test_linux_etc_environment_path_guard_handles_platform_semantics(tmp_path: P
     ensure(resolved.as_posix() == r"\etc\environment")
 
 def test_write_linux_etc_environment_with_privilege_rejects_non_fixed_path(tmp_path: Path, monkeypatch):
+    """Test write linux etc environment with privilege rejects non fixed path."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
     monkeypatch.setattr(EnvInspectorService, "_LINUX_ETC_ENV_PATH", r"\etc\environment")
 
@@ -71,6 +78,7 @@ def test_write_linux_etc_environment_with_privilege_rejects_non_fixed_path(tmp_p
         svc._write_linux_etc_environment_with_privilege("A=1\n")
 
 def test_restore_dotenv_path_checks_continue_until_matching_root(tmp_path: Path, monkeypatch):
+    """Test restore dotenv path checks continue until matching root."""
     monkeypatch.chdir(tmp_path)
     svc = EnvInspectorService(state_dir=tmp_path / "state")
 
@@ -89,6 +97,7 @@ def test_restore_dotenv_path_checks_continue_until_matching_root(tmp_path: Path,
     ensure(env_file.read_text(encoding="utf-8") == "A=1\n")
 
 def test_restore_wsl_dotenv_backup_uses_wsl_write_file(tmp_path: Path, monkeypatch):
+    """Test restore wsl dotenv backup uses wsl write file."""
     monkeypatch.chdir(tmp_path)
     svc = EnvInspectorService(state_dir=tmp_path / "state")
 
@@ -102,6 +111,7 @@ def test_restore_wsl_dotenv_backup_uses_wsl_write_file(tmp_path: Path, monkeypat
     ensure(calls == [("Ubuntu", "/home/user/.env", "A=1\n")])
 
 def test_restore_wsl_bashrc_backup_uses_wsl_write_file(tmp_path: Path, monkeypatch):
+    """Test restore wsl bashrc backup uses wsl write file."""
     monkeypatch.chdir(tmp_path)
     svc = EnvInspectorService(state_dir=tmp_path / "state")
 
@@ -115,6 +125,7 @@ def test_restore_wsl_bashrc_backup_uses_wsl_write_file(tmp_path: Path, monkeypat
     ensure(calls == [("Ubuntu", "~/.bashrc", "export A='1'\n")])
 
 def test_linux_etc_environment_path_guard_non_windows_branch(tmp_path: Path, monkeypatch):
+    """Test linux etc environment path guard non windows branch."""
     _ = EnvInspectorService(state_dir=tmp_path / "state")
     monkeypatch.setattr(service_paths_module.os, "name", "posix", raising=False)
     monkeypatch.setattr(EnvInspectorService, "_LINUX_ETC_ENV_PATH", r"\etc\environment")
@@ -124,6 +135,7 @@ def test_linux_etc_environment_path_guard_non_windows_branch(tmp_path: Path, mon
     ensure(resolved.as_posix() == r"\etc\environment")
 
 def test_restore_wsl_dotenv_backup_rejects_path_traversal(tmp_path: Path, monkeypatch):
+    """Test restore wsl dotenv backup rejects path traversal."""
     monkeypatch.chdir(tmp_path)
     svc = EnvInspectorService(state_dir=tmp_path / "state")
 
@@ -138,12 +150,14 @@ def test_restore_wsl_dotenv_backup_rejects_path_traversal(tmp_path: Path, monkey
     ensure(calls == [])
 
 def test_validate_target_for_operation_rejects_unknown_target(tmp_path: Path):
+    """Test validate target for operation rejects unknown target."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
 
     with pytest.raises(RuntimeError, match="Unsupported target"):
         svc._validate_target_for_operation("custom:target", scope_roots=[tmp_path])
 
 def test_validate_target_for_operation_rejects_dotenv_outside_scope(tmp_path: Path):
+    """Test validate target for operation rejects dotenv outside scope."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
     allowed = tmp_path / "allowed"
     allowed.mkdir(parents=True, exist_ok=True)
@@ -154,12 +168,14 @@ def test_validate_target_for_operation_rejects_dotenv_outside_scope(tmp_path: Pa
         svc._validate_target_for_operation(f"dotenv:{outside / '.env'}", scope_roots=[allowed])
 
 def test_validate_target_for_operation_accepts_wsl_variants(tmp_path: Path):
+    """Test validate target for operation accepts wsl variants."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
 
     svc._validate_target_for_operation("wsl_dotenv:Ubuntu:/home/user/.env", scope_roots=[tmp_path])
     svc._validate_target_for_operation("wsl:Ubuntu:bashrc", scope_roots=[tmp_path])
 
 def test_restore_powershell_target_all_users_uses_program_files_root(tmp_path: Path, monkeypatch):
+    """Test restore powershell target all users uses program files root."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
     profile = tmp_path / "program_files" / "PowerShell" / "7" / "profile.ps1"
 
@@ -179,6 +195,7 @@ def test_restore_powershell_target_all_users_uses_program_files_root(tmp_path: P
 
 
 def test_write_text_file_without_ensure_parent_uses_existing_parent(tmp_path: Path):
+    """Test write text file without ensure parent uses existing parent."""
     file_path = tmp_path / "existing" / "env.txt"
     file_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/tests/test_service_path_guards.py
+++ b/tests/test_service_path_guards.py
@@ -176,3 +176,12 @@ def test_restore_powershell_target_all_users_uses_program_files_root(tmp_path: P
     ensure(writes["path"] == profile)
     ensure(writes["text"] == "$env:A='1'\n")
     ensure(writes["ensure_parent"] is True)
+
+
+def test_write_text_file_without_ensure_parent_uses_existing_parent(tmp_path: Path):
+    file_path = tmp_path / "existing" / "env.txt"
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+
+    service_paths_module.write_text_file(file_path, "A=1\n", ensure_parent=False)
+
+    ensure(file_path.read_text(encoding="utf-8") == "A=1\n")


### PR DESCRIPTION
## Summary\n- remove the repo-local Bandit and lizard exclusions from .codacy.yml\n- let Codacy scan the actual first-party env-inspector code and tests instead of hiding those surfaces\n\n## Verification\n- provider/PR checks on this branch will show the newly exposed debt or confirm the repo is already clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated code quality configuration by removing select static-analysis engines.

* **Tests**
  * Added a test ensuring legacy secret-printing skips non-secret rows.
  * Added coverage tests for service listing, bridging/target logic and falsey branches.
  * Added tests for preview update behavior (no-write mode) and file-write/path guard behavior.
  * Added tests validating a quality-check script’s exit and environment handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->