### PR TITLE
fix: ruff format + remaining Codacy/Sonar fixes

### DIFF
--- a/env_inspector.py
+++ b/env_inspector.py
@@ -25,7 +25,9 @@ def _resolve_legacy_print_secrets_root(root: str | Path) -> Path:
     workspace_root = resolve_scan_root(Path.cwd())
     requested = resolve_scan_root(root)
     if requested != workspace_root:
-        raise PathPolicyError("Legacy --print-secrets only supports the current working directory.")
+        raise PathPolicyError(
+            "Legacy --print-secrets only supports the current working directory."
+        )
     return workspace_root
 
 
@@ -46,8 +48,14 @@ def _legacy_print_secrets(root: str | Path) -> int:
 
 def _parse_gui_args(argv: List[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Env Inspector GUI")
-    parser.add_argument("--root", default=os.getcwd(), help="Root path to scan for .env files")
-    parser.add_argument("--print-secrets", action="store_true", help="Print detected secret keys and exit")
+    parser.add_argument(
+        "--root", default=os.getcwd(), help="Root path to scan for .env files"
+    )
+    parser.add_argument(
+        "--print-secrets",
+        action="store_true",
+        help="Print detected secret keys and exit",
+    )
     return parser.parse_args(argv)
 
 

--- a/env_inspector_core/constants.py
+++ b/env_inspector_core/constants.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, division
+
 SOURCE_PROCESS = "process"
 SOURCE_WINDOWS_USER = "windows_user"
 SOURCE_WINDOWS_MACHINE = "windows_machine"

--- a/env_inspector_core/path_policy.py
+++ b/env_inspector_core/path_policy.py
@@ -44,9 +44,15 @@ def normalize_scope_roots(roots: Iterable[str | Path]) -> List[Path]:
     for root in roots:
         path = Path(_normalize_path_text(root, field_name="scope root"))
         path_text = str(path)
-        if path_text != workspace_text and not path_text.startswith(workspace_text + os.sep):
-            raise PathPolicyError(f"Scope root must be inside the current working directory: {path}")
-        if not path.exists() or not path.is_dir():  # codeql[py/path-injection] user-approved local path validation
+        if path_text != workspace_text and not path_text.startswith(
+            workspace_text + os.sep
+        ):
+            raise PathPolicyError(
+                f"Scope root must be inside the current working directory: {path}"
+            )
+        if (
+            not path.exists() or not path.is_dir()
+        ):  # codeql[py/path-injection] user-approved local path validation
             raise PathPolicyError(f"Scope root must exist as a directory: {path}")
         key = str(path)
         if key in seen:
@@ -63,9 +69,15 @@ def resolve_scan_root(root: str | Path) -> Path:
     workspace_root = Path.cwd()
     workspace_text = str(workspace_root)
     path_text = str(path)
-    if path_text != workspace_text and not path_text.startswith(workspace_text + os.sep):
-        raise PathPolicyError(f"Scan root must be inside the current working directory: {path}")
-    if not path.exists() or not path.is_dir():  # codeql[py/path-injection] user-approved local path validation
+    if path_text != workspace_text and not path_text.startswith(
+        workspace_text + os.sep
+    ):
+        raise PathPolicyError(
+            f"Scan root must be inside the current working directory: {path}"
+        )
+    if (
+        not path.exists() or not path.is_dir()
+    ):  # codeql[py/path-injection] user-approved local path validation
         raise PathPolicyError(f"Scan root must exist as a directory: {path}")
     return path
 
@@ -74,7 +86,9 @@ def _validate_dotenv_name(path: Path) -> None:
     name = path.name
     if name == ".env" or name.startswith(".env."):
         return
-    raise PathPolicyError("dotenv target must point to a file named '.env' or '.env.*'.")
+    raise PathPolicyError(
+        "dotenv target must point to a file named '.env' or '.env.*'."
+    )
 
 
 def parse_scoped_dotenv_target(target: str, *, roots: List[Path]) -> ScopedPath:
@@ -104,8 +118,12 @@ def validate_backup_path(backup: str | Path, *, backups_dir: Path) -> Path:
     backups_root = resolve_scan_root(backups_dir)
     backup_text = str(backup_path)
     backups_text = str(backups_root)
-    if backup_text != backups_text and not backup_text.startswith(backups_text + os.sep):
+    if backup_text != backups_text and not backup_text.startswith(
+        backups_text + os.sep
+    ):
         raise PathPolicyError("Backup path is outside managed backup directory.")
-    if not backup_path.exists() or not backup_path.is_file():  # codeql[py/path-injection] validated backup scope guard
+    if (
+        not backup_path.exists() or not backup_path.is_file()
+    ):  # codeql[py/path-injection] validated backup scope guard
         raise PathPolicyError(f"Backup file does not exist: {backup_path}")
     return backup_path

--- a/env_inspector_core/providers.py
+++ b/env_inspector_core/providers.py
@@ -45,7 +45,6 @@ if TYPE_CHECKING:
         SetValueEx: Callable[[Any, str, int, int, str], None]
         DeleteValue: Callable[[Any, str], None]
 
-
     class WslClient(Protocol):
         """Protocol for the WSL interop client."""
 
@@ -88,6 +87,8 @@ SKIP_DIRS = {
 }
 
 _HELPER_DISTRO_RE = re.compile(r"^(docker-desktop|docker-desktop-data)$", re.IGNORECASE)
+
+
 def is_windows() -> bool:
     return os.name == "nt"
 
@@ -115,14 +116,20 @@ def _dotenv_matches(filename: str) -> bool:
 
 def _iter_dotenv_candidates(root: Path, max_depth: int) -> List[Path]:
     files: List[Path] = []
-    for current, dirs, filenames in os.walk(root):  # codeql[py/path-injection] root constrained to workspace scope
+    for current, dirs, filenames in os.walk(
+        root
+    ):  # codeql[py/path-injection] root constrained to workspace scope
         rel = Path(os.path.relpath(current, root))
         depth = 0 if str(rel) == "." else len(rel.parts)
         if depth > max_depth:
             dirs[:] = []
             continue
         dirs[:] = [d for d in dirs if d not in SKIP_DIRS]
-        files.extend(Path(current) / filename for filename in filenames if _dotenv_matches(filename))
+        files.extend(
+            Path(current) / filename
+            for filename in filenames
+            if _dotenv_matches(filename)
+        )
     return files
 
 
@@ -169,12 +176,19 @@ class WindowsRegistryProvider:
 
     @staticmethod
     def _scope_details(scope: str, access: int) -> Tuple[Any, str, int]:
-        if scope not in {WindowsRegistryProvider.USER_SCOPE, WindowsRegistryProvider.MACHINE_SCOPE}:
+        if scope not in {
+            WindowsRegistryProvider.USER_SCOPE,
+            WindowsRegistryProvider.MACHINE_SCOPE,
+        }:
             raise ValueError(f"Unsupported scope: {scope}")
 
         registry = _require_winreg()
         root, path, scoped_access = {
-            WindowsRegistryProvider.USER_SCOPE: (registry.HKEY_CURRENT_USER, r"Environment", access),
+            WindowsRegistryProvider.USER_SCOPE: (
+                registry.HKEY_CURRENT_USER,
+                r"Environment",
+                access,
+            ),
             WindowsRegistryProvider.MACHINE_SCOPE: (
                 registry.HKEY_LOCAL_MACHINE,
                 r"SYSTEM\CurrentControlSet\Control\Session Manager\Environment",
@@ -209,13 +223,23 @@ class WindowsRegistryProvider:
     def remove_scope_value(self, scope: str, key: str) -> None:
         registry = _require_winreg()
         root, path, access = self._scope_details(scope, registry.KEY_SET_VALUE)
-        with registry.OpenKey(root, path, 0, access) as regkey, suppress(FileNotFoundError):
+        with (
+            registry.OpenKey(root, path, 0, access) as regkey,
+            suppress(FileNotFoundError),
+        ):
             registry.DeleteValue(regkey, key)
 
 
 def build_registry_records(provider: WindowsRegistryProvider) -> List[EnvRecord]:
     rows: List[EnvRecord] = []
-    for source_type, source_id, source_path, scope, precedence_rank, requires_privilege in (
+    for (
+        source_type,
+        source_id,
+        source_path,
+        scope,
+        precedence_rank,
+        requires_privilege,
+    ) in (
         (
             SOURCE_WINDOWS_USER,
             "user",
@@ -233,7 +257,9 @@ def build_registry_records(provider: WindowsRegistryProvider) -> List[EnvRecord]
             True,
         ),
     ):
-        for key, value in sorted(provider.list_scope(scope).items(), key=lambda kv: kv[0].lower()):
+        for key, value in sorted(
+            provider.list_scope(scope).items(), key=lambda kv: kv[0].lower()
+        ):
             rows.append(
                 EnvRecord(
                     source_type=source_type,
@@ -289,7 +315,9 @@ def parse_powershell_profile_text(text: str) -> List[Tuple[str, str]]:
     return rows
 
 
-def collect_dotenv_records(root: Path, max_depth: int = 5, context: str = "windows") -> List[EnvRecord]:
+def collect_dotenv_records(
+    root: Path, max_depth: int = 5, context: str = "windows"
+) -> List[EnvRecord]:
     rows: List[EnvRecord] = []
     for path in discover_dotenv_files(root, max_depth=max_depth):
         try:

--- a/env_inspector_core/providers_wsl.py
+++ b/env_inspector_core/providers_wsl.py
@@ -32,11 +32,24 @@ class WslProvider:
     @staticmethod
     def _discover_wsl_exe() -> str | None:
         candidate_paths = (
-            Path(system_root) / "System32" / "wsl.exe" if (system_root := os.environ.get("SystemRoot")) else None,
+            Path(system_root) / "System32" / "wsl.exe"
+            if (system_root := os.environ.get("SystemRoot"))
+            else None,
             Path("/mnt/c/Windows/System32/wsl.exe") if os.name != "nt" else None,
         )
-        discovered = next((candidate for candidate in filter(None, candidate_paths) if candidate.exists()), None)
-        return (str(discovered) if discovered is not None else None) or shutil.which("wsl.exe") or shutil.which("wsl")
+        discovered = next(
+            (
+                candidate
+                for candidate in filter(None, candidate_paths)
+                if candidate.exists()
+            ),
+            None,
+        )
+        return (
+            (str(discovered) if discovered is not None else None)
+            or shutil.which("wsl.exe")
+            or shutil.which("wsl")
+        )
 
     def available(self) -> bool:
         if self._available_cache is not None:
@@ -84,7 +97,9 @@ class WslProvider:
         out = self._decode(proc.stdout)
         err = self._decode(proc.stderr)
         if proc.returncode != 0:
-            raise RuntimeError((err or out).strip() or f"wsl command failed ({proc.returncode})")
+            raise RuntimeError(
+                (err or out).strip() or f"wsl command failed ({proc.returncode})"
+            )
         return out
 
     def list_distros(self) -> List[str]:
@@ -105,11 +120,23 @@ class WslProvider:
 
     def read_file(self, distro: str, path: str) -> str:
         quoted_path = shlex.quote(path)
-        return self._run(["-d", distro, "-e", "bash", "-lc", f"cat {quoted_path} 2>/dev/null || true"])
+        return self._run(
+            [
+                "-d",
+                distro,
+                "-e",
+                "bash",
+                "-lc",
+                f"cat {quoted_path} 2>/dev/null || true",
+            ]
+        )
 
     def write_file(self, distro: str, path: str, content: str) -> None:
         quoted_path = shlex.quote(path)
-        self._run(["-d", distro, "-e", "bash", "-lc", f"cat > {quoted_path}"], input_text=content)
+        self._run(
+            ["-d", distro, "-e", "bash", "-lc", f"cat > {quoted_path}"],
+            input_text=content,
+        )
 
     def write_file_with_privilege(self, distro: str, path: str, content: str) -> None:
         quoted_path = shlex.quote(path)
@@ -128,7 +155,9 @@ class WslProvider:
             "Failed to write with both root and sudo fallback. Run app as admin or configure sudo/root access."
         ) from root_error
 
-    def scan_dotenv_files(self, distro: str, root_path: str, max_depth: int) -> List[str]:
+    def scan_dotenv_files(
+        self, distro: str, root_path: str, max_depth: int
+    ) -> List[str]:
         quoted_root = shlex.quote(root_path)
         command = (
             f"find {quoted_root} -maxdepth {max_depth} -type f "
@@ -211,7 +240,9 @@ def collect_wsl_records(
     return rows
 
 
-def collect_wsl_dotenv_records(wsl: WslProvider, distro: str, root_path: str, max_depth: int) -> List[EnvRecord]:
+def collect_wsl_dotenv_records(
+    wsl: WslProvider, distro: str, root_path: str, max_depth: int
+) -> List[EnvRecord]:
     rows: List[EnvRecord] = []
     if not wsl.available():
         return rows

--- a/env_inspector_core/rendering.py
+++ b/env_inspector_core/rendering.py
@@ -37,5 +37,8 @@ def export_rows(rows: List[Dict[str, Any]], *, output: str) -> str:
         writer.writerows(rows)
         return buf.getvalue()
 
-    lines = [f"{row['context']}\t{row['source_type']}\t{row['name']}\t{row['value']}" for row in rows]
+    lines = [
+        f"{row['context']}\t{row['source_type']}\t{row['name']}\t{row['value']}"
+        for row in rows
+    ]
     return "\n".join(lines) + ("\n" if lines else "")

--- a/env_inspector_core/resolver.py
+++ b/env_inspector_core/resolver.py
@@ -45,4 +45,4 @@ def resolve_effective_value(records: List[EnvRecord], key: str, context: str) ->
         source_rank = table.get(rec.source_type, rec.precedence_rank)
         return (source_rank, rec.precedence_rank, rec.source_path)
 
-    return sorted(candidates, key=rank)[0]
+    return min(candidates, key=rank)

--- a/env_inspector_core/resolver.py
+++ b/env_inspector_core/resolver.py
@@ -28,9 +28,15 @@ LINUX_PRECEDENCE = {
 }
 
 
-def resolve_effective_value(records: List[EnvRecord], key: str, context: str) -> EnvRecord | None:
+def resolve_effective_value(
+    records: List[EnvRecord], key: str, context: str
+) -> EnvRecord | None:
     key_norm = key.strip().lower()
-    candidates = [r for r in records if r.name.lower() == key_norm and r.context in (context, "global")]
+    candidates = [
+        r
+        for r in records
+        if r.name.lower() == key_norm and r.context in (context, "global")
+    ]
     if not candidates:
         return None
 

--- a/env_inspector_core/secrets.py
+++ b/env_inspector_core/secrets.py
@@ -27,7 +27,12 @@ def _name_suggests_secret(name: str) -> bool:
 
 
 def _is_path_like(candidate: str) -> bool:
-    return candidate.startswith(("/", "./", "../")) or "://" in candidate or "\\" in candidate or ":" in candidate
+    return (
+        candidate.startswith(("/", "./", "../"))
+        or "://" in candidate
+        or "\\" in candidate
+        or ":" in candidate
+    )
 
 
 def _is_base64_secret(candidate: str) -> bool:

--- a/env_inspector_core/service.py
+++ b/env_inspector_core/service.py
@@ -17,21 +17,30 @@ from .path_policy import (
     validate_backup_path,
 )
 from .providers import (
-    WindowsRegistryProvider, WslProvider, build_registry_records,
+    WindowsRegistryProvider,
+    WslProvider,
+    build_registry_records,
     collect_dotenv_records,
-    collect_linux_records, collect_powershell_profile_records, collect_process_records,
-    collect_wsl_dotenv_records, collect_wsl_records, current_wsl_distro_name,
-    get_runtime_context, is_windows,
+    collect_linux_records,
+    collect_powershell_profile_records,
+    collect_process_records,
+    collect_wsl_dotenv_records,
+    collect_wsl_records,
+    current_wsl_distro_name,
+    get_runtime_context,
+    is_windows,
 )
 from .rendering import audit_safe_result
 from .resolver import resolve_effective_value
 from .service_listing import (
-    HostCollectionRequest, HostRowCollectors,
+    HostCollectionRequest,
+    HostRowCollectors,
     apply_row_filters as _apply_row_filters_helper,
     collect_host_rows as _collect_host_rows_helper,
     collect_wsl_rows as _collect_wsl_rows_helper,
     powershell_target_for_path as _powershell_target_for_path_helper,
-    record_target as _record_target_helper, rows_to_payload as _rows_to_payload_helper,
+    record_target as _record_target_helper,
+    rows_to_payload as _rows_to_payload_helper,
 )
 from .service_ops import (
     diff_text as _diff_text_helper,
@@ -74,13 +83,22 @@ WSL_DOTENV_TARGET_PREFIX = _service_mutations.WSL_DOTENV_TARGET_PREFIX
 which, run = _privileged_which, _privileged_run
 
 __all__ = [
-    "DOTENV_TARGET_PREFIX", "EnvInspectorService", "LINUX_ETC_ENV_PATH",
+    "DOTENV_TARGET_PREFIX",
+    "EnvInspectorService",
+    "LINUX_ETC_ENV_PATH",
     "ListRecordsRequest",
-    "ShellMutationRequest", "TARGET_LINUX_BASHRC", "TARGET_LINUX_ETC_ENV",
-    "TARGET_POWERSHELL_ALL_USERS", "TARGET_POWERSHELL_CURRENT_USER",
+    "ShellMutationRequest",
+    "TARGET_LINUX_BASHRC",
+    "TARGET_LINUX_ETC_ENV",
+    "TARGET_POWERSHELL_ALL_USERS",
+    "TARGET_POWERSHELL_CURRENT_USER",
     "TARGET_WINDOWS_MACHINE",
-    "TARGET_WINDOWS_USER", "TargetOperationBatch", "TargetOperationRequest",
-    "WSL_DOTENV_TARGET_PREFIX", "run", "which",
+    "TARGET_WINDOWS_USER",
+    "TargetOperationBatch",
+    "TargetOperationRequest",
+    "WSL_DOTENV_TARGET_PREFIX",
+    "run",
+    "which",
 ]
 
 

--- a/env_inspector_core/service_listing.py
+++ b/env_inspector_core/service_listing.py
@@ -78,9 +78,15 @@ def collect_host_rows(
         rows.extend(registry_rows)
 
     if request.runtime_context == "windows":
-        rows.extend(collectors.collect_powershell_profile_records_fn(request.powershell_profile_paths))
+        rows.extend(
+            collectors.collect_powershell_profile_records_fn(
+                request.powershell_profile_paths
+            )
+        )
     else:
-        rows.extend(collectors.collect_linux_records_fn(context=request.runtime_context))
+        rows.extend(
+            collectors.collect_linux_records_fn(context=request.runtime_context)
+        )
 
     return rows
 
@@ -112,7 +118,9 @@ def collect_wsl_rows(*args: Any, **kwargs: Any) -> List[EnvRecord]:
     )
     rows.extend(
         _wsl_dotenv_rows(
-            request=_WslDotenvRequest(distro=distro, wsl_path=wsl_path, scan_depth=scan_depth),
+            request=_WslDotenvRequest(
+                distro=distro, wsl_path=wsl_path, scan_depth=scan_depth
+            ),
             wsl=wsl,
             collect_wsl_dotenv_records_fn=collect_wsl_dotenv_records_fn,
         )
@@ -120,17 +128,27 @@ def collect_wsl_rows(*args: Any, **kwargs: Any) -> List[EnvRecord]:
     return rows
 
 
-def _bridge_rows(*, runtime_context: str, current_wsl_distro: str | None, wsl: Any, collect_wsl_records_fn) -> List[EnvRecord]:
+def _bridge_rows(
+    *,
+    runtime_context: str,
+    current_wsl_distro: str | None,
+    wsl: Any,
+    collect_wsl_records_fn,
+) -> List[EnvRecord]:
     try:
         exclude_distros: Optional[Set[str]] = None
         if runtime_context == "linux" and current_wsl_distro:
             exclude_distros = {current_wsl_distro}
-        return collect_wsl_records_fn(wsl, include_etc=True, exclude_distros=exclude_distros)
+        return collect_wsl_records_fn(
+            wsl, include_etc=True, exclude_distros=exclude_distros
+        )
     except (OSError, RuntimeError, ValueError):
         return []
 
 
-def _wsl_dotenv_rows(*, request: _WslDotenvRequest, wsl: Any, collect_wsl_dotenv_records_fn) -> List[EnvRecord]:
+def _wsl_dotenv_rows(
+    *, request: _WslDotenvRequest, wsl: Any, collect_wsl_dotenv_records_fn
+) -> List[EnvRecord]:
     if not (request.distro and request.wsl_path):
         return []
     try:
@@ -159,7 +177,11 @@ def apply_row_filters(
 
 
 def powershell_target_for_path(source_path: str) -> str:
-    return TARGET_POWERSHELL_ALL_USERS if "Program Files" in source_path else TARGET_POWERSHELL_CURRENT_USER
+    return (
+        TARGET_POWERSHELL_ALL_USERS
+        if "Program Files" in source_path
+        else TARGET_POWERSHELL_CURRENT_USER
+    )
 
 
 def record_target(record: EnvRecord) -> Optional[str]:
@@ -172,7 +194,9 @@ def record_target(record: EnvRecord) -> Optional[str]:
         SOURCE_WSL_DOTENV: lambda rec: f"wsl_dotenv:{rec.source_path}",
         SOURCE_WSL_BASHRC: lambda rec: f"wsl:{rec.source_id}:bashrc",
         SOURCE_WSL_ETC_ENV: lambda rec: f"wsl:{rec.source_id}:etc_environment",
-        SOURCE_POWERSHELL_PROFILE: lambda rec: powershell_target_for_path(rec.source_path),
+        SOURCE_POWERSHELL_PROFILE: lambda rec: powershell_target_for_path(
+            rec.source_path
+        ),
     }
 
     static_target = static_targets.get(record.source_type)
@@ -204,7 +228,9 @@ def available_targets(
     return sorted(targets)
 
 
-def rows_to_payload(rows: List[EnvRecord], *, include_raw_secrets: bool) -> List[Dict[str, Any]]:
+def rows_to_payload(
+    rows: List[EnvRecord], *, include_raw_secrets: bool
+) -> List[Dict[str, Any]]:
     payload: List[Dict[str, Any]] = []
     for record in rows:
         item = record.to_dict(include_value=True)

--- a/env_inspector_core/service_mutations.py
+++ b/env_inspector_core/service_mutations.py
@@ -224,9 +224,7 @@ def update_wsl_file(
 
     if apply_changes:
         writer = (
-            self.wsl.write_file_with_privilege
-            if requires_priv
-            else self.wsl.write_file
+            self.wsl.write_file_with_privilege if requires_priv else self.wsl.write_file
         )
         writer(distro, path, after)
 

--- a/env_inspector_core/service_ops.py
+++ b/env_inspector_core/service_ops.py
@@ -9,7 +9,9 @@ from .secrets import mask_value
 from . import service_ops_request as _service_ops_request
 
 normalize_target_operation_batch = _service_ops_request.normalize_target_operation_batch
-normalize_target_operation_request = _service_ops_request.normalize_target_operation_request
+normalize_target_operation_request = (
+    _service_ops_request.normalize_target_operation_request
+)
 
 
 @dataclass(frozen=True)
@@ -50,7 +52,9 @@ def make_operation_result(payload: OperationResultInput) -> OperationResult:
         target=payload.target,
         action=payload.action,
         success=payload.success,
-        backup_path=(None if payload.preview_only and payload.success else payload.backup_path),
+        backup_path=(
+            None if payload.preview_only and payload.success else payload.backup_path
+        ),
         diff_preview=payload.diff_preview,
         error_message=payload.error_message,
         value_masked=payload.value_masked,

--- a/env_inspector_core/service_ops_request.py
+++ b/env_inspector_core/service_ops_request.py
@@ -44,7 +44,9 @@ def _target_operation_batch_payload(request: Any) -> Dict[str, Any]:
         "key": request.key,
         "value": request.value,
         "targets": list(request.targets),
-        "scope_roots": None if request.scope_roots is None else list(request.scope_roots),
+        "scope_roots": None
+        if request.scope_roots is None
+        else list(request.scope_roots),
     }
 
 
@@ -90,7 +92,9 @@ def normalize_target_operation_request(*args: Any, **kwargs: Any) -> Dict[str, A
 
     if kwargs:
         raise TypeError("Unexpected keyword arguments for target operation request.")
-    _require_values("Target, key, and action are required.", target=target, key=key, action=action)
+    _require_values(
+        "Target, key, and action are required.", target=target, key=key, action=action
+    )
 
     return {
         "target": _coerce_string(target),
@@ -99,6 +103,7 @@ def normalize_target_operation_request(*args: Any, **kwargs: Any) -> Dict[str, A
         "action": _coerce_string(action),
         "scope_roots": list(scope_roots or []),
     }
+
 
 def normalize_target_operation_batch(*args: Any, **kwargs: Any) -> Dict[str, Any]:
     request = _extract_request_object(
@@ -116,7 +121,12 @@ def normalize_target_operation_batch(*args: Any, **kwargs: Any) -> Dict[str, Any
 
     if kwargs:
         raise TypeError("Unexpected keyword arguments for target operation batch.")
-    _require_values("Action, key, and targets are required.", action=action, key=key, targets=targets)
+    _require_values(
+        "Action, key, and targets are required.",
+        action=action,
+        key=key,
+        targets=targets,
+    )
 
     return {
         "action": _coerce_string(action),

--- a/env_inspector_core/service_paths.py
+++ b/env_inspector_core/service_paths.py
@@ -77,11 +77,17 @@ def validated_powershell_restore_path(
         current_user_target=current_user_target,
         all_users_target=all_users_target,
     )
-    return validate_path_in_roots(profile, allowed_roots, label="PowerShell profile path")
+    return validate_path_in_roots(
+        profile, allowed_roots, label="PowerShell profile path"
+    )
 
 
 def linux_etc_environment_path(linux_etc_env_path: str) -> Path:
-    path = Path(PureWindowsPath(linux_etc_env_path).as_posix()) if os.name == "nt" else Path(linux_etc_env_path)
+    path = (
+        Path(PureWindowsPath(linux_etc_env_path).as_posix())
+        if os.name == "nt"
+        else Path(linux_etc_env_path)
+    )
     if path.as_posix() != linux_etc_env_path:
         raise RuntimeError(f"Unexpected /etc/environment resolution: {path}")
     return path

--- a/env_inspector_core/service_privileged.py
+++ b/env_inspector_core/service_privileged.py
@@ -6,7 +6,9 @@ from subprocess import PIPE, CompletedProcess, run  # nosec B404
 from typing import Callable, Optional
 
 
-def _try_direct_write(path: Path, text: str, write_text_file: Callable[[Path, str], None]) -> bool:
+def _try_direct_write(
+    path: Path, text: str, write_text_file: Callable[[Path, str], None]
+) -> bool:
     try:
         write_text_file(path, text)
         return True
@@ -57,7 +59,9 @@ def _write_with_sudo(
 
 def write_linux_etc_environment_with_privilege(*args, **kwargs) -> None:
     if args:
-        raise TypeError("write_linux_etc_environment_with_privilege accepts keyword arguments only.")
+        raise TypeError(
+            "write_linux_etc_environment_with_privilege accepts keyword arguments only."
+        )
 
     fixed_path = kwargs.pop("fixed_path")
     expected_path = kwargs.pop("expected_path")

--- a/env_inspector_core/service_restore.py
+++ b/env_inspector_core/service_restore.py
@@ -36,9 +36,7 @@ def restore_linux_target(*args, **kwargs) -> None:
 
     target = kwargs.pop("target")
     text = kwargs.pop("text")
-    write_linux_etc_env_fn = kwargs.pop(
-        "write_linux_etc_environment_with_privilege_fn"
-    )
+    write_linux_etc_env_fn = kwargs.pop("write_linux_etc_environment_with_privilege_fn")
     bashrc_target = kwargs.pop("bashrc_target", "linux:bashrc")
     etc_target = kwargs.pop("etc_target", "linux:etc_environment")
     if kwargs:
@@ -91,9 +89,7 @@ def restore_wsl_target(*args, **kwargs) -> None:
 def restore_powershell_target(*args, **kwargs) -> None:
     """Restore a PowerShell profile target via the validated path helper."""
     if args:
-        raise TypeError(
-            "restore_powershell_target accepts keyword arguments only."
-        )
+        raise TypeError("restore_powershell_target accepts keyword arguments only.")
 
     target = kwargs.pop("target")
     text = kwargs.pop("text")
@@ -199,9 +195,7 @@ def _dispatch_restore_dotenv(**kwargs) -> None:
 
 def _dispatch_restore_linux(**kwargs) -> None:
     """Forward Linux-target restore work to the injected callable."""
-    kwargs["restore_linux_target_fn"](
-        target=kwargs["target"], text=kwargs["text"]
-    )
+    kwargs["restore_linux_target_fn"](target=kwargs["target"], text=kwargs["text"])
 
 
 def _dispatch_restore_wsl(**kwargs) -> None:
@@ -211,9 +205,7 @@ def _dispatch_restore_wsl(**kwargs) -> None:
 
 def _dispatch_restore_powershell(**kwargs) -> None:
     """Forward PowerShell-target restore work to the injected callable."""
-    kwargs["restore_powershell_target_fn"](
-        target=kwargs["target"], text=kwargs["text"]
-    )
+    kwargs["restore_powershell_target_fn"](target=kwargs["target"], text=kwargs["text"])
 
 
 def _dispatch_restore_windows(**kwargs) -> None:

--- a/env_inspector_core/service_wsl.py
+++ b/env_inspector_core/service_wsl.py
@@ -66,7 +66,9 @@ def resolve_wsl_target(*args, **kwargs) -> Tuple[str, str, str, bool]:
         raise TypeError("resolve_wsl_target requires a target argument.")
     target = args[0]
     if len(args) > 1:
-        raise TypeError("resolve_wsl_target accepts a single positional target argument only.")
+        raise TypeError(
+            "resolve_wsl_target accepts a single positional target argument only."
+        )
 
     dotenv_prefix = kwargs.pop("dotenv_prefix")
     validate_distro_name_fn = kwargs.pop("validate_distro_name_fn")

--- a/env_inspector_core/storage.py
+++ b/env_inspector_core/storage.py
@@ -81,7 +81,15 @@ class BackupManager:
         return sorted(backups, reverse=True)
 
     def list_all_backups(self) -> List[Path]:
-        return sorted((Path(path) for path in glob.glob(str(self.base_dir / "**" / "*.backup.json"), recursive=True)), reverse=True)
+        return sorted(
+            (
+                Path(path)
+                for path in glob.glob(
+                    str(self.base_dir / "**" / "*.backup.json"), recursive=True
+                )
+            ),
+            reverse=True,
+        )
 
     @staticmethod
     def _load_backup_payload(backup_path: Path) -> dict | None:

--- a/env_inspector_gui/controller.py
+++ b/env_inspector_gui/controller.py
@@ -27,7 +27,12 @@ from .models import (
 )
 from .path_actions import is_openable_local_path
 from .state_store import load_ui_state, sanitize_loaded_state, save_ui_state
-from .table_logic import DisplayRowsRequest, build_display_rows, sort_display_rows, toggle_sort
+from .table_logic import (
+    DisplayRowsRequest,
+    build_display_rows,
+    sort_display_rows,
+    toggle_sort,
+)
 from .view import EnvInspectorView
 
 
@@ -68,7 +73,9 @@ class EnvInspectorController(EnvInspectorControllerActionsMixin):
 
         boot_state, fallback_root = self._load_boot_state(root_path)
         self._initialize_runtime_state(tk, boot_state, fallback_root)
-        self.sort_state = SortState(column=boot_state.sort_column, descending=boot_state.sort_descending)
+        self.sort_state = SortState(
+            column=boot_state.sort_column, descending=boot_state.sort_descending
+        )
         self._initialize_view(tk, ttk, boot_state)
         self._bind_shortcuts()
         # _init_root_window assigned a real Tk instance; the runtime tk root is non-optional from here on.
@@ -89,7 +96,9 @@ class EnvInspectorController(EnvInspectorControllerActionsMixin):
             ) from exc
         return tk, filedialog, messagebox, ttk
 
-    def _assign_tk_modules(self, tk: Any, filedialog: Any, messagebox: Any, ttk: Any) -> None:
+    def _assign_tk_modules(
+        self, tk: Any, filedialog: Any, messagebox: Any, ttk: Any
+    ) -> None:
         self.tkmod = tk
         self.ttk = ttk
         self.filedialog = filedialog
@@ -110,7 +119,9 @@ class EnvInspectorController(EnvInspectorControllerActionsMixin):
         )
         return boot_state, fallback_root
 
-    def _initialize_runtime_state(self, tk: Any, boot_state: PersistedUiState, fallback_root: Path) -> None:
+    def _initialize_runtime_state(
+        self, tk: Any, boot_state: PersistedUiState, fallback_root: Path
+    ) -> None:
         self.root_path = self._resolve_root_path(boot_state, fallback_root)
         self.records_raw = []
         self.displayed_rows = []
@@ -257,7 +268,9 @@ class EnvInspectorController(EnvInspectorControllerActionsMixin):
         )
         self.view.update_details_value(row.visible_value)
         self.view.set_details_enabled(True)
-        self.view.detail_open_button.configure(state=("normal" if is_openable_local_path(rec.source_path) else "disabled"))
+        self.view.detail_open_button.configure(
+            state=("normal" if is_openable_local_path(rec.source_path) else "disabled")
+        )
 
     @staticmethod
     def _record_flag(record: EnvRecord, name: str) -> bool:
@@ -315,8 +328,12 @@ class EnvInspectorController(EnvInspectorControllerActionsMixin):
         self.records_raw = self.service.list_records_raw(**kwargs)
 
     def _reconcile_targets(self) -> None:
-        available = self.service.available_targets(self.records_raw, context=self.context_var.get())
-        self.selected_targets = reconcile_selected_targets(self.selected_targets, available)
+        available = self.service.available_targets(
+            self.records_raw, context=self.context_var.get()
+        )
+        self.selected_targets = reconcile_selected_targets(
+            self.selected_targets, available
+        )
 
         self.targets_summary_var.set(f"Targets: {len(self.selected_targets)} selected")
 
@@ -402,14 +419,22 @@ class EnvInspectorController(EnvInspectorControllerActionsMixin):
         )
 
     def choose_targets(self) -> List[str] | None:
-        available = self.service.available_targets(self.records_raw, context=self.context_var.get())
+        available = self.service.available_targets(
+            self.records_raw, context=self.context_var.get()
+        )
         if not available:
-            self.messagebox.showinfo(APP_NAME, "No writable targets found in current context.")
+            self.messagebox.showinfo(
+                APP_NAME, "No writable targets found in current context."
+            )
             return None
 
-        dialog = TargetPickerDialog(self.tk, targets=available, selected=self.selected_targets)
+        dialog = TargetPickerDialog(
+            self.tk, targets=available, selected=self.selected_targets
+        )
         self.tk.wait_window(dialog.win)
-        selected = select_target_dialog_result(dialog.result, messagebox=self.messagebox, app_name=APP_NAME)
+        selected = select_target_dialog_result(
+            dialog.result, messagebox=self.messagebox, app_name=APP_NAME
+        )
         if selected is None:
             return None
 
@@ -418,7 +443,9 @@ class EnvInspectorController(EnvInspectorControllerActionsMixin):
         self._persist_state()
         return list(self.selected_targets)
 
-    def _maybe_choose_dotenv_targets(self, key: str, targets: List[str]) -> List[str] | None:
+    def _maybe_choose_dotenv_targets(
+        self, key: str, targets: List[str]
+    ) -> List[str] | None:
         dotenv_targets = self._collect_dotenv_targets(targets)
         if len(dotenv_targets) <= 1 or not self._has_multiple_dotenv_matches(key):
             return targets
@@ -429,29 +456,53 @@ class EnvInspectorController(EnvInspectorControllerActionsMixin):
             return None
 
         keep = set(dialog.result)
-        return [target for target in targets if target not in dotenv_targets or target in keep]
+        return [
+            target
+            for target in targets
+            if target not in dotenv_targets or target in keep
+        ]
 
     @staticmethod
     def _collect_dotenv_targets(targets: List[str]) -> List[str]:
-        return [target for target in targets if target.startswith(("dotenv:", "wsl_dotenv:"))]
+        return [
+            target
+            for target in targets
+            if target.startswith(("dotenv:", "wsl_dotenv:"))
+        ]
 
     def _has_multiple_dotenv_matches(self, key: str) -> bool:
         return has_multiple_dotenv_matches(self.records_raw, key)
 
-    def _preview_operation(self, action: str, key: str, value: str, targets: List[str]) -> List[Dict[str, Any]]:
+    def _preview_operation(
+        self, action: str, key: str, value: str, targets: List[str]
+    ) -> List[Dict[str, Any]]:
         if action == "set":
-            return self.service.preview_set(key=key, value=value, targets=targets, scope_roots=[self.root_path])
-        return self.service.preview_remove(key=key, targets=targets, scope_roots=[self.root_path])
+            return self.service.preview_set(
+                key=key, value=value, targets=targets, scope_roots=[self.root_path]
+            )
+        return self.service.preview_remove(
+            key=key, targets=targets, scope_roots=[self.root_path]
+        )
 
-    def _confirm_diff(self, action: str, previews: List[Dict[str, Any]], preview_only: bool = False) -> bool:
-        dialog = DiffPreviewDialog(self.tk, action=action, previews=previews, preview_only=preview_only)
+    def _confirm_diff(
+        self, action: str, previews: List[Dict[str, Any]], preview_only: bool = False
+    ) -> bool:
+        dialog = DiffPreviewDialog(
+            self.tk, action=action, previews=previews, preview_only=preview_only
+        )
         self.tk.wait_window(dialog.win)
         return bool(dialog.confirmed)
 
-    def _apply_operation(self, action: str, key: str, value: str, targets: List[str]) -> Dict[str, Any]:
+    def _apply_operation(
+        self, action: str, key: str, value: str, targets: List[str]
+    ) -> Dict[str, Any]:
         if action == "set":
-            return self.service.set_key(key=key, value=value, targets=targets, scope_roots=[self.root_path])
-        return self.service.remove_key(key=key, targets=targets, scope_roots=[self.root_path])
+            return self.service.set_key(
+                key=key, value=value, targets=targets, scope_roots=[self.root_path]
+            )
+        return self.service.remove_key(
+            key=key, targets=targets, scope_roots=[self.root_path]
+        )
 
     def _run_operation(self, action: str) -> None:
         resolved = self._resolve_operation_inputs()
@@ -490,14 +541,18 @@ class EnvInspectorController(EnvInspectorControllerActionsMixin):
             return None
         return key, value, scoped_targets
 
-    def _safe_preview(self, action: str, key: str, value: str, targets: List[str]) -> List[Dict[str, Any]] | None:
+    def _safe_preview(
+        self, action: str, key: str, value: str, targets: List[str]
+    ) -> List[Dict[str, Any]] | None:
         try:
             return self._preview_operation(action, key, value, targets)
         except (OSError, PathPolicyError, RuntimeError) as exc:
             self.messagebox.showerror(APP_NAME, f"Failed to compute preview: {exc}")
             return None
 
-    def _safe_apply(self, action: str, key: str, value: str, targets: List[str]) -> Dict[str, Any] | None:
+    def _safe_apply(
+        self, action: str, key: str, value: str, targets: List[str]
+    ) -> Dict[str, Any] | None:
         try:
             return self._apply_operation(action, key, value, targets)
         except (OSError, PathPolicyError, RuntimeError) as exc:

--- a/env_inspector_gui/controller_actions.py
+++ b/env_inspector_gui/controller_actions.py
@@ -192,12 +192,16 @@ class EnvInspectorControllerActionsMixin:
         if not dialog.result:
             return
 
-        result = self.service.restore_backup(backup=dialog.result, scope_roots=[self.root_path])
+        result = self.service.restore_backup(
+            backup=dialog.result, scope_roots=[self.root_path]
+        )
         if result.get("success"):
             self._set_status(f"Restored backup ({result.get('operation_id')})")
             self.refresh_data()
         else:
-            self.messagebox.showerror(APP_NAME, f"Restore failed: {result.get('error_message')}")
+            self.messagebox.showerror(
+                APP_NAME, f"Restore failed: {result.get('error_message')}"
+            )
 
     def _show_select_row_required(self) -> None:
         self.messagebox.showinfo(APP_NAME, MSG_SELECT_ROW_FIRST)

--- a/env_inspector_gui/dialogs.py
+++ b/env_inspector_gui/dialogs.py
@@ -15,7 +15,9 @@ class _PreviewTabDeps:
 class TargetPickerDialog:
     """Modal dialog for selecting mutation targets."""
 
-    def __init__(self, parent: Any, targets: List[str], selected: List[str] | None = None) -> None:
+    def __init__(
+        self, parent: Any, targets: List[str], selected: List[str] | None = None
+    ) -> None:
         import tkinter as tk
         from tkinter import ttk
 
@@ -39,7 +41,9 @@ class TargetPickerDialog:
         frame = ttk.Frame(self.win, padding=10)
         frame.pack(fill="both", expand=True)
 
-        ttk.Label(frame, text="Choose one or more targets for this operation:").pack(anchor="w", pady=(0, 8))
+        ttk.Label(frame, text="Choose one or more targets for this operation:").pack(
+            anchor="w", pady=(0, 8)
+        )
         self._build_search_row(frame, tk, ttk)
         self._build_preset_row(frame, ttk)
 
@@ -81,13 +85,25 @@ class TargetPickerDialog:
     def _build_preset_row(self, frame: Any, ttk: Any) -> None:
         preset_row = ttk.Frame(frame)
         preset_row.pack(fill="x", pady=(0, 8))
-        ttk.Button(preset_row, text="Select All", command=self._select_all).pack(side="left", padx=(0, 6))
-        ttk.Button(preset_row, text="Select None", command=self._select_none).pack(side="left", padx=(0, 6))
-        ttk.Button(preset_row, text="Select Dotenv Only", command=self._select_dotenv).pack(side="left", padx=(0, 6))
-        ttk.Button(preset_row, text="Select Windows Only", command=self._select_windows).pack(side="left", padx=(0, 6))
-        ttk.Button(preset_row, text="Select WSL Only", command=self._select_wsl).pack(side="left", padx=(0, 6))
+        ttk.Button(preset_row, text="Select All", command=self._select_all).pack(
+            side="left", padx=(0, 6)
+        )
+        ttk.Button(preset_row, text="Select None", command=self._select_none).pack(
+            side="left", padx=(0, 6)
+        )
+        ttk.Button(
+            preset_row, text="Select Dotenv Only", command=self._select_dotenv
+        ).pack(side="left", padx=(0, 6))
+        ttk.Button(
+            preset_row, text="Select Windows Only", command=self._select_windows
+        ).pack(side="left", padx=(0, 6))
+        ttk.Button(preset_row, text="Select WSL Only", command=self._select_wsl).pack(
+            side="left", padx=(0, 6)
+        )
 
-    def _build_target_checks(self, body: Any, selected_set: Set[str], has_selected: bool, tk: Any, ttk: Any) -> None:
+    def _build_target_checks(
+        self, body: Any, selected_set: Set[str], has_selected: bool, tk: Any, ttk: Any
+    ) -> None:
         for target in self._targets:
             default = target in selected_set if has_selected else True
             var = tk.BooleanVar(value=default)
@@ -100,7 +116,9 @@ class TargetPickerDialog:
     def _build_buttons(self, frame: Any, ttk: Any) -> None:
         btns = ttk.Frame(frame)
         btns.pack(fill="x", pady=(10, 0))
-        ttk.Button(btns, text="Cancel", command=self._cancel).pack(side="right", padx=(6, 0))
+        ttk.Button(btns, text="Cancel", command=self._cancel).pack(
+            side="right", padx=(6, 0)
+        )
         ttk.Button(btns, text="Apply", command=self._apply).pack(side="right")
 
     def _sync_scrollregion(self, _event: Any) -> None:
@@ -135,13 +153,23 @@ class TargetPickerDialog:
         self._set_by_predicate(lambda _target: False)
 
     def _select_dotenv(self) -> None:
-        self._set_by_predicate(lambda target: target.startswith("dotenv:") or target.startswith("wsl_dotenv:"))
+        self._set_by_predicate(
+            lambda target: (
+                target.startswith("dotenv:") or target.startswith("wsl_dotenv:")
+            )
+        )
 
     def _select_windows(self) -> None:
-        self._set_by_predicate(lambda target: target.startswith("windows:") or target.startswith("powershell:"))
+        self._set_by_predicate(
+            lambda target: (
+                target.startswith("windows:") or target.startswith("powershell:")
+            )
+        )
 
     def _select_wsl(self) -> None:
-        self._set_by_predicate(lambda target: target.startswith("wsl:") or target.startswith("wsl_dotenv:"))
+        self._set_by_predicate(
+            lambda target: target.startswith("wsl:") or target.startswith("wsl_dotenv:")
+        )
 
     def _update_selected_count(self) -> None:
         count = sum(1 for var in self._vars.values() if var.get())
@@ -175,9 +203,10 @@ class DotenvTargetDialog:
         frame = ttk.Frame(self.win, padding=12)
         frame.pack(fill="both", expand=True)
 
-        ttk.Label(frame, text=f"'{key}' appears in multiple .env targets. Choose which file(s) to modify:").pack(
-            anchor="w", pady=(0, 8)
-        )
+        ttk.Label(
+            frame,
+            text=f"'{key}' appears in multiple .env targets. Choose which file(s) to modify:",
+        ).pack(anchor="w", pady=(0, 8))
 
         for target in targets:
             var = tk.BooleanVar(value=True)
@@ -186,7 +215,9 @@ class DotenvTargetDialog:
 
         btns = ttk.Frame(frame)
         btns.pack(fill="x", pady=(10, 0))
-        ttk.Button(btns, text="Cancel", command=self._cancel).pack(side="right", padx=(6, 0))
+        ttk.Button(btns, text="Cancel", command=self._cancel).pack(
+            side="right", padx=(6, 0)
+        )
         ttk.Button(btns, text="Apply", command=self._apply).pack(side="right")
 
     def _apply(self) -> None:
@@ -228,7 +259,9 @@ class DiffPreviewDialog:
         notebook.pack(fill="both", expand=True)
 
         mono = tkfont.nametofont("TkFixedFont")
-        self._build_preview_tabs(notebook, previews, _PreviewTabDeps(mono, ttk, scrolledtext))
+        self._build_preview_tabs(
+            notebook, previews, _PreviewTabDeps(mono, ttk, scrolledtext)
+        )
 
         btns = ttk.Frame(frame)
         btns.pack(fill="x", pady=(10, 0))
@@ -262,11 +295,15 @@ class DiffPreviewDialog:
         txt.tag_configure("diff_add", foreground="#1f7a1f")
         txt.tag_configure("diff_remove", foreground="#9b1c1c")
         txt.tag_configure("diff_hunk", foreground="#005a9c")
-        self._render_diff_text(txt, str(preview.get("diff_preview") or "(no textual diff)"))
+        self._render_diff_text(
+            txt, str(preview.get("diff_preview") or "(no textual diff)")
+        )
         txt.configure(state="disabled")
 
     @staticmethod
-    def _build_summary(tab: Any, preview: Dict[str, Any], target: str, ttk: Any) -> None:
+    def _build_summary(
+        tab: Any, preview: Dict[str, Any], target: str, ttk: Any
+    ) -> None:
         summary = ttk.Frame(tab)
         summary.pack(fill="x", pady=(0, 6))
         ttk.Label(summary, text=f"Target: {target}").pack(anchor="w")
@@ -297,7 +334,9 @@ class DiffPreviewDialog:
         if preview_only:
             ttk.Button(btns, text="Close", command=self._cancel).pack(side="right")
             return
-        ttk.Button(btns, text="Cancel", command=self._cancel).pack(side="right", padx=(6, 0))
+        ttk.Button(btns, text="Cancel", command=self._cancel).pack(
+            side="right", padx=(6, 0)
+        )
         ttk.Button(btns, text="Apply Changes", command=self._apply).pack(side="right")
 
     def _apply(self) -> None:
@@ -330,7 +369,9 @@ class BackupPickerDialog:
         frame = ttk.Frame(self.win, padding=10)
         frame.pack(fill="both", expand=True)
 
-        ttk.Label(frame, text="Select backup file to restore:").pack(anchor="w", pady=(0, 8))
+        ttk.Label(frame, text="Select backup file to restore:").pack(
+            anchor="w", pady=(0, 8)
+        )
 
         self.listbox = tk.Listbox(frame)
         self.listbox.pack(fill="both", expand=True)
@@ -339,7 +380,9 @@ class BackupPickerDialog:
 
         btns = ttk.Frame(frame)
         btns.pack(fill="x", pady=(10, 0))
-        ttk.Button(btns, text="Cancel", command=self._cancel).pack(side="right", padx=(6, 0))
+        ttk.Button(btns, text="Cancel", command=self._cancel).pack(
+            side="right", padx=(6, 0)
+        )
         ttk.Button(btns, text="Restore", command=self._restore).pack(side="right")
 
     def _restore(self) -> None:

--- a/env_inspector_gui/models.py
+++ b/env_inspector_gui/models.py
@@ -145,7 +145,9 @@ def resolve_context_selection(
     current_wsl_distro: str,
     runtime_context: str,
 ) -> ContextSelection:
-    distros = [context.split(":", 1)[1] for context in contexts if context.startswith("wsl:")]
+    distros = [
+        context.split(":", 1)[1] for context in contexts if context.startswith("wsl:")
+    ]
     if current_context in contexts:
         context = current_context
     elif contexts:
@@ -162,7 +164,9 @@ def resolve_context_selection(
     return ContextSelection(context=context, wsl_distro=wsl_distro, distros=distros)
 
 
-def reconcile_selected_targets(selected_targets: Sequence[str], available_targets: Sequence[str]) -> List[str]:
+def reconcile_selected_targets(
+    selected_targets: Sequence[str], available_targets: Sequence[str]
+) -> List[str]:
     if not selected_targets:
         return list(available_targets)
     remaining = [target for target in selected_targets if target in available_targets]
@@ -181,7 +185,9 @@ def has_multiple_dotenv_matches(records: Iterable[EnvRecord], key: str) -> bool:
 
 def build_status_line(shown: int, total: int, context: str, last_refresh_at) -> str:
     when = "-" if last_refresh_at is None else last_refresh_at.strftime("%H:%M:%S")
-    return f"Showing {shown} / {total} entries | Context: {context} | Last refresh: {when}"
+    return (
+        f"Showing {shown} / {total} entries | Context: {context} | Last refresh: {when}"
+    )
 
 
 def resolve_selected_targets(
@@ -201,13 +207,16 @@ def resolve_selected_targets(
     return scoped_targets
 
 
-def summarize_operation_result(action: str, result: Mapping[str, Any]) -> OperationResultSummary:
+def summarize_operation_result(
+    action: str, result: Mapping[str, Any]
+) -> OperationResultSummary:
     if isinstance(result, dict) and "results" in result:
         failures = _batch_failures(result["results"])
         if failures:
             return OperationResultSummary(
                 status_message=None,
-                error_message=f"{action.title()} had failures:\n" + "\n".join(str(item.get("error_message", "")) for item in failures),
+                error_message=f"{action.title()} had failures:\n"
+                + "\n".join(str(item.get("error_message", "")) for item in failures),
             )
         return OperationResultSummary(
             status_message=f"{action.title()} succeeded for {len(result['results'])} targets",
@@ -226,10 +235,14 @@ def summarize_operation_result(action: str, result: Mapping[str, Any]) -> Operat
 
 
 def _batch_failures(results: Any) -> List[Mapping[str, Any]]:
-    return [item for item in results if isinstance(item, dict) and not item.get("success")]
+    return [
+        item for item in results if isinstance(item, dict) and not item.get("success")
+    ]
 
 
-def select_target_dialog_result(result: List[str] | None, *, messagebox: Any, app_name: str) -> List[str] | None:
+def select_target_dialog_result(
+    result: List[str] | None, *, messagebox: Any, app_name: str
+) -> List[str] | None:
     if result is None:
         return None
     if not result:

--- a/env_inspector_gui/path_actions.py
+++ b/env_inspector_gui/path_actions.py
@@ -18,7 +18,9 @@ def is_openable_local_path(source_path: str) -> bool:
         return False
 
     # Typical pseudo form: distro:/path or distro:~/path
-    if source_path.count(":") >= 2 and not (len(source_path) >= 2 and source_path[1] == ":"):
+    if source_path.count(":") >= 2 and not (
+        len(source_path) >= 2 and source_path[1] == ":"
+    ):
         return False
 
     return False
@@ -40,7 +42,9 @@ def open_source_path(
     return True, None
 
 
-def _open_path(source_path: str, *, open_uri: Callable[[str], bool] | None = None) -> None:
+def _open_path(
+    source_path: str, *, open_uri: Callable[[str], bool] | None = None
+) -> None:
     uri = Path(source_path).resolve().as_uri()
     opener = open_uri or webbrowser.open
     opened = opener(uri)

--- a/env_inspector_gui/state_store.py
+++ b/env_inspector_gui/state_store.py
@@ -79,7 +79,9 @@ def sanitize_loaded_state(
     clean = PersistedUiState.from_dict(state.to_dict())
     clean.root_path = str(_sanitize_root(clean.root_path, fallback_root))
     clean.context = _sanitize_context(clean.context, available_contexts)
-    clean.selected_targets = _sanitize_targets(clean.selected_targets, available_targets)
+    clean.selected_targets = _sanitize_targets(
+        clean.selected_targets, available_targets
+    )
     clean.sort_column = _sanitize_sort_column(clean.sort_column)
     clean.scan_depth = _sanitize_scan_depth(clean.scan_depth)
     return clean
@@ -108,7 +110,9 @@ def _sanitize_context(context: str, available_contexts: List[str]) -> str:
     return available_contexts[0]
 
 
-def _sanitize_targets(selected_targets: List[str], available_targets: List[str]) -> List[str]:
+def _sanitize_targets(
+    selected_targets: List[str], available_targets: List[str]
+) -> List[str]:
     available_set = set(available_targets)
     return [target for target in selected_targets if target in available_set]
 

--- a/env_inspector_gui/view.py
+++ b/env_inspector_gui/view.py
@@ -62,27 +62,47 @@ class EnvInspectorView:
         ttk.Label(top, text="Root folder:").grid(row=0, column=0, sticky="w")
         self.root_label = ttk.Label(top, text=str(self.controller.root_path))
         self.root_label.grid(row=0, column=1, sticky="w", padx=6)
-        ttk.Button(top, text="Choose Folder", command=self.controller.choose_folder).grid(row=0, column=2, padx=4)
-        self.refresh_button = ttk.Button(top, text="Refresh", command=self.controller.refresh_data)
+        ttk.Button(
+            top, text="Choose Folder", command=self.controller.choose_folder
+        ).grid(row=0, column=2, padx=4)
+        self.refresh_button = ttk.Button(
+            top, text="Refresh", command=self.controller.refresh_data
+        )
         self.refresh_button.grid(row=0, column=3, padx=4)
 
         ttk.Label(top, text="Context:").grid(row=0, column=4, sticky="e", padx=(16, 4))
-        self.context_combo = ttk.Combobox(top, textvariable=self.controller.context_var, state="readonly", width=28)
+        self.context_combo = ttk.Combobox(
+            top, textvariable=self.controller.context_var, state="readonly", width=28
+        )
         self.context_combo.grid(row=0, column=5, sticky="w")
-        self.context_combo.bind("<<ComboboxSelected>>", lambda _e: self.controller.on_context_selected())
+        self.context_combo.bind(
+            "<<ComboboxSelected>>", lambda _e: self.controller.on_context_selected()
+        )
 
-        ttk.Checkbutton(top, text="Show secrets", variable=self.controller.show_secrets, command=self.controller.on_filter_changed).grid(
-            row=1, column=0, sticky="w", pady=(8, 0)
-        )
-        ttk.Checkbutton(top, text="Only secrets", variable=self.controller.only_secrets, command=self.controller.on_filter_changed).grid(
-            row=1, column=1, sticky="w", pady=(8, 0)
-        )
+        ttk.Checkbutton(
+            top,
+            text="Show secrets",
+            variable=self.controller.show_secrets,
+            command=self.controller.on_filter_changed,
+        ).grid(row=1, column=0, sticky="w", pady=(8, 0))
+        ttk.Checkbutton(
+            top,
+            text="Only secrets",
+            variable=self.controller.only_secrets,
+            command=self.controller.on_filter_changed,
+        ).grid(row=1, column=1, sticky="w", pady=(8, 0))
 
         ttk.Label(top, text="Filter:").grid(row=1, column=2, sticky="e", pady=(8, 0))
         self.filter_entry = ttk.Entry(top, textvariable=self.controller.filter_text)
-        self.filter_entry.grid(row=1, column=3, columnspan=3, sticky="ew", padx=4, pady=(8, 0))
-        self.filter_entry.bind("<KeyRelease>", lambda _e: self.controller.on_filter_changed())
-        self.filter_entry.bind("<Escape>", lambda _e: self.controller.on_filter_escape())
+        self.filter_entry.grid(
+            row=1, column=3, columnspan=3, sticky="ew", padx=4, pady=(8, 0)
+        )
+        self.filter_entry.bind(
+            "<KeyRelease>", lambda _e: self.controller.on_filter_changed()
+        )
+        self.filter_entry.bind(
+            "<Escape>", lambda _e: self.controller.on_filter_escape()
+        )
         top.columnconfigure(3, weight=1)
 
     def _build_scan_section(self) -> None:
@@ -91,18 +111,29 @@ class EnvInspectorView:
         scan.pack(fill="x", padx=10, pady=(0, 8))
 
         ttk.Label(scan, text="WSL distro:").grid(row=0, column=0, sticky="w")
-        self.wsl_distro_combo = ttk.Combobox(scan, textvariable=self.controller.wsl_distro_var, state="readonly", width=28)
+        self.wsl_distro_combo = ttk.Combobox(
+            scan,
+            textvariable=self.controller.wsl_distro_var,
+            state="readonly",
+            width=28,
+        )
         self.wsl_distro_combo.grid(row=0, column=1, sticky="w", padx=(4, 10))
 
         ttk.Label(scan, text="WSL path:").grid(row=0, column=2, sticky="w")
-        self.wsl_path_entry = ttk.Entry(scan, textvariable=self.controller.wsl_path_var, width=46)
+        self.wsl_path_entry = ttk.Entry(
+            scan, textvariable=self.controller.wsl_path_var, width=46
+        )
         self.wsl_path_entry.grid(row=0, column=3, sticky="w", padx=(4, 10))
 
         ttk.Label(scan, text="Depth:").grid(row=0, column=4, sticky="w")
-        self.wsl_depth_spinbox = ttk.Spinbox(scan, from_=1, to=20, textvariable=self.controller.scan_depth_var, width=6)
+        self.wsl_depth_spinbox = ttk.Spinbox(
+            scan, from_=1, to=20, textvariable=self.controller.scan_depth_var, width=6
+        )
         self.wsl_depth_spinbox.grid(row=0, column=5, sticky="w", padx=(4, 10))
 
-        self.wsl_scan_button = ttk.Button(scan, text="Apply WSL Scan", command=self.controller.refresh_data)
+        self.wsl_scan_button = ttk.Button(
+            scan, text="Apply WSL Scan", command=self.controller.refresh_data
+        )
         self.wsl_scan_button.grid(row=0, column=6, sticky="w")
 
     def _build_mutation_section(self) -> None:
@@ -111,24 +142,42 @@ class EnvInspectorView:
         mutate.pack(fill="x", padx=10, pady=(0, 8))
 
         ttk.Label(mutate, text="Key:").grid(row=0, column=0, sticky="w")
-        self.key_entry = ttk.Entry(mutate, textvariable=self.controller.key_text, width=34)
+        self.key_entry = ttk.Entry(
+            mutate, textvariable=self.controller.key_text, width=34
+        )
         self.key_entry.grid(row=0, column=1, sticky="w", padx=(4, 10))
 
         ttk.Label(mutate, text="Value:").grid(row=0, column=2, sticky="w")
-        self.value_entry = ttk.Entry(mutate, textvariable=self.controller.value_text, width=52)
+        self.value_entry = ttk.Entry(
+            mutate, textvariable=self.controller.value_text, width=52
+        )
         self.value_entry.grid(row=0, column=3, sticky="w", padx=(4, 10))
 
-        self.load_button = ttk.Button(mutate, text="Load Selected", command=self.controller.load_selected)
+        self.load_button = ttk.Button(
+            mutate, text="Load Selected", command=self.controller.load_selected
+        )
         self.load_button.grid(row=0, column=4, padx=(0, 6))
-        self.choose_targets_button = ttk.Button(mutate, text="Choose Targets", command=self.controller.choose_targets)
+        self.choose_targets_button = ttk.Button(
+            mutate, text="Choose Targets", command=self.controller.choose_targets
+        )
         self.choose_targets_button.grid(row=0, column=5, padx=(0, 6))
-        self.set_button = ttk.Button(mutate, text="Set", command=lambda: self.controller._run_operation("set"))
+        self.set_button = ttk.Button(
+            mutate, text="Set", command=lambda: self.controller._run_operation("set")
+        )
         self.set_button.grid(row=0, column=6, padx=(0, 6))
-        self.remove_button = ttk.Button(mutate, text="Remove", command=lambda: self.controller._run_operation("remove"))
+        self.remove_button = ttk.Button(
+            mutate,
+            text="Remove",
+            command=lambda: self.controller._run_operation("remove"),
+        )
         self.remove_button.grid(row=0, column=7)
 
-        ttk.Label(mutate, textvariable=self.controller.targets_summary_var).grid(row=1, column=0, columnspan=8, sticky="w", pady=(8, 0))
-        ttk.Label(mutate, textvariable=self.controller.effective_value_var).grid(row=2, column=0, columnspan=8, sticky="w", pady=(6, 0))
+        ttk.Label(mutate, textvariable=self.controller.targets_summary_var).grid(
+            row=1, column=0, columnspan=8, sticky="w", pady=(8, 0)
+        )
+        ttk.Label(mutate, textvariable=self.controller.effective_value_var).grid(
+            row=2, column=0, columnspan=8, sticky="w", pady=(6, 0)
+        )
 
     def _build_mid_section(self) -> Any:
         ttk = self.ttk
@@ -166,11 +215,15 @@ class EnvInspectorView:
             ("mutable", "Mutable", 80, "center"),
             ("source_path", "Source Path", 320, "w"),
         ]:
-            self.tree.heading(col, text=title, command=lambda c=col: self.controller.on_sort_column(c))
+            self.tree.heading(
+                col, text=title, command=lambda c=col: self.controller.on_sort_column(c)
+            )
             self.tree.column(col, width=width, anchor=anchor)
 
         yscroll = ttk.Scrollbar(table_wrap, orient="vertical", command=self.tree.yview)
-        xscroll = ttk.Scrollbar(table_wrap, orient="horizontal", command=self.tree.xview)
+        xscroll = ttk.Scrollbar(
+            table_wrap, orient="horizontal", command=self.tree.xview
+        )
         self.tree.configure(yscrollcommand=yscroll.set, xscrollcommand=xscroll.set)
 
         self.tree.grid(row=0, column=0, sticky="nsew")
@@ -178,7 +231,9 @@ class EnvInspectorView:
         xscroll.grid(row=1, column=0, sticky="ew")
         table_wrap.columnconfigure(0, weight=1)
         table_wrap.rowconfigure(0, weight=1)
-        self.tree.bind("<<TreeviewSelect>>", lambda _e: self.controller.on_tree_selected())
+        self.tree.bind(
+            "<<TreeviewSelect>>", lambda _e: self.controller.on_tree_selected()
+        )
 
     def _create_details_var_map(self) -> Dict[str, Any]:
         self.details_vars = {
@@ -199,14 +254,26 @@ class EnvInspectorView:
         ttk = self.ttk
 
         ttk.Label(detail_wrap, text="Name:").grid(row=0, column=0, sticky="nw")
-        ttk.Label(detail_wrap, textvariable=self.details_vars["name"]).grid(row=0, column=1, sticky="nw", padx=(6, 0))
+        ttk.Label(detail_wrap, textvariable=self.details_vars["name"]).grid(
+            row=0, column=1, sticky="nw", padx=(6, 0)
+        )
 
-        ttk.Label(detail_wrap, text="Value:").grid(row=1, column=0, sticky="nw", pady=(6, 0))
-        self.details_value_text = self.tkmod.Text(detail_wrap, height=4, wrap="none", font="TkFixedFont")
-        self.details_value_text.grid(row=1, column=1, sticky="nsew", padx=(6, 0), pady=(6, 0))
+        ttk.Label(detail_wrap, text="Value:").grid(
+            row=1, column=0, sticky="nw", pady=(6, 0)
+        )
+        self.details_value_text = self.tkmod.Text(
+            detail_wrap, height=4, wrap="none", font="TkFixedFont"
+        )
+        self.details_value_text.grid(
+            row=1, column=1, sticky="nsew", padx=(6, 0), pady=(6, 0)
+        )
         self.details_value_text.configure(state="disabled")
-        self.details_value_scroll_x = ttk.Scrollbar(detail_wrap, orient="horizontal", command=self.details_value_text.xview)
-        self.details_value_text.configure(xscrollcommand=self.details_value_scroll_x.set)
+        self.details_value_scroll_x = ttk.Scrollbar(
+            detail_wrap, orient="horizontal", command=self.details_value_text.xview
+        )
+        self.details_value_text.configure(
+            xscrollcommand=self.details_value_scroll_x.set
+        )
         self.details_value_scroll_x.grid(row=2, column=1, sticky="ew", padx=(6, 0))
 
     def _build_details_metadata_rows(self, detail_wrap: Any, *, start_row: int) -> int:
@@ -224,26 +291,44 @@ class EnvInspectorView:
         )
         for idx, (label, key) in enumerate(meta_fields):
             row = start_row + idx
-            ttk.Label(detail_wrap, text=f"{label}:").grid(row=row, column=0, sticky="nw", pady=(4, 0))
-            ttk.Label(detail_wrap, textvariable=self.details_vars[key]).grid(row=row, column=1, sticky="nw", padx=(6, 0), pady=(4, 0))
+            ttk.Label(detail_wrap, text=f"{label}:").grid(
+                row=row, column=0, sticky="nw", pady=(4, 0)
+            )
+            ttk.Label(detail_wrap, textvariable=self.details_vars[key]).grid(
+                row=row, column=1, sticky="nw", padx=(6, 0), pady=(4, 0)
+            )
         return start_row + len(meta_fields)
 
     def _build_details_action_rows(self, detail_wrap: Any, *, start_row: int) -> None:
         ttk = self.ttk
         btn_row = ttk.Frame(detail_wrap)
         btn_row.grid(row=start_row, column=0, columnspan=2, sticky="ew", pady=(10, 0))
-        self.copy_name_button = ttk.Button(btn_row, text="Copy Name", command=self.controller.copy_selected_name)
+        self.copy_name_button = ttk.Button(
+            btn_row, text="Copy Name", command=self.controller.copy_selected_name
+        )
         self.copy_name_button.pack(side="left", padx=(0, 6))
-        self.copy_value_button = ttk.Button(btn_row, text="Copy Value", command=self.controller.copy_selected_value)
+        self.copy_value_button = ttk.Button(
+            btn_row, text="Copy Value", command=self.controller.copy_selected_value
+        )
         self.copy_value_button.pack(side="left", padx=(0, 6))
-        self.copy_pair_button = ttk.Button(btn_row, text="Copy Name=Value", command=self.controller.copy_selected_pair)
+        self.copy_pair_button = ttk.Button(
+            btn_row, text="Copy Name=Value", command=self.controller.copy_selected_pair
+        )
         self.copy_pair_button.pack(side="left", padx=(0, 6))
 
         btn_row_2 = ttk.Frame(detail_wrap)
-        btn_row_2.grid(row=start_row + 1, column=0, columnspan=2, sticky="ew", pady=(6, 0))
-        self.copy_source_path_button = ttk.Button(btn_row_2, text="Copy Source Path", command=self.controller.copy_selected_source_path)
+        btn_row_2.grid(
+            row=start_row + 1, column=0, columnspan=2, sticky="ew", pady=(6, 0)
+        )
+        self.copy_source_path_button = ttk.Button(
+            btn_row_2,
+            text="Copy Source Path",
+            command=self.controller.copy_selected_source_path,
+        )
         self.copy_source_path_button.pack(side="left", padx=(0, 6))
-        self.detail_open_button = ttk.Button(btn_row_2, text="Open Source", command=self.controller.open_selected_source)
+        self.detail_open_button = ttk.Button(
+            btn_row_2, text="Open Source", command=self.controller.open_selected_source
+        )
         self.detail_open_button.pack(side="left")
 
     def _build_details_section(self, detail_wrap: Any) -> None:
@@ -259,9 +344,19 @@ class EnvInspectorView:
         bottom = ttk.Frame(self.tk, padding=10)
         bottom.pack(fill="x")
 
-        ttk.Button(bottom, text="Export JSON", command=lambda: self.controller.export_records("json")).pack(side="left", padx=4)
-        ttk.Button(bottom, text="Export CSV", command=lambda: self.controller.export_records("csv")).pack(side="left", padx=4)
-        ttk.Button(bottom, text="Restore Backup", command=self.controller.restore_backup).pack(side="left", padx=(20, 4))
+        ttk.Button(
+            bottom,
+            text="Export JSON",
+            command=lambda: self.controller.export_records("json"),
+        ).pack(side="left", padx=4)
+        ttk.Button(
+            bottom,
+            text="Export CSV",
+            command=lambda: self.controller.export_records("csv"),
+        ).pack(side="left", padx=4)
+        ttk.Button(
+            bottom, text="Restore Backup", command=self.controller.restore_backup
+        ).pack(side="left", padx=(20, 4))
 
         self.progress = ttk.Progressbar(bottom, mode="indeterminate", length=120)
         self.progress.pack(side="right", padx=(8, 0))
@@ -276,7 +371,11 @@ class EnvInspectorView:
         self.wsl_distro_combo.configure(values=distros)
         self.wsl_distro_combo.configure(state=("readonly" if enabled else "disabled"))
         state = "normal" if enabled else "disabled"
-        for widget in (self.wsl_path_entry, self.wsl_depth_spinbox, self.wsl_scan_button):
+        for widget in (
+            self.wsl_path_entry,
+            self.wsl_depth_spinbox,
+            self.wsl_scan_button,
+        ):
             widget.configure(state=state)
 
     def set_root_label(self, text: str) -> None:
@@ -293,7 +392,13 @@ class EnvInspectorView:
 
     def set_mutation_actions_enabled(self, enabled: bool) -> None:
         state = "normal" if enabled else "disabled"
-        for widget in (self.refresh_button, self.load_button, self.choose_targets_button, self.set_button, self.remove_button):
+        for widget in (
+            self.refresh_button,
+            self.load_button,
+            self.choose_targets_button,
+            self.set_button,
+            self.remove_button,
+        ):
             widget.configure(state=state)
 
     def clear_table(self) -> None:

--- a/scripts/quality/_codacy_zero_impl.py
+++ b/scripts/quality/_codacy_zero_impl.py
@@ -36,14 +36,28 @@ def _public_codacy_module() -> Any | None:
 
 
 def _parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Assert Codacy has zero total open issues.")
-    parser.add_argument("--provider", default="gh", help="Organization provider, for example gh")
+    parser = argparse.ArgumentParser(
+        description="Assert Codacy has zero total open issues."
+    )
+    parser.add_argument(
+        "--provider", default="gh", help="Organization provider, for example gh"
+    )
     parser.add_argument("--owner", required=True, help="Repository owner")
     parser.add_argument("--repo", required=True, help="Repository name")
-    parser.add_argument("--branch", default="", help="Optional branch name to scope issue totals")
-    parser.add_argument("--token", default="", help="Codacy API token (falls back to CODACY_API_TOKEN env)")
-    parser.add_argument("--out-json", default="codacy-zero/codacy.json", help="Output JSON path")
-    parser.add_argument("--out-md", default="codacy-zero/codacy.md", help="Output markdown path")
+    parser.add_argument(
+        "--branch", default="", help="Optional branch name to scope issue totals"
+    )
+    parser.add_argument(
+        "--token",
+        default="",
+        help="Codacy API token (falls back to CODACY_API_TOKEN env)",
+    )
+    parser.add_argument(
+        "--out-json", default="codacy-zero/codacy.json", help="Output JSON path"
+    )
+    parser.add_argument(
+        "--out-md", default="codacy-zero/codacy.md", help="Output markdown path"
+    )
     return parser.parse_args()
 
 
@@ -88,9 +102,17 @@ def _fetch_open_issues_for_provider(
 
     public = _public_codacy_module()
     request_json_fn = getattr(public, "_request_json", _request_json)
-    sample_findings_fn = getattr(public, "_sample_issue_findings", _sample_issue_findings)
-    handled, open_issues, findings, error = _attempt_issue_total(request, request_json_fn)
-    findings.extend(_issue_total_findings(request, open_issues, handled, request_json_fn, sample_findings_fn))
+    sample_findings_fn = getattr(
+        public, "_sample_issue_findings", _sample_issue_findings
+    )
+    handled, open_issues, findings, error = _attempt_issue_total(
+        request, request_json_fn
+    )
+    findings.extend(
+        _issue_total_findings(
+            request, open_issues, handled, request_json_fn, sample_findings_fn
+        )
+    )
     return handled, open_issues, findings, error
 
 
@@ -105,12 +127,16 @@ def _attempt_issue_total(
     except urllib.error.HTTPError as exc:
         handled, error = _handle_http_error(exc, findings)
         return handled, None, findings, error
-    except CODACY_REQUEST_EXCEPTIONS as exc:  # pragma: no cover - network/runtime surface
+    except (
+        CODACY_REQUEST_EXCEPTIONS
+    ) as exc:  # pragma: no cover - network/runtime surface
         findings.append(f"Codacy API request failed: {exc}")
         return True, None, findings, exc
 
 
-def _resolve_codacy_request(request: CodacyRequest | None, kwargs: Any) -> CodacyRequest:
+def _resolve_codacy_request(
+    request: CodacyRequest | None, kwargs: Any
+) -> CodacyRequest:
     if request is None:
         return CodacyRequest(**kwargs)
     if kwargs:
@@ -123,7 +149,9 @@ def _request_issue_total(request: CodacyRequest, request_json_fn: Any) -> int | 
     return extract_total_open(payload)
 
 
-def _handle_http_error(exc: urllib.error.HTTPError, findings: List[str]) -> Tuple[bool, Exception]:
+def _handle_http_error(
+    exc: urllib.error.HTTPError, findings: List[str]
+) -> Tuple[bool, Exception]:
     if exc.code == 404:
         return False, exc
     findings.append(f"Codacy API request failed: HTTP {exc.code}")
@@ -137,7 +165,9 @@ def _non_zero_issue_findings(
     sample_findings_fn: Any,
 ) -> List[str]:
     findings = [f"Codacy reports {open_issues} open issues (expected 0)."]
-    sample_payload = request_json_fn(request=replace(request, limit=20, method="POST", data={}))
+    sample_payload = request_json_fn(
+        request=replace(request, limit=20, method="POST", data={})
+    )
     findings.extend(sample_findings_fn(sample_payload))
     return findings
 
@@ -155,10 +185,14 @@ def _issue_total_findings(
         return ["Codacy response did not include a parseable total issue count."]
     if open_issues == 0:
         return []
-    return _non_zero_issue_findings(request, open_issues, request_json_fn, sample_findings_fn)
+    return _non_zero_issue_findings(
+        request, open_issues, request_json_fn, sample_findings_fn
+    )
 
 
-def _query_open_issues(request: CodacyRequest | None = None, **kwargs: Any) -> Tuple[int | None, List[str]]:
+def _query_open_issues(
+    request: CodacyRequest | None = None, **kwargs: Any
+) -> Tuple[int | None, List[str]]:
     if request is None:
         request = CodacyRequest(**kwargs)
     elif kwargs:
@@ -167,11 +201,17 @@ def _query_open_issues(request: CodacyRequest | None = None, **kwargs: Any) -> T
     last_exc: Exception | None = None
 
     public = _public_codacy_module()
-    provider_candidates_fn = getattr(public, "_provider_candidates", _provider_candidates)
-    fetch_fn = getattr(public, "_fetch_open_issues_for_provider", _fetch_open_issues_for_provider)
+    provider_candidates_fn = getattr(
+        public, "_provider_candidates", _provider_candidates
+    )
+    fetch_fn = getattr(
+        public, "_fetch_open_issues_for_provider", _fetch_open_issues_for_provider
+    )
 
     for candidate in provider_candidates_fn(request.provider):
-        handled, open_issues, findings, error = fetch_fn(request=replace(request, provider=candidate))
+        handled, open_issues, findings, error = fetch_fn(
+            request=replace(request, provider=candidate)
+        )
         if handled:
             return open_issues, findings
         last_exc = error

--- a/scripts/quality/_codacy_zero_support.py
+++ b/scripts/quality/_codacy_zero_support.py
@@ -72,7 +72,9 @@ __all__ = [
 ]
 
 
-def _request_json(request: CodacyRequest | None = None, **kwargs: Any) -> Dict[str, Any]:
+def _request_json(
+    request: CodacyRequest | None = None, **kwargs: Any
+) -> Dict[str, Any]:
     if request is None:
         request = CodacyRequest(**kwargs)
     elif kwargs:
@@ -87,8 +89,12 @@ def _request_json(request: CodacyRequest | None = None, **kwargs: Any) -> Dict[s
         headers["Content-Type"] = "application/json"
 
     public = _public_codacy_module()
-    request_json_fn = cast(RequestJsonHttps, getattr(public, "request_json_https", request_json_https))
-    encode_identifier_fn = cast(EncodeIdentifier, getattr(public, "encode_identifier", encode_identifier))
+    request_json_fn = cast(
+        RequestJsonHttps, getattr(public, "request_json_https", request_json_https)
+    )
+    encode_identifier_fn = cast(
+        EncodeIdentifier, getattr(public, "encode_identifier", encode_identifier)
+    )
 
     provider_slug = encode_identifier_fn(request.provider, field_name="Codacy provider")
     owner_slug = encode_identifier_fn(request.owner, field_name="Codacy owner")

--- a/scripts/quality/_coverage_assert_support.py
+++ b/scripts/quality/_coverage_assert_support.py
@@ -13,7 +13,9 @@ _PAIR_RE = re.compile(r"^(?P<name>[^=]+)=(?P<path>.+)$")
 _XML_LINES_VALID_RE = re.compile(r'lines-valid="(\d+(?:\.\d+)?)"')
 _XML_LINES_COVERED_RE = re.compile(r'lines-covered="(\d+(?:\.\d+)?)"')
 _XML_LINE_HITS_RE = re.compile(r'<line\b[^>]*\bhits="(\d+(?:\.\d+)?)"')
-_XML_FILENAME_RE = re.compile(r'''<[^>]+\bfilename=(?P<quote>["'])(?P<value>.*?)(?P=quote)''')
+_XML_FILENAME_RE = re.compile(
+    r"""<[^>]+\bfilename=(?P<quote>["'])(?P<value>.*?)(?P=quote)"""
+)
 _NONE_LIST_ITEM = "- None"
 
 
@@ -96,7 +98,9 @@ def parse_lcov(name: str, path: Path) -> CoverageStats:
     total = 0
     covered = 0
 
-    for raw in path.read_text(encoding="utf-8").splitlines():  # lgtm [py/path-injection]
+    for raw in path.read_text(
+        encoding="utf-8"
+    ).splitlines():  # lgtm [py/path-injection]
         line = raw.strip()
         if line.startswith("LF:"):
             total += int(line.split(":", 1)[1])
@@ -108,7 +112,9 @@ def parse_lcov(name: str, path: Path) -> CoverageStats:
 
 def coverage_sources_from_lcov(path: Path) -> Set[str]:
     covered_sources: Set[str] = set()
-    for raw in path.read_text(encoding="utf-8").splitlines():  # lgtm [py/path-injection]
+    for raw in path.read_text(
+        encoding="utf-8"
+    ).splitlines():  # lgtm [py/path-injection]
         line = raw.strip()
         if not line.startswith("SF:"):
             continue
@@ -122,16 +128,23 @@ def _matches_required_source(source_path: str, required_source: str) -> bool:
     normalized_required = _normalize_source_path(required_source).rstrip("/")
     if not normalized_required:
         return False
-    return source_path == normalized_required or source_path.startswith(f"{normalized_required}/")
+    return source_path == normalized_required or source_path.startswith(
+        f"{normalized_required}/"
+    )
 
 
-def _find_missing_required_sources(reported_sources: Set[str], required_sources: List[str]) -> List[str]:
+def _find_missing_required_sources(
+    reported_sources: Set[str], required_sources: List[str]
+) -> List[str]:
     missing: List[str] = []
     for required_source in required_sources:
         normalized_required = _normalize_source_path(required_source).rstrip("/")
         if not normalized_required:
             continue
-        if any(_matches_required_source(source_path, normalized_required) for source_path in reported_sources):
+        if any(
+            _matches_required_source(source_path, normalized_required)
+            for source_path in reported_sources
+        ):
             continue
         missing.append(normalized_required)
     return missing
@@ -139,7 +152,8 @@ def _find_missing_required_sources(reported_sources: Set[str], required_sources:
 
 def _is_tests_only_report(reported_sources: Set[str]) -> bool:
     return bool(reported_sources) and all(
-        source_path == "tests" or source_path.startswith("tests/") for source_path in reported_sources
+        source_path == "tests" or source_path.startswith("tests/")
+        for source_path in reported_sources
     )
 
 
@@ -153,7 +167,9 @@ def _coverage_findings(stats: List[CoverageStats], min_percent: float) -> List[s
 
     combined_total = sum(item.total for item in stats)
     combined_covered = sum(item.covered for item in stats)
-    combined = 100.0 if combined_total <= 0 else (combined_covered / combined_total) * 100.0
+    combined = (
+        100.0 if combined_total <= 0 else (combined_covered / combined_total) * 100.0
+    )
     if combined < min_percent:
         findings.append(
             f"combined coverage below {min_percent:.2f}%: {combined:.2f}% ({combined_covered}/{combined_total})"
@@ -161,12 +177,18 @@ def _coverage_findings(stats: List[CoverageStats], min_percent: float) -> List[s
     return findings
 
 
-def _source_findings(reported_sources: Set[str], required_sources: List[str]) -> List[str]:
+def _source_findings(
+    reported_sources: Set[str], required_sources: List[str]
+) -> List[str]:
     findings: List[str] = []
     if _is_tests_only_report(reported_sources):
-        findings.append("coverage inputs only reference tests/ paths; first-party sources are missing.")
+        findings.append(
+            "coverage inputs only reference tests/ paths; first-party sources are missing."
+        )
 
-    for required_source in _find_missing_required_sources(reported_sources, required_sources):
+    for required_source in _find_missing_required_sources(
+        reported_sources, required_sources
+    ):
         findings.append(f"missing required source path: {required_source}")
     return findings
 
@@ -227,7 +249,7 @@ def _render_md(payload: Dict[str, Any]) -> str:
     _append_covered_source_lines(lines, payload)
     lines.extend(["", "## Findings"])
     _append_finding_lines(lines, payload)
-    return "`n".replace('`n','\n').join(lines) + "\n"
+    return "`n".replace("`n", "\n").join(lines) + "\n"
 
 
 def _build_payload(

--- a/scripts/quality/_required_checks_impl.py
+++ b/scripts/quality/_required_checks_impl.py
@@ -54,10 +54,14 @@ safe_output_path_in_workspace = _http.safe_output_path_in_workspace
 
 
 def _parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Wait for required GitHub check contexts and assert they are successful.")
+    parser = argparse.ArgumentParser(
+        description="Wait for required GitHub check contexts and assert they are successful."
+    )
     parser.add_argument("--repo", required=True, help="owner/repo")
     parser.add_argument("--sha", required=True, help="commit SHA")
-    parser.add_argument("--required-context", action="append", default=[], help="Required context name")
+    parser.add_argument(
+        "--required-context", action="append", default=[], help="Required context name"
+    )
     parser.add_argument("--timeout-seconds", type=int, default=900)
     parser.add_argument("--poll-seconds", type=int, default=20)
     parser.add_argument("--out-json", default="quality-zero-gate/required-checks.json")
@@ -100,7 +104,9 @@ def _required_contexts(args: argparse.Namespace) -> List[str]:
 
 
 def _github_token() -> str:
-    token = (os.environ.get("GITHUB_TOKEN", "") or os.environ.get("GH_TOKEN", "")).strip()
+    token = (
+        os.environ.get("GITHUB_TOKEN", "") or os.environ.get("GH_TOKEN", "")
+    ).strip()
     if not token:
         raise SystemExit("GITHUB_TOKEN or GH_TOKEN is required")
     return token
@@ -146,11 +152,26 @@ def _collect_until_settled(request: SettledChecksRequest) -> Dict[str, Any]:
     final_payload: Optional[Dict[str, Any]] = None
 
     while time.time() <= deadline:
-        check_runs = _api_get_check_runs(owner=request.owner_slug, repo=request.repo_slug, sha=request.sha, token=request.token)
-        statuses = _api_get_status(owner=request.owner_slug, repo=request.repo_slug, sha=request.sha, token=request.token)
+        check_runs = _api_get_check_runs(
+            owner=request.owner_slug,
+            repo=request.repo_slug,
+            sha=request.sha,
+            token=request.token,
+        )
+        statuses = _api_get_status(
+            owner=request.owner_slug,
+            repo=request.repo_slug,
+            sha=request.sha,
+            token=request.token,
+        )
         contexts = _collect_contexts(check_runs, statuses)
 
-        final_payload = _snapshot(repo_arg=request.repo_arg, sha=request.sha, required=request.required, contexts=contexts)
+        final_payload = _snapshot(
+            repo_arg=request.repo_arg,
+            sha=request.sha,
+            required=request.required,
+            contexts=contexts,
+        )
         if not _should_wait(final_payload):
             break
         time.sleep(max(request.poll_seconds, 1))

--- a/scripts/quality/assert_coverage_100.py
+++ b/scripts/quality/assert_coverage_100.py
@@ -44,13 +44,21 @@ def _load_security_helpers():
     )
 
 
-SAFE_INPUT_FILE_PATH_IN_WORKSPACE, SAFE_OUTPUT_PATH_IN_WORKSPACE = _load_security_helpers()
+SAFE_INPUT_FILE_PATH_IN_WORKSPACE, SAFE_OUTPUT_PATH_IN_WORKSPACE = (
+    _load_security_helpers()
+)
 
 
 def _parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Assert minimum coverage for all declared components.")
-    parser.add_argument("--xml", action="append", default=[], help="Coverage XML input: name=path")
-    parser.add_argument("--lcov", action="append", default=[], help="LCOV input: name=path")
+    parser = argparse.ArgumentParser(
+        description="Assert minimum coverage for all declared components."
+    )
+    parser.add_argument(
+        "--xml", action="append", default=[], help="Coverage XML input: name=path"
+    )
+    parser.add_argument(
+        "--lcov", action="append", default=[], help="LCOV input: name=path"
+    )
     parser.add_argument(
         "--require-source",
         action="append",
@@ -63,8 +71,12 @@ def _parse_args() -> argparse.Namespace:
         default=100.0,
         help="Minimum required coverage percentage for each component and combined summary.",
     )
-    parser.add_argument("--out-json", default="coverage-100/coverage.json", help="Output JSON path")
-    parser.add_argument("--out-md", default="coverage-100/coverage.md", help="Output markdown path")
+    parser.add_argument(
+        "--out-json", default="coverage-100/coverage.json", help="Output JSON path"
+    )
+    parser.add_argument(
+        "--out-md", default="coverage-100/coverage.md", help="Output markdown path"
+    )
     return parser.parse_args()
 
 
@@ -91,7 +103,9 @@ def main() -> int:
     stats, covered_sources = _collect_stats(args)
 
     if not stats:
-        raise SystemExit("No coverage files were provided; pass --xml and/or --lcov inputs.")
+        raise SystemExit(
+            "No coverage files were provided; pass --xml and/or --lcov inputs."
+        )
 
     min_percent = max(0.0, min(100.0, float(args.min_percent)))
     status, findings = evaluate(
@@ -103,7 +117,9 @@ def main() -> int:
     payload = _build_payload(stats, covered_sources, min_percent, findings, status)
 
     try:
-        out_json = SAFE_OUTPUT_PATH_IN_WORKSPACE(args.out_json, "coverage-100/coverage.json")
+        out_json = SAFE_OUTPUT_PATH_IN_WORKSPACE(
+            args.out_json, "coverage-100/coverage.json"
+        )
         out_md = SAFE_OUTPUT_PATH_IN_WORKSPACE(args.out_md, "coverage-100/coverage.md")
     except ValueError as exc:
         print(str(exc), file=sys.stderr)

--- a/scripts/quality/check_deepscan_zero.py
+++ b/scripts/quality/check_deepscan_zero.py
@@ -54,10 +54,20 @@ split_validated_https_url = cast(
 
 
 def _parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Assert DeepScan has zero total open issues.")
-    parser.add_argument("--token", default="", help="DeepScan API token (falls back to DEEPSCAN_API_TOKEN env)")
-    parser.add_argument("--out-json", default="deepscan-zero/deepscan.json", help="Output JSON path")
-    parser.add_argument("--out-md", default="deepscan-zero/deepscan.md", help="Output markdown path")
+    parser = argparse.ArgumentParser(
+        description="Assert DeepScan has zero total open issues."
+    )
+    parser.add_argument(
+        "--token",
+        default="",
+        help="DeepScan API token (falls back to DEEPSCAN_API_TOKEN env)",
+    )
+    parser.add_argument(
+        "--out-json", default="deepscan-zero/deepscan.json", help="Output JSON path"
+    )
+    parser.add_argument(
+        "--out-md", default="deepscan-zero/deepscan.md", help="Output markdown path"
+    )
     return parser.parse_args()
 
 
@@ -76,7 +86,9 @@ def extract_total_open(payload: Any) -> int | None:
     return None
 
 
-def _request_json(*, host: str, path: str, query: Dict[str, str], token: str) -> Dict[str, Any]:
+def _request_json(
+    *, host: str, path: str, query: Dict[str, str], token: str
+) -> Dict[str, Any]:
     payload, _headers = request_json_https(
         host=host,
         path=path,
@@ -104,12 +116,22 @@ def _coerce_fetch_request(*args: Any, **kwargs: Any) -> DeepScanRequest:
     if args:
         if len(args) == 1 and isinstance(args[0], DeepScanRequest):
             if kwargs:
-                raise TypeError("Pass either a request object or keyword arguments, not both.")
+                raise TypeError(
+                    "Pass either a request object or keyword arguments, not both."
+                )
             return args[0]
         if len(args) == 5 and not kwargs:
             host, path, query, token, findings = args
-            return DeepScanRequest(host=str(host), path=str(path), query=dict(query), token=str(token), findings=findings)
-        raise TypeError("Pass a request object or keyword arguments, not positional arguments.")
+            return DeepScanRequest(
+                host=str(host),
+                path=str(path),
+                query=dict(query),
+                token=str(token),
+                findings=findings,
+            )
+        raise TypeError(
+            "Pass a request object or keyword arguments, not positional arguments."
+        )
     return DeepScanRequest(
         host=str(kwargs.pop("host")),
         path=str(kwargs.pop("path")),
@@ -122,17 +144,30 @@ def _coerce_fetch_request(*args: Any, **kwargs: Any) -> DeepScanRequest:
 def _fetch_open_issues(*args: Any, **kwargs: Any) -> int | None:
     request = _coerce_fetch_request(*args, **kwargs)
     try:
-        payload = _request_json(host=request.host, path=request.path, query=request.query, token=request.token)
-    except (urllib.error.URLError, RuntimeError, ValueError) as exc:  # pragma: no cover - network/runtime surface
+        payload = _request_json(
+            host=request.host,
+            path=request.path,
+            query=request.query,
+            token=request.token,
+        )
+    except (
+        urllib.error.URLError,
+        RuntimeError,
+        ValueError,
+    ) as exc:  # pragma: no cover - network/runtime surface
         request.findings.append(f"DeepScan API request failed: {exc}")
         return None
 
     open_issues = extract_total_open(payload)
     if open_issues is None:
-        request.findings.append("DeepScan response did not include a parseable total issue count.")
+        request.findings.append(
+            "DeepScan response did not include a parseable total issue count."
+        )
         return None
     if open_issues != 0:
-        request.findings.append(f"DeepScan reports {open_issues} open issues (expected 0).")
+        request.findings.append(
+            f"DeepScan reports {open_issues} open issues (expected 0)."
+        )
     return open_issues
 
 
@@ -170,7 +205,9 @@ def main() -> int:
 
     if not findings:
         host, path, query = _resolve_deepscan_endpoint(open_issues_url)
-        open_issues = _fetch_open_issues(host=host, path=path, query=query, token=token, findings=findings)
+        open_issues = _fetch_open_issues(
+            host=host, path=path, query=query, token=token, findings=findings
+        )
 
     status = "pass" if not findings else "fail"
     payload = {
@@ -182,7 +219,9 @@ def main() -> int:
     }
 
     try:
-        out_json = safe_output_path_in_workspace(args.out_json, "deepscan-zero/deepscan.json")
+        out_json = safe_output_path_in_workspace(
+            args.out_json, "deepscan-zero/deepscan.json"
+        )
         out_md = safe_output_path_in_workspace(args.out_md, "deepscan-zero/deepscan.md")
     except ValueError as exc:
         print(str(exc), file=sys.stderr)
@@ -190,7 +229,9 @@ def main() -> int:
 
     out_json.parent.mkdir(parents=True, exist_ok=True)
     out_md.parent.mkdir(parents=True, exist_ok=True)
-    out_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_json.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
     out_md.write_text(_render_md(payload), encoding="utf-8")
     print(out_md.read_text(encoding="utf-8"), end="")
     return 0 if status == "pass" else 1

--- a/scripts/quality/check_quality_secrets.py
+++ b/scripts/quality/check_quality_secrets.py
@@ -28,16 +28,32 @@ DEFAULT_REQUIRED_VARS = [
 
 
 def _parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Validate required quality-gate secrets/variables are configured.")
-    parser.add_argument("--required-secret", action="append", default=[], help="Additional required secret env var name")
-    parser.add_argument("--required-var", action="append", default=[], help="Additional required variable env var name")
+    parser = argparse.ArgumentParser(
+        description="Validate required quality-gate secrets/variables are configured."
+    )
+    parser.add_argument(
+        "--required-secret",
+        action="append",
+        default=[],
+        help="Additional required secret env var name",
+    )
+    parser.add_argument(
+        "--required-var",
+        action="append",
+        default=[],
+        help="Additional required variable env var name",
+    )
     parser.add_argument(
         "--strict",
         action="store_true",
         help="Fail when required secrets/vars are missing. Default mode only reports missing items.",
     )
-    parser.add_argument("--out-json", default="quality-secrets/secrets.json", help="Output JSON path")
-    parser.add_argument("--out-md", default="quality-secrets/secrets.md", help="Output markdown path")
+    parser.add_argument(
+        "--out-json", default="quality-secrets/secrets.json", help="Output JSON path"
+    )
+    parser.add_argument(
+        "--out-md", default="quality-secrets/secrets.md", help="Output markdown path"
+    )
     return parser.parse_args()
 
 
@@ -68,7 +84,9 @@ def _partition_required(names: List[str]) -> Tuple[List[str], List[str]]:
     return missing, present
 
 
-def evaluate_env(required_secrets: List[str], required_vars: List[str]) -> Dict[str, List[str]]:
+def evaluate_env(
+    required_secrets: List[str], required_vars: List[str]
+) -> Dict[str, List[str]]:
     missing_secrets, present_secrets = _partition_required(required_secrets)
     missing_vars, present_vars = _partition_required(required_vars)
     return {
@@ -108,7 +126,9 @@ def _render_md(payload: dict) -> str:
 def main() -> int:
     args = _parse_args()
 
-    required_secrets = _dedupe(DEFAULT_REQUIRED_SECRETS + list(args.required_secret or []))
+    required_secrets = _dedupe(
+        DEFAULT_REQUIRED_SECRETS + list(args.required_secret or [])
+    )
     required_vars = _dedupe(DEFAULT_REQUIRED_VARS + list(args.required_var or []))
 
     result = evaluate_env(required_secrets, required_vars)
@@ -124,8 +144,12 @@ def main() -> int:
     }
 
     try:
-        out_json = safe_output_path_in_workspace(args.out_json, "quality-secrets/secrets.json")
-        out_md = safe_output_path_in_workspace(args.out_md, "quality-secrets/secrets.md")
+        out_json = safe_output_path_in_workspace(
+            args.out_json, "quality-secrets/secrets.json"
+        )
+        out_md = safe_output_path_in_workspace(
+            args.out_md, "quality-secrets/secrets.md"
+        )
     except ValueError as exc:
         print(str(exc), file=sys.stderr)
         return 1
@@ -133,7 +157,9 @@ def main() -> int:
     out_json.parent.mkdir(parents=True, exist_ok=True)
     out_md.parent.mkdir(parents=True, exist_ok=True)
 
-    out_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_json.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
     out_md.write_text(_render_md(payload), encoding="utf-8")
     print(out_md.read_text(encoding="utf-8"), end="")
 

--- a/scripts/quality/check_required_checks.py
+++ b/scripts/quality/check_required_checks.py
@@ -42,8 +42,7 @@ def _parse_args() -> argparse.Namespace:
     """Parse command-line arguments for the required-checks gate."""
     parser = argparse.ArgumentParser(
         description=(
-            "Wait for required GitHub check contexts and assert they are"
-            " successful."
+            "Wait for required GitHub check contexts and assert they are successful."
         )
     )
     parser.add_argument("--repo", required=True, help="owner/repo")

--- a/scripts/quality/check_sentry_zero.py
+++ b/scripts/quality/check_sentry_zero.py
@@ -14,7 +14,11 @@ from pathlib import Path
 from typing import Any, Dict, List, Mapping, Tuple
 
 _SCRIPT_DIR = Path(__file__).resolve().parent
-_HELPER_ROOT = _SCRIPT_DIR if os.path.exists(_SCRIPT_DIR / "security_helpers.py") else _SCRIPT_DIR.parent
+_HELPER_ROOT = (
+    _SCRIPT_DIR
+    if os.path.exists(_SCRIPT_DIR / "security_helpers.py")
+    else _SCRIPT_DIR.parent
+)
 if str(_HELPER_ROOT) not in sys.path:
     sys.path.insert(0, str(_HELPER_ROOT))
 
@@ -36,21 +40,35 @@ class SentryScanRequest:
 
 
 def _parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Assert Sentry has zero unresolved issues for configured projects.")
-    parser.add_argument("--org", default="", help="Sentry org slug (falls back to SENTRY_ORG env)")
+    parser = argparse.ArgumentParser(
+        description="Assert Sentry has zero unresolved issues for configured projects."
+    )
+    parser.add_argument(
+        "--org", default="", help="Sentry org slug (falls back to SENTRY_ORG env)"
+    )
     parser.add_argument(
         "--project",
         action="append",
         default=[],
         help="Project slug (repeatable, falls back to SENTRY_PROJECT_BACKEND/SENTRY_PROJECT_WEB env)",
     )
-    parser.add_argument("--token", default="", help="Sentry auth token (falls back to SENTRY_AUTH_TOKEN env)")
-    parser.add_argument("--out-json", default="sentry-zero/sentry.json", help="Output JSON path")
-    parser.add_argument("--out-md", default="sentry-zero/sentry.md", help="Output markdown path")
+    parser.add_argument(
+        "--token",
+        default="",
+        help="Sentry auth token (falls back to SENTRY_AUTH_TOKEN env)",
+    )
+    parser.add_argument(
+        "--out-json", default="sentry-zero/sentry.json", help="Output JSON path"
+    )
+    parser.add_argument(
+        "--out-md", default="sentry-zero/sentry.md", help="Output markdown path"
+    )
     return parser.parse_args()
 
 
-def _request_project_issues(org: str, project: str, token: str) -> Tuple[List[Any], Dict[str, str]]:
+def _request_project_issues(
+    org: str, project: str, token: str
+) -> Tuple[List[Any], Dict[str, str]]:
     org_slug = encode_identifier(org, field_name="Sentry org")
     project_slug = encode_identifier(project, field_name="Sentry project")
     payload, headers = request_json_https(
@@ -99,7 +117,9 @@ def _missing_config_findings(token: str, org: str, projects: List[str]) -> List[
     if not org:
         findings.append("SENTRY_ORG is missing.")
     if not projects:
-        findings.append("No Sentry projects configured (SENTRY_PROJECT_BACKEND/SENTRY_PROJECT_WEB).")
+        findings.append(
+            "No Sentry projects configured (SENTRY_PROJECT_BACKEND/SENTRY_PROJECT_WEB)."
+        )
     return findings
 
 
@@ -123,12 +143,18 @@ def _coerce_scan_request(*args: Any, **kwargs: Any) -> SentryScanRequest:
     if args:
         if len(args) == 1 and isinstance(args[0], SentryScanRequest):
             if kwargs:
-                raise TypeError("Pass either a request object or keyword arguments, not both.")
+                raise TypeError(
+                    "Pass either a request object or keyword arguments, not both."
+                )
             return args[0]
         if len(args) == 3 and not kwargs:
             org, projects, token = args
-            return SentryScanRequest(org=str(org), projects=list(projects), token=str(token))
-        raise TypeError("Pass a request object or keyword arguments, not positional arguments.")
+            return SentryScanRequest(
+                org=str(org), projects=list(projects), token=str(token)
+            )
+        raise TypeError(
+            "Pass a request object or keyword arguments, not positional arguments."
+        )
     return SentryScanRequest(
         org=str(kwargs.pop("org")),
         projects=list(kwargs.pop("projects")),
@@ -136,7 +162,9 @@ def _coerce_scan_request(*args: Any, **kwargs: Any) -> SentryScanRequest:
     )
 
 
-def _scan_projects(*args: Any, **kwargs: Any) -> Tuple[str, List[Dict[str, Any]], List[str], List[str]]:
+def _scan_projects(
+    *args: Any, **kwargs: Any
+) -> Tuple[str, List[Dict[str, Any]], List[str], List[str]]:
     request = _coerce_scan_request(*args, **kwargs)
     mode = "strict"
     project_results: List[Dict[str, Any]] = []
@@ -145,20 +173,32 @@ def _scan_projects(*args: Any, **kwargs: Any) -> Tuple[str, List[Dict[str, Any]]
 
     for project in request.projects:
         try:
-            issues, headers = _request_project_issues(request.org, project, request.token)
+            issues, headers = _request_project_issues(
+                request.org, project, request.token
+            )
             unresolved = _resolve_unresolved_count(issues, headers, project, failures)
             if unresolved != 0:
-                failures.append(f"Sentry project {project} has {unresolved} unresolved issues (expected 0).")
+                failures.append(
+                    f"Sentry project {project} has {unresolved} unresolved issues (expected 0)."
+                )
             project_results.append({"project": project, "unresolved": unresolved})
         except urllib.error.HTTPError as exc:
             if exc.code == 404:
                 mode = "skipped"
-                findings.append(f"Sentry project {project} not found (HTTP 404). Skipping project.")
+                findings.append(
+                    f"Sentry project {project} not found (HTTP 404). Skipping project."
+                )
                 continue
-            failures.append(f"Sentry API request failed for project {project}: HTTP {exc.code}")
+            failures.append(
+                f"Sentry API request failed for project {project}: HTTP {exc.code}"
+            )
             mode = "error"
             break
-        except (OSError, ValueError, RuntimeError) as exc:  # pragma: no cover - network/runtime surface
+        except (
+            OSError,
+            ValueError,
+            RuntimeError,
+        ) as exc:  # pragma: no cover - network/runtime surface
             failures.append(f"Sentry API request failed for project {project}: {exc}")
             mode = "error"
             break
@@ -208,7 +248,9 @@ def main() -> int:
         status = "pass"
         mode = "skipped"
     else:
-        mode, project_results, runtime_findings, failures = _scan_projects(org=org, projects=projects, token=token)
+        mode, project_results, runtime_findings, failures = _scan_projects(
+            org=org, projects=projects, token=token
+        )
         findings.extend(runtime_findings)
         findings.extend(failures)
         status = "pass" if not failures else "fail"
@@ -223,7 +265,9 @@ def main() -> int:
     }
 
     try:
-        out_json = safe_output_path_in_workspace(args.out_json, "sentry-zero/sentry.json")
+        out_json = safe_output_path_in_workspace(
+            args.out_json, "sentry-zero/sentry.json"
+        )
         out_md = safe_output_path_in_workspace(args.out_md, "sentry-zero/sentry.md")
     except ValueError as exc:
         print(str(exc), file=sys.stderr)

--- a/scripts/quality/check_sonar_zero.py
+++ b/scripts/quality/check_sonar_zero.py
@@ -11,9 +11,17 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Tuple
 
 try:
-    from ._security_imports import normalize_https_url, request_json_https, safe_output_path_in_workspace
+    from ._security_imports import (
+        normalize_https_url,
+        request_json_https,
+        safe_output_path_in_workspace,
+    )
 except ImportError:  # pragma: no cover - direct script execution
-    from _security_imports import normalize_https_url, request_json_https, safe_output_path_in_workspace
+    from _security_imports import (
+        normalize_https_url,
+        request_json_https,
+        safe_output_path_in_workspace,
+    )
 
 SONAR_API_HOST = "sonarcloud.io"
 SONAR_API_BASE = f"https://{SONAR_API_HOST}"
@@ -24,11 +32,17 @@ def _parse_args() -> argparse.Namespace:
         description="Assert SonarCloud has zero open issues and zero open security hotspots."
     )
     parser.add_argument("--project-key", required=True, help="Sonar project key")
-    parser.add_argument("--token", default="", help="Sonar token (falls back to SONAR_TOKEN env)")
+    parser.add_argument(
+        "--token", default="", help="Sonar token (falls back to SONAR_TOKEN env)"
+    )
     parser.add_argument("--branch", default="", help="Optional branch scope")
     parser.add_argument("--pull-request", default="", help="Optional PR scope")
-    parser.add_argument("--out-json", default="sonar-zero/sonar.json", help="Output JSON path")
-    parser.add_argument("--out-md", default="sonar-zero/sonar.md", help="Output markdown path")
+    parser.add_argument(
+        "--out-json", default="sonar-zero/sonar.json", help="Output JSON path"
+    )
+    parser.add_argument(
+        "--out-md", default="sonar-zero/sonar.md", help="Output markdown path"
+    )
     return parser.parse_args()
 
 
@@ -37,7 +51,9 @@ def _auth_header(token: str) -> str:
     return "Basic " + base64.b64encode(raw).decode("ascii")
 
 
-def _request_json(*, path: str, query: Dict[str, str], auth_header: str) -> Dict[str, Any]:
+def _request_json(
+    *, path: str, query: Dict[str, str], auth_header: str
+) -> Dict[str, Any]:
     payload, _headers = request_json_https(
         host=SONAR_API_HOST,
         path=path,
@@ -54,7 +70,9 @@ def _request_json(*, path: str, query: Dict[str, str], auth_header: str) -> Dict
     return payload
 
 
-def _build_issue_query(project_key: str, *, branch: str, pull_request: str) -> Dict[str, str]:
+def _build_issue_query(
+    project_key: str, *, branch: str, pull_request: str
+) -> Dict[str, str]:
     query = {
         "componentKeys": project_key,
         "resolved": "false",
@@ -67,7 +85,9 @@ def _build_issue_query(project_key: str, *, branch: str, pull_request: str) -> D
     return query
 
 
-def _build_quality_gate_query(project_key: str, *, branch: str, pull_request: str) -> dict:
+def _build_quality_gate_query(
+    project_key: str, *, branch: str, pull_request: str
+) -> dict:
     query = {"projectKey": project_key}
     if pull_request:
         query["pullRequest"] = pull_request
@@ -76,7 +96,9 @@ def _build_quality_gate_query(project_key: str, *, branch: str, pull_request: st
     return query
 
 
-def _build_hotspot_query(project_key: str, *, branch: str, pull_request: str) -> Dict[str, str]:
+def _build_hotspot_query(
+    project_key: str, *, branch: str, pull_request: str
+) -> Dict[str, str]:
     query = {
         "projectKey": project_key,
         "status": "TO_REVIEW",
@@ -105,14 +127,20 @@ def _fetch_sonar_status(
 
     gate_payload = _request_json(
         path="/api/qualitygates/project_status",
-        query=_build_quality_gate_query(project_key, branch=branch, pull_request=pull_request),
+        query=_build_quality_gate_query(
+            project_key, branch=branch, pull_request=pull_request
+        ),
         auth_header=auth_header,
     )
-    quality_gate = str((gate_payload.get("projectStatus") or {}).get("status") or "UNKNOWN")
+    quality_gate = str(
+        (gate_payload.get("projectStatus") or {}).get("status") or "UNKNOWN"
+    )
 
     hotspots_payload = _request_json(
         path="/api/hotspots/search",
-        query=_build_hotspot_query(project_key, branch=branch, pull_request=pull_request),
+        query=_build_hotspot_query(
+            project_key, branch=branch, pull_request=pull_request
+        ),
         auth_header=auth_header,
     )
     open_hotspots = int((hotspots_payload.get("paging") or {}).get("total") or 0)
@@ -134,7 +162,13 @@ def _evaluate_sonar(
     quality_gate_warning: str | None = None
 
     if not token:
-        return open_issues, quality_gate, open_hotspots, quality_gate_warning, ["SONAR_TOKEN is missing."]
+        return (
+            open_issues,
+            quality_gate,
+            open_hotspots,
+            quality_gate_warning,
+            ["SONAR_TOKEN is missing."],
+        )
 
     try:
         open_issues, quality_gate, open_hotspots = _fetch_sonar_status(
@@ -143,13 +177,25 @@ def _evaluate_sonar(
             branch=branch,
             pull_request=pull_request,
         )
-    except (urllib.error.URLError, RuntimeError, ValueError) as exc:  # pragma: no cover - network/runtime surface
-        return open_issues, quality_gate, open_hotspots, quality_gate_warning, [f"Sonar API request failed: {exc}"]
+    except (
+        urllib.error.URLError,
+        RuntimeError,
+        ValueError,
+    ) as exc:  # pragma: no cover - network/runtime surface
+        return (
+            open_issues,
+            quality_gate,
+            open_hotspots,
+            quality_gate_warning,
+            [f"Sonar API request failed: {exc}"],
+        )
 
     if open_issues != 0:
         findings.append(f"Sonar reports {open_issues} open issues (expected 0).")
     if open_hotspots != 0:
-        findings.append(f"Sonar reports {open_hotspots} open security hotspots pending review (expected 0).")
+        findings.append(
+            f"Sonar reports {open_hotspots} open security hotspots pending review (expected 0)."
+        )
     if quality_gate != "OK":
         quality_gate_warning = (
             f"Sonar quality gate status is {quality_gate}; "
@@ -189,11 +235,13 @@ def main() -> int:
     args = _parse_args()
     token = (args.token or os.environ.get("SONAR_TOKEN", "")).strip()
 
-    open_issues, quality_gate, open_hotspots, quality_gate_warning, findings = _evaluate_sonar(
-        token=token,
-        project_key=args.project_key,
-        branch=args.branch,
-        pull_request=args.pull_request,
+    open_issues, quality_gate, open_hotspots, quality_gate_warning, findings = (
+        _evaluate_sonar(
+            token=token,
+            project_key=args.project_key,
+            branch=args.branch,
+            pull_request=args.pull_request,
+        )
     )
 
     status = "pass" if not findings else "fail"
@@ -206,7 +254,9 @@ def main() -> int:
         "quality_gate_warning": quality_gate_warning,
         "timestamp_utc": datetime.now(timezone.utc).isoformat(),
         "findings": findings,
-        "api_base": normalize_https_url(SONAR_API_BASE, allowed_hosts={SONAR_API_HOST}).rstrip("/"),
+        "api_base": normalize_https_url(
+            SONAR_API_BASE, allowed_hosts={SONAR_API_HOST}
+        ).rstrip("/"),
     }
 
     try:
@@ -218,7 +268,9 @@ def main() -> int:
 
     out_json.parent.mkdir(parents=True, exist_ok=True)
     out_md.parent.mkdir(parents=True, exist_ok=True)
-    out_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_json.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
     out_md.write_text(_render_md(payload), encoding="utf-8")
     print(out_md.read_text(encoding="utf-8"), end="")
     return 0 if status == "pass" else 1

--- a/scripts/security_helpers.py
+++ b/scripts/security_helpers.py
@@ -73,8 +73,7 @@ def _normalized_hosts(values: Optional[Set[str]]) -> Set[str]:
 def _hostname_matches_suffix(hostname: str, suffixes: Set[str]) -> bool:
     """Return whether the hostname matches any allowed suffix entry."""
     return any(
-        hostname == suffix or hostname.endswith(f".{suffix}")
-        for suffix in suffixes
+        hostname == suffix or hostname.endswith(f".{suffix}") for suffix in suffixes
     )
 
 
@@ -242,9 +241,7 @@ def _read_https_error(
 ) -> Tuple[int, str, str, Dict[str, str]]:
     """Read an HTTPS error response into normalized primitives."""
     raw_body = (
-        exc.read().decode("utf-8", errors="replace")
-        if exc.fp is not None
-        else ""
+        exc.read().decode("utf-8", errors="replace") if exc.fp is not None else ""
     )
     error_headers = tuple(exc.headers.items()) if exc.headers else ()
     response_headers = {str(k).lower(): str(v) for k, v in error_headers}

--- a/tests/_gui_controller_fixtures.py
+++ b/tests/_gui_controller_fixtures.py
@@ -210,7 +210,9 @@ class _Harness(EnvInspectorController):
         """Handle  load boot state."""
         return PersistedUiState(context="linux"), Path.cwd()
 
-    def _initialize_view(self, _tk: Any, _ttk: Any, _boot_state: PersistedUiState) -> None:
+    def _initialize_view(
+        self, _tk: Any, _ttk: Any, _boot_state: PersistedUiState
+    ) -> None:
         """Handle  initialize view."""
         self.view = cast(Any, _MockView())
 

--- a/tests/test_backup_and_audit.py
+++ b/tests/test_backup_and_audit.py
@@ -12,6 +12,7 @@ from env_inspector_core.service import EnvInspectorService
 
 from tests.assertions import ensure
 
+
 def test_backup_manager_retention_and_restore(tmp_path: Path):
     mgr = BackupManager(tmp_path, retention=2)
     target = "dotenv:/tmp/.env"
@@ -29,7 +30,10 @@ def test_backup_manager_retention_and_restore(tmp_path: Path):
     restored = mgr.restore_text(p2)
     ensure(restored == "A=2\n")
 
-def test_backup_manager_uses_unique_path_when_timestamp_collides(tmp_path: Path, monkeypatch):
+
+def test_backup_manager_uses_unique_path_when_timestamp_collides(
+    tmp_path: Path, monkeypatch
+):
     fixed_time = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
 
     class _FixedDateTime(datetime):
@@ -53,7 +57,10 @@ def test_backup_manager_uses_unique_path_when_timestamp_collides(tmp_path: Path,
     ensure(p2.name.endswith("-0001.backup.json"))
     ensure(p3.name.endswith("-0002.backup.json"))
 
-def test_next_backup_path_raises_when_timestamp_sequence_exhausted(tmp_path: Path, monkeypatch):
+
+def test_next_backup_path_raises_when_timestamp_sequence_exhausted(
+    tmp_path: Path, monkeypatch
+):
     fixed_time = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
 
     class _FixedDateTime(datetime):
@@ -76,8 +83,11 @@ def test_next_backup_path_raises_when_timestamp_sequence_exhausted(tmp_path: Pat
     monkeypatch.setattr(storage_mod, "_path_exists", _always_exists)
     ensure(storage_mod._path_exists(tmp_path))
 
-    with pytest.raises(RuntimeError, match="Could not allocate unique backup file name"):
+    with pytest.raises(
+        RuntimeError, match="Could not allocate unique backup file name"
+    ):
         mgr._next_backup_path()
+
 
 def test_normalize_backup_path_rejects_escape(tmp_path: Path):
     mgr = BackupManager(tmp_path / "backups", retention=5)
@@ -86,12 +96,14 @@ def test_normalize_backup_path_rejects_escape(tmp_path: Path):
     with pytest.raises(ValueError, match="escapes backup root"):
         mgr._normalize_backup_path(outside)
 
+
 def test_load_backup_payload_returns_none_for_invalid_json(tmp_path: Path):
     mgr = BackupManager(tmp_path, retention=5)
     bad = tmp_path / "bad.backup.json"
     bad.write_text("{not valid json", encoding="utf-8")
 
     ensure(mgr._load_backup_payload(bad) is None)
+
 
 def test_audit_logger_writes_masked_values(tmp_path: Path):
     logger = AuditLogger(tmp_path)
@@ -112,16 +124,23 @@ def test_audit_logger_writes_masked_values(tmp_path: Path):
     ensure("op-1" in text)
     ensure("abc********xyz" in text)
 
-def test_restore_rejects_backup_file_outside_state_directory(tmp_path: Path, monkeypatch):
+
+def test_restore_rejects_backup_file_outside_state_directory(
+    tmp_path: Path, monkeypatch
+):
     monkeypatch.chdir(tmp_path)
     svc = EnvInspectorService(state_dir=tmp_path / "state")
     external_backup = tmp_path / "external.backup.json"
-    external_backup.write_text(json.dumps({"target": "linux:bashrc", "text": "export A='1'\n"}), encoding="utf-8")
+    external_backup.write_text(
+        json.dumps({"target": "linux:bashrc", "text": "export A='1'\n"}),
+        encoding="utf-8",
+    )
 
     result = svc.restore_backup(backup=str(external_backup))
 
     ensure(result["success"] is False)
     ensure("outside managed backup directory" in (result["error_message"] or ""))
+
 
 def test_restore_dotenv_backup_in_scope_writes_file(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
@@ -136,6 +155,7 @@ def test_restore_dotenv_backup_in_scope_writes_file(tmp_path: Path, monkeypatch)
 
     ensure(result["success"] is True)
     ensure(env_file.read_text(encoding="utf-8") == "A=1\n")
+
 
 def test_restore_dotenv_backup_rejects_outside_scope(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -193,8 +193,13 @@ def test_stdout_safe_rows_projects_only_exportable_fields():
 
 
 def test_run_cli_set_and_remove(capsys):
-    set_code = run_cli(["set", "--key", "A", "--value", "1", "--target", "windows:user"], service=FakeService())
-    remove_code = run_cli(["remove", "--key", "A", "--target", "windows:user"], service=FakeService())
+    set_code = run_cli(
+        ["set", "--key", "A", "--value", "1", "--target", "windows:user"],
+        service=FakeService(),
+    )
+    remove_code = run_cli(
+        ["remove", "--key", "A", "--target", "windows:user"], service=FakeService()
+    )
     case = _case()
     case.assertEqual(set_code, 0)
     case.assertEqual(remove_code, 0)
@@ -206,7 +211,16 @@ def test_run_cli_set_and_remove(capsys):
 def test_run_cli_preview_set_and_remove(capsys):
     svc = FakeService()
     set_code = run_cli(
-        ["set", "--key", "A", "--value", "1", "--target", "windows:user", "--preview-only"],
+        [
+            "set",
+            "--key",
+            "A",
+            "--value",
+            "1",
+            "--target",
+            "windows:user",
+            "--preview-only",
+        ],
         service=svc,
     )
     remove_code = run_cli(

--- a/tests/test_core_coverage_path_policy.py
+++ b/tests/test_core_coverage_path_policy.py
@@ -23,7 +23,9 @@ def test_as_raw_text_rejects_empty() -> None:
 
 
 # Line 46: normalize_scope_roots outside cwd
-def test_normalize_scope_roots_rejects_outside_cwd(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_normalize_scope_roots_rejects_outside_cwd(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     """normalize_scope_roots raises when root is outside cwd."""
     workspace = tmp_path / "workspace"
     workspace.mkdir()
@@ -35,7 +37,9 @@ def test_normalize_scope_roots_rejects_outside_cwd(monkeypatch: pytest.MonkeyPat
 
 
 # Line 48: normalize_scope_roots non-existent directory
-def test_normalize_scope_roots_rejects_nonexistent(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_normalize_scope_roots_rejects_nonexistent(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     """normalize_scope_roots raises when root does not exist."""
     monkeypatch.chdir(tmp_path)
     with pytest.raises(PathPolicyError, match="must exist as a directory"):
@@ -57,7 +61,9 @@ def test_parse_scoped_dotenv_target_rejects_non_dotenv_prefix(tmp_path: Path) ->
 
 
 # parse_scoped_dotenv_target outside scope
-def test_parse_scoped_dotenv_target_rejects_outside_roots(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_parse_scoped_dotenv_target_rejects_outside_roots(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     """parse_scoped_dotenv_target raises when path is outside approved roots."""
     monkeypatch.chdir(tmp_path)
     allowed = tmp_path / "allowed"
@@ -72,7 +78,9 @@ def test_parse_scoped_dotenv_target_rejects_outside_roots(monkeypatch: pytest.Mo
 
 
 # Line 108: validate_backup_path non-existent file
-def test_validate_backup_path_rejects_nonexistent(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_validate_backup_path_rejects_nonexistent(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     """validate_backup_path raises when backup file does not exist."""
     monkeypatch.chdir(tmp_path)
     backups_dir = tmp_path / "backups"

--- a/tests/test_core_coverage_providers.py
+++ b/tests/test_core_coverage_providers.py
@@ -29,14 +29,19 @@ def _case() -> unittest.TestCase:
 # _require_winreg (lines 70-72)
 # ---------------------------------------------------------------------------
 
+
 def test_require_winreg_raises_when_none(monkeypatch: pytest.MonkeyPatch) -> None:
     """_require_winreg raises RuntimeError when winreg is None."""
     monkeypatch.setattr(providers, "_winreg", None)
-    with pytest.raises(RuntimeError, match="Windows registry provider only available on Windows"):
+    with pytest.raises(
+        RuntimeError, match="Windows registry provider only available on Windows"
+    ):
         providers._require_winreg()
 
 
-def test_require_winreg_returns_module_when_present(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_require_winreg_returns_module_when_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """_require_winreg returns the module when it is not None."""
     fake = types.SimpleNamespace()
     monkeypatch.setattr(providers, "_winreg", fake)
@@ -48,7 +53,10 @@ def test_require_winreg_returns_module_when_present(monkeypatch: pytest.MonkeyPa
 # Already tested for non-Windows, but we need the Windows+winreg path.
 # ---------------------------------------------------------------------------
 
-def test_windows_registry_provider_init_succeeds_on_windows(monkeypatch: pytest.MonkeyPatch) -> None:
+
+def test_windows_registry_provider_init_succeeds_on_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """WindowsRegistryProvider init succeeds when is_windows() and _winreg are both truthy."""
     monkeypatch.setattr(providers, "is_windows", lambda: True)
     fake_winreg = types.SimpleNamespace()
@@ -60,6 +68,7 @@ def test_windows_registry_provider_init_succeeds_on_windows(monkeypatch: pytest.
 # ---------------------------------------------------------------------------
 # WindowsRegistryProvider._scope_details (lines 169-181)
 # ---------------------------------------------------------------------------
+
 
 def _make_fake_winreg() -> types.SimpleNamespace:
     """Build a fake winreg module with all needed attributes."""
@@ -84,7 +93,9 @@ def test_scope_details_user_scope(monkeypatch: pytest.MonkeyPatch) -> None:
     fake_winreg = _make_fake_winreg()
     monkeypatch.setattr(providers, "_winreg", fake_winreg)
 
-    root, path, access = providers.WindowsRegistryProvider._scope_details("User", fake_winreg.KEY_READ)
+    root, path, access = providers.WindowsRegistryProvider._scope_details(
+        "User", fake_winreg.KEY_READ
+    )
     ensure(root == "HKCU")
     ensure(path == r"Environment")
     ensure(access == fake_winreg.KEY_READ)
@@ -95,7 +106,9 @@ def test_scope_details_machine_scope(monkeypatch: pytest.MonkeyPatch) -> None:
     fake_winreg = _make_fake_winreg()
     monkeypatch.setattr(providers, "_winreg", fake_winreg)
 
-    root, path, access = providers.WindowsRegistryProvider._scope_details("Machine", fake_winreg.KEY_READ)
+    root, path, access = providers.WindowsRegistryProvider._scope_details(
+        "Machine", fake_winreg.KEY_READ
+    )
     ensure(root == "HKLM")
     ensure("Session Manager" in path)
     ensure(access == (fake_winreg.KEY_READ | fake_winreg.KEY_WOW64_64KEY))
@@ -114,6 +127,7 @@ def test_scope_details_invalid_scope(monkeypatch: pytest.MonkeyPatch) -> None:
 # WindowsRegistryProvider._scope_to_key (line 186)
 # ---------------------------------------------------------------------------
 
+
 def test_scope_to_key_returns_root_and_path(monkeypatch: pytest.MonkeyPatch) -> None:
     """_scope_to_key returns (root, path) for a valid scope."""
     fake_winreg = _make_fake_winreg()
@@ -128,6 +142,7 @@ def test_scope_to_key_returns_root_and_path(monkeypatch: pytest.MonkeyPatch) -> 
 # WindowsRegistryProvider.list_scope (lines 189-197)
 # ---------------------------------------------------------------------------
 
+
 def test_list_scope_returns_registry_values(monkeypatch: pytest.MonkeyPatch) -> None:
     """list_scope reads values from the fake registry."""
     fake_winreg = _make_fake_winreg()
@@ -140,10 +155,12 @@ def test_list_scope_returns_registry_values(monkeypatch: pytest.MonkeyPatch) -> 
     mock_key.__enter__ = MagicMock(return_value=mock_key)
     mock_key.__exit__ = MagicMock(return_value=False)
     fake_winreg.QueryInfoKey = MagicMock(return_value=(0, 2, 0))
-    fake_winreg.EnumValue = MagicMock(side_effect=[
-        ("PATH", "C:\\Windows", 1),
-        ("HOME", "C:\\Users\\test", 1),
-    ])
+    fake_winreg.EnumValue = MagicMock(
+        side_effect=[
+            ("PATH", "C:\\Windows", 1),
+            ("HOME", "C:\\Users\\test", 1),
+        ]
+    )
 
     provider = providers.WindowsRegistryProvider()
     result = provider.list_scope("User")
@@ -153,6 +170,7 @@ def test_list_scope_returns_registry_values(monkeypatch: pytest.MonkeyPatch) -> 
 # ---------------------------------------------------------------------------
 # WindowsRegistryProvider.set_scope_value (lines 200-204)
 # ---------------------------------------------------------------------------
+
 
 def test_set_scope_value_reg_sz(monkeypatch: pytest.MonkeyPatch) -> None:
     """set_scope_value uses REG_SZ for values without %."""
@@ -167,7 +185,9 @@ def test_set_scope_value_reg_sz(monkeypatch: pytest.MonkeyPatch) -> None:
 
     provider = providers.WindowsRegistryProvider()
     provider.set_scope_value("User", "MY_KEY", "my_value")
-    fake_winreg.SetValueEx.assert_called_once_with(mock_key, "MY_KEY", 0, fake_winreg.REG_SZ, "my_value")
+    fake_winreg.SetValueEx.assert_called_once_with(
+        mock_key, "MY_KEY", 0, fake_winreg.REG_SZ, "my_value"
+    )
 
 
 def test_set_scope_value_reg_expand_sz(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -183,12 +203,15 @@ def test_set_scope_value_reg_expand_sz(monkeypatch: pytest.MonkeyPatch) -> None:
 
     provider = providers.WindowsRegistryProvider()
     provider.set_scope_value("User", "PATH", "%SystemRoot%\\bin")
-    fake_winreg.SetValueEx.assert_called_once_with(mock_key, "PATH", 0, fake_winreg.REG_EXPAND_SZ, "%SystemRoot%\\bin")
+    fake_winreg.SetValueEx.assert_called_once_with(
+        mock_key, "PATH", 0, fake_winreg.REG_EXPAND_SZ, "%SystemRoot%\\bin"
+    )
 
 
 # ---------------------------------------------------------------------------
 # WindowsRegistryProvider.remove_scope_value (lines 207-211)
 # ---------------------------------------------------------------------------
+
 
 def test_remove_scope_value_deletes_key(monkeypatch: pytest.MonkeyPatch) -> None:
     """remove_scope_value calls DeleteValue on the registry key."""
@@ -206,7 +229,9 @@ def test_remove_scope_value_deletes_key(monkeypatch: pytest.MonkeyPatch) -> None
     fake_winreg.DeleteValue.assert_called_once_with(mock_key, "MY_KEY")
 
 
-def test_remove_scope_value_suppresses_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_remove_scope_value_suppresses_not_found(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """remove_scope_value suppresses FileNotFoundError."""
     fake_winreg = _make_fake_winreg()
     monkeypatch.setattr(providers, "_winreg", fake_winreg)
@@ -227,7 +252,10 @@ def test_remove_scope_value_suppresses_not_found(monkeypatch: pytest.MonkeyPatch
 # build_registry_records (lines 215-252)
 # ---------------------------------------------------------------------------
 
-def test_build_registry_records_creates_records(monkeypatch: pytest.MonkeyPatch) -> None:
+
+def test_build_registry_records_creates_records(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """build_registry_records creates EnvRecord entries from both User and Machine scopes."""
     fake_winreg = _make_fake_winreg()
     monkeypatch.setattr(providers, "_winreg", fake_winreg)
@@ -258,7 +286,10 @@ def test_build_registry_records_creates_records(monkeypatch: pytest.MonkeyPatch)
 # collect_dotenv_records UnicodeDecodeError branch (lines 295-296)
 # ---------------------------------------------------------------------------
 
-def test_collect_dotenv_records_falls_back_to_latin1(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+
+def test_collect_dotenv_records_falls_back_to_latin1(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     """collect_dotenv_records falls back to latin-1 when UTF-8 decoding fails."""
     monkeypatch.chdir(tmp_path)
     env_file = tmp_path / ".env"
@@ -278,6 +309,7 @@ def test_collect_dotenv_records_falls_back_to_latin1(monkeypatch: pytest.MonkeyP
 # collect_powershell_profile_records (lines 319-343)
 # ---------------------------------------------------------------------------
 
+
 def test_collect_powershell_profile_records_reads_profiles(tmp_path: Path) -> None:
     """collect_powershell_profile_records reads PS profiles and builds records."""
     profile = tmp_path / "profile.ps1"
@@ -292,7 +324,9 @@ def test_collect_powershell_profile_records_reads_profiles(tmp_path: Path) -> No
     case.assertFalse(records[0].requires_privilege)
 
 
-def test_collect_powershell_profile_records_requires_privilege_for_program_files(tmp_path: Path) -> None:
+def test_collect_powershell_profile_records_requires_privilege_for_program_files(
+    tmp_path: Path,
+) -> None:
     """collect_powershell_profile_records sets requires_privilege for 'program files' paths."""
     program_files = tmp_path / "program files" / "powershell"
     program_files.mkdir(parents=True)
@@ -315,6 +349,7 @@ def test_collect_powershell_profile_records_skips_missing_files(tmp_path: Path) 
 # ---------------------------------------------------------------------------
 # collect_linux_records (lines 346-383 — exercises the Linux provider paths)
 # ---------------------------------------------------------------------------
+
 
 def test_collect_linux_records_reads_bashrc_and_etc_environment(tmp_path: Path) -> None:
     """collect_linux_records reads both bashrc and /etc/environment when they exist."""

--- a/tests/test_core_coverage_providers_wsl.py
+++ b/tests/test_core_coverage_providers_wsl.py
@@ -32,7 +32,9 @@ def _case() -> unittest.TestCase:
 
 
 # Line 41: _discover_wsl_exe returns None or shutil.which fallback
-def test_discover_wsl_exe_returns_none_when_no_candidates(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_discover_wsl_exe_returns_none_when_no_candidates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """_discover_wsl_exe returns None when no wsl.exe candidates exist."""
     monkeypatch.delenv("SystemRoot", raising=False)
     monkeypatch.setattr("shutil.which", lambda _name: None)
@@ -99,7 +101,8 @@ def test_list_distros_for_ui_filters_docker_distros() -> None:
 
     def _fake_runner(*args, **kwargs):
         return _CompletedProcessLike(
-            args=[], returncode=0,
+            args=[],
+            returncode=0,
             stdout=b"Ubuntu\ndocker-desktop\nDebian\ndocker-desktop-data\n",
             stderr=b"",
         )
@@ -118,7 +121,9 @@ def test_read_file_returns_content() -> None:
     """read_file runs cat command and returns the output."""
 
     def _fake_runner(*args, **kwargs):
-        return _CompletedProcessLike(args=[], returncode=0, stdout=b"file content", stderr=b"")
+        return _CompletedProcessLike(
+            args=[], returncode=0, stdout=b"file content", stderr=b""
+        )
 
     provider = WslProvider(runner=_fake_runner, wsl_exe="/fake/wsl.exe")
     provider._available_cache = True
@@ -150,7 +155,9 @@ def test_write_file_with_privilege_tries_root_then_sudo() -> None:
         nonlocal attempt
         attempt += 1
         if attempt == 1:
-            return _CompletedProcessLike(args=[], returncode=1, stdout=b"", stderr=b"root failed")
+            return _CompletedProcessLike(
+                args=[], returncode=1, stdout=b"", stderr=b"root failed"
+            )
         return _CompletedProcessLike(args=[], returncode=0, stdout=b"", stderr=b"")
 
     provider = WslProvider(runner=_fake_runner, wsl_exe="/fake/wsl.exe")
@@ -165,7 +172,8 @@ def test_scan_dotenv_files_returns_paths() -> None:
 
     def _fake_runner(*args, **kwargs):
         return _CompletedProcessLike(
-            args=[], returncode=0,
+            args=[],
+            returncode=0,
             stdout=b"/workspace/.env\n/workspace/.env.local\n",
             stderr=b"",
         )
@@ -181,7 +189,9 @@ def test_write_file_with_privilege_raises_on_both_failures() -> None:
     """write_file_with_privilege raises when both root and sudo fail."""
 
     def _fake_runner(*args, **kwargs):
-        return _CompletedProcessLike(args=[], returncode=1, stdout=b"", stderr=b"failed")
+        return _CompletedProcessLike(
+            args=[], returncode=1, stdout=b"", stderr=b"failed"
+        )
 
     provider = WslProvider(runner=_fake_runner, wsl_exe="/fake/wsl.exe")
     provider._available_cache = True

--- a/tests/test_core_coverage_remaining.py
+++ b/tests/test_core_coverage_remaining.py
@@ -12,7 +12,12 @@ import pytest
 
 from env_inspector_core.models import EnvRecord
 from env_inspector_core.resolver import resolve_effective_value
-from env_inspector_core.secrets import looks_secret, mask_value, _is_path_like, _is_base64_secret
+from env_inspector_core.secrets import (
+    looks_secret,
+    mask_value,
+    _is_path_like,
+    _is_base64_secret,
+)
 from env_inspector_core.storage import BackupManager
 
 
@@ -23,6 +28,7 @@ def _case() -> unittest.TestCase:
 # ---------------------------------------------------------------------------
 # cli.py coverage
 # ---------------------------------------------------------------------------
+
 
 def test_cli_csv_output(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """CLI list command with csv output exercises the CSV rendering path (line 156)."""
@@ -38,7 +44,9 @@ def test_cli_csv_output(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None
     captured = StringIO()
     monkeypatch.setattr(sys, "stdout", captured)
 
-    exit_code = run_cli(["list", "--output", "csv", "--root", str(tmp_path)], service=svc)
+    exit_code = run_cli(
+        ["list", "--output", "csv", "--root", str(tmp_path)], service=svc
+    )
     ensure(exit_code == 0)
     output = captured.getvalue()
     ensure("MY_VAR" in output or "context" in output)
@@ -68,7 +76,9 @@ def test_cli_table_output(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> No
     captured = StringIO()
     monkeypatch.setattr(sys, "stdout", captured)
 
-    exit_code = run_cli(["list", "--output", "table", "--root", str(tmp_path)], service=svc)
+    exit_code = run_cli(
+        ["list", "--output", "table", "--root", str(tmp_path)], service=svc
+    )
     assert exit_code == 0
     output = captured.getvalue()
     # Table output uses tabs
@@ -95,7 +105,9 @@ def test_cli_no_command_prints_help(monkeypatch: pytest.MonkeyPatch) -> None:
     assert exit_code == 0
 
 
-def test_cli_value_error_handling(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_cli_value_error_handling(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     """CLI catches ValueError and prints to stderr (lines 254-255)."""
     from env_inspector_core.cli import run_cli
     from env_inspector_core.service import EnvInspectorService
@@ -120,6 +132,7 @@ def test_cli_value_error_handling(monkeypatch: pytest.MonkeyPatch, tmp_path: Pat
 # ---------------------------------------------------------------------------
 # resolver.py coverage — line 35: linux context
 # ---------------------------------------------------------------------------
+
 
 def test_resolve_effective_value_no_candidates() -> None:
     """resolve_effective_value returns None when no records match (line 35)."""
@@ -167,6 +180,7 @@ def test_resolve_effective_value_linux_context() -> None:
 # ---------------------------------------------------------------------------
 # secrets.py coverage
 # ---------------------------------------------------------------------------
+
 
 # Line 45: looks_secret GitHub token detection
 def test_looks_secret_github_short_token() -> None:
@@ -232,6 +246,7 @@ def test_looks_secret_base64_path_not_secret() -> None:
 # models.py coverage — line 26: to_dict with include_value=False
 # ---------------------------------------------------------------------------
 
+
 def test_env_record_to_dict_excludes_value() -> None:
     """EnvRecord.to_dict(include_value=False) sets value to empty string."""
     record = EnvRecord(
@@ -256,6 +271,7 @@ def test_env_record_to_dict_excludes_value() -> None:
 # ---------------------------------------------------------------------------
 # storage.py coverage — line 75->73 branch: list_backups with non-matching target
 # ---------------------------------------------------------------------------
+
 
 def test_list_backups_filters_by_target(tmp_path: Path) -> None:
     """list_backups only returns backups matching the requested target."""

--- a/tests/test_core_coverage_service_ops_request.py
+++ b/tests/test_core_coverage_service_ops_request.py
@@ -22,14 +22,18 @@ from env_inspector_core.service_ops_request import (
 # Line 7: _raise_mixed_request_usage
 def test_raise_mixed_request_usage() -> None:
     """_raise_mixed_request_usage raises TypeError."""
-    with pytest.raises(TypeError, match="Pass either a request object or legacy arguments"):
+    with pytest.raises(
+        TypeError, match="Pass either a request object or legacy arguments"
+    ):
         _raise_mixed_request_usage()
 
 
 # Line 19: mixed usage — request kwarg with extra kwargs
 def test_extract_request_object_raises_on_mixed_kwargs() -> None:
     """_extract_request_object raises when request kwarg is mixed with other kwargs."""
-    with pytest.raises(TypeError, match="Pass either a request object or legacy arguments"):
+    with pytest.raises(
+        TypeError, match="Pass either a request object or legacy arguments"
+    ):
         _extract_request_object(
             args=(),
             kwargs={"request": object(), "extra": "bad"},
@@ -40,7 +44,9 @@ def test_extract_request_object_raises_on_mixed_kwargs() -> None:
 # Line 19: mixed usage — request kwarg with extra positional args
 def test_extract_request_object_raises_on_mixed_args() -> None:
     """_extract_request_object raises when request kwarg is mixed with positional args."""
-    with pytest.raises(TypeError, match="Pass either a request object or legacy arguments"):
+    with pytest.raises(
+        TypeError, match="Pass either a request object or legacy arguments"
+    ):
         _extract_request_object(
             args=("extra",),
             kwargs={"request": object()},
@@ -63,7 +69,11 @@ def test_extract_request_object_returns_none_for_non_request() -> None:
 def test_target_operation_batch_payload() -> None:
     """_target_operation_batch_payload extracts correct fields."""
     req = types.SimpleNamespace(
-        action="set", key="A", value="1", targets=["t1"], scope_roots=None,
+        action="set",
+        key="A",
+        value="1",
+        targets=["t1"],
+        scope_roots=None,
     )
     result = _target_operation_batch_payload(req)
     ensure(result["action"] == "set")
@@ -74,7 +84,11 @@ def test_target_operation_batch_payload() -> None:
 def test_target_operation_batch_payload_with_scope_roots() -> None:
     """_target_operation_batch_payload converts scope_roots to list."""
     req = types.SimpleNamespace(
-        action="set", key="A", value="1", targets=["t1"], scope_roots=("/root",),
+        action="set",
+        key="A",
+        value="1",
+        targets=["t1"],
+        scope_roots=("/root",),
     )
     result = _target_operation_batch_payload(req)
     ensure(result["scope_roots"] == ["/root"])
@@ -101,7 +115,10 @@ def test_normalize_target_operation_request_unexpected_kwargs() -> None:
     """normalize_target_operation_request raises on unexpected keyword arguments."""
     with pytest.raises(TypeError, match="Unexpected keyword arguments"):
         normalize_target_operation_request(
-            target="t", key="k", action="set", bogus="bad",
+            target="t",
+            key="k",
+            action="set",
+            bogus="bad",
         )
 
 
@@ -109,7 +126,11 @@ def test_normalize_target_operation_request_unexpected_kwargs() -> None:
 def test_normalize_target_operation_batch_with_request() -> None:
     """normalize_target_operation_batch accepts a request object."""
     req = types.SimpleNamespace(
-        action="set", key="A", value="1", targets=["t1"], scope_roots=None,
+        action="set",
+        key="A",
+        value="1",
+        targets=["t1"],
+        scope_roots=None,
     )
     result = normalize_target_operation_batch(req)
     assert result["action"] == "set"
@@ -121,7 +142,10 @@ def test_normalize_target_operation_batch_unexpected_kwargs() -> None:
     """normalize_target_operation_batch raises on unexpected keyword arguments."""
     with pytest.raises(TypeError, match="Unexpected keyword arguments"):
         normalize_target_operation_batch(
-            action="set", key="k", targets=["t"], bogus="bad",
+            action="set",
+            key="k",
+            targets=["t"],
+            bogus="bad",
         )
 
 

--- a/tests/test_core_coverage_service_wsl.py
+++ b/tests/test_core_coverage_service_wsl.py
@@ -72,7 +72,8 @@ def test_resolve_wsl_target_rejects_extra_args() -> None:
     """resolve_wsl_target raises TypeError with more than one positional arg."""
     with pytest.raises(TypeError, match="single positional target argument only"):
         resolve_wsl_target(
-            "wsl:Ubuntu:bashrc", "extra",
+            "wsl:Ubuntu:bashrc",
+            "extra",
             dotenv_prefix="wsl_dotenv:",
             validate_distro_name_fn=validate_wsl_distro_name,
             parse_wsl_dotenv_target_fn=lambda t: ("d", "/p"),

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -26,7 +26,9 @@ def test_main_print_secrets_rejects_invalid_root(tmp_path: Path, monkeypatch, ca
 
         def __init__(self, *args, **kwargs):  # pragma: no cover - should not be reached
             """Init."""
-            raise AssertionError("EnvInspectorService should not be created for invalid --root")
+            raise AssertionError(
+                "EnvInspectorService should not be created for invalid --root"
+            )
 
     monkeypatch.setattr(env_inspector, "EnvInspectorService", _ForbiddenService)
     monkeypatch.setattr(
@@ -43,7 +45,9 @@ def test_main_print_secrets_rejects_invalid_root(tmp_path: Path, monkeypatch, ca
     case.assertIn("Invalid --root", err)
 
 
-def test_legacy_print_secrets_uses_workspace_root_for_listing(tmp_path: Path, monkeypatch, capsys):
+def test_legacy_print_secrets_uses_workspace_root_for_listing(
+    tmp_path: Path, monkeypatch, capsys
+):
     """Legacy print-secrets should list secrets from the validated workspace root."""
     workspace = tmp_path / "workspace"
     workspace.mkdir()
@@ -56,7 +60,14 @@ def test_legacy_print_secrets_uses_workspace_root_for_listing(tmp_path: Path, mo
         """List records."""
         secret_flag = bool(1)
         captured.update(kwargs)
-        return [{"is_secret": secret_flag, "source_type": "dotenv", "source_id": ".env", "name": "API_TOKEN"}]
+        return [
+            {
+                "is_secret": secret_flag,
+                "source_type": "dotenv",
+                "source_id": ".env",
+                "name": "API_TOKEN",
+            }
+        ]
 
     class _Service:
         """Minimal service stub that returns the captured secret rows."""
@@ -75,7 +86,9 @@ def test_legacy_print_secrets_uses_workspace_root_for_listing(tmp_path: Path, mo
     case.assertIn("API_TOKEN", out)
 
 
-def test_legacy_print_secrets_skips_non_secret_rows(tmp_path: Path, monkeypatch, capsys):
+def test_legacy_print_secrets_skips_non_secret_rows(
+    tmp_path: Path, monkeypatch, capsys
+):
     """Legacy print-secrets should not emit rows that are not marked as secrets."""
     workspace = tmp_path / "workspace"
     workspace.mkdir()
@@ -84,7 +97,14 @@ def test_legacy_print_secrets_skips_non_secret_rows(tmp_path: Path, monkeypatch,
 
     def _list_records(**_kwargs):
         """List records."""
-        return [{"is_secret": False, "source_type": "dotenv", "source_id": ".env", "name": "PUBLIC_VAR"}]
+        return [
+            {
+                "is_secret": False,
+                "source_type": "dotenv",
+                "source_id": ".env",
+                "name": "PUBLIC_VAR",
+            }
+        ]
 
     class _Service:
         """Minimal service stub that only yields non-secret rows."""
@@ -100,7 +120,9 @@ def test_legacy_print_secrets_skips_non_secret_rows(tmp_path: Path, monkeypatch,
     case.assertEqual(capsys.readouterr().out, "")
 
 
-def test_legacy_print_secrets_rejects_nested_subdirectory_root(tmp_path: Path, monkeypatch, capsys):
+def test_legacy_print_secrets_rejects_nested_subdirectory_root(
+    tmp_path: Path, monkeypatch, capsys
+):
     """Legacy print-secrets should reject nested roots even when they are under the workspace."""
     workspace = tmp_path / "workspace"
     nested = workspace / "nested"
@@ -113,7 +135,9 @@ def test_legacy_print_secrets_rejects_nested_subdirectory_root(tmp_path: Path, m
 
         def __init__(self, *args, **kwargs):  # pragma: no cover - should not be reached
             """Init."""
-            raise AssertionError("EnvInspectorService should not be created for unsupported nested root")
+            raise AssertionError(
+                "EnvInspectorService should not be created for unsupported nested root"
+            )
 
     monkeypatch.setattr(env_inspector, "EnvInspectorService", _ForbiddenService)
 
@@ -122,10 +146,14 @@ def test_legacy_print_secrets_rejects_nested_subdirectory_root(tmp_path: Path, m
     case = _case()
     case.assertEqual(code, 2)
     err = capsys.readouterr().err
-    case.assertIn("Legacy --print-secrets only supports the current working directory.", err)
+    case.assertIn(
+        "Legacy --print-secrets only supports the current working directory.", err
+    )
 
 
-def test_resolve_legacy_print_secrets_root_does_not_renormalize_validated_root(tmp_path: Path, monkeypatch):
+def test_resolve_legacy_print_secrets_root_does_not_renormalize_validated_root(
+    tmp_path: Path, monkeypatch
+):
     """Validated roots should round-trip through the legacy resolver without drift."""
     workspace = (tmp_path / "workspace").resolve()
     workspace.mkdir()
@@ -141,11 +169,15 @@ def test_resolve_legacy_print_secrets_root_does_not_renormalize_validated_root(t
     monkeypatch.setattr(env_inspector, "resolve_scan_root", _validated_root)
 
     case = _case()
-    case.assertEqual(env_inspector._resolve_legacy_print_secrets_root(str(workspace)), workspace)
+    case.assertEqual(
+        env_inspector._resolve_legacy_print_secrets_root(str(workspace)), workspace
+    )
     case.assertEqual(len(calls), 2)
 
 
-def test_resolve_legacy_print_secrets_root_rejects_missing_directory(tmp_path: Path, monkeypatch):
+def test_resolve_legacy_print_secrets_root_rejects_missing_directory(
+    tmp_path: Path, monkeypatch
+):
     """Legacy secret-root resolution should fail when the requested directory is missing."""
     workspace = (tmp_path / "workspace").resolve()
     missing = workspace / "missing"

--- a/tests/test_export_masking.py
+++ b/tests/test_export_masking.py
@@ -5,6 +5,7 @@ from env_inspector_core.service import EnvInspectorService
 
 from tests.assertions import ensure
 
+
 def test_export_masks_secrets_by_default(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     env_file = tmp_path / ".env"
@@ -18,6 +19,7 @@ def test_export_masks_secrets_by_default(tmp_path: Path, monkeypatch):
         context=svc.runtime_context,
     )
     ensure("supersecretvalue" not in csv_text)
+
 
 def test_export_can_include_raw_secrets_when_opted_in(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)

--- a/tests/test_gui_controller.py
+++ b/tests/test_gui_controller.py
@@ -136,7 +136,9 @@ class _ControllerHarness(EnvInspectorController):
         """Provide a deterministic boot state for controller tests."""
         return PersistedUiState(context="linux"), Path.cwd()
 
-    def _initialize_view(self, _tk: Any, _ttk: Any, _boot_state: PersistedUiState) -> None:
+    def _initialize_view(
+        self, _tk: Any, _ttk: Any, _boot_state: PersistedUiState
+    ) -> None:
         """Install a stub view for controller bootstrap."""
         self.view = cast(Any, _BootstrapView())
 

--- a/tests/test_gui_controller_actions_coverage.py
+++ b/tests/test_gui_controller_actions_coverage.py
@@ -103,8 +103,10 @@ class _ActionTestMixin(EnvInspectorControllerActionsMixin):
 
 # --- abstract method stubs (NotImplementedError) ---
 
+
 def test_abstract_selected_row():
     import pytest
+
     mixin = EnvInspectorControllerActionsMixin()
     with pytest.raises(NotImplementedError):
         mixin._selected_row()
@@ -112,6 +114,7 @@ def test_abstract_selected_row():
 
 def test_abstract_set_status():
     import pytest
+
     mixin = EnvInspectorControllerActionsMixin()
     with pytest.raises(NotImplementedError):
         mixin._set_status("test")
@@ -119,6 +122,7 @@ def test_abstract_set_status():
 
 def test_abstract_update_effective():
     import pytest
+
     mixin = EnvInspectorControllerActionsMixin()
     with pytest.raises(NotImplementedError):
         mixin._update_effective("key")
@@ -126,12 +130,14 @@ def test_abstract_update_effective():
 
 def test_abstract_refresh_data():
     import pytest
+
     mixin = EnvInspectorControllerActionsMixin()
     with pytest.raises(NotImplementedError):
         mixin.refresh_data()
 
 
 # --- load_selected ---
+
 
 def test_load_selected_no_row():
     ctrl = _ActionTestMixin()
@@ -181,6 +187,7 @@ def test_load_selected_secret_hidden_confirm_no():
 
 # --- copy_selected_name ---
 
+
 def test_copy_selected_name_no_row():
     ctrl = _ActionTestMixin()
     ctrl.copy_selected_name()
@@ -198,6 +205,7 @@ def test_copy_selected_name():
 
 
 # --- copy_selected_value ---
+
 
 def test_copy_selected_value_no_row():
     ctrl = _ActionTestMixin()
@@ -235,6 +243,7 @@ def test_copy_selected_value_secret_shown():
 
 # --- copy_selected_pair ---
 
+
 def test_copy_selected_pair_no_row():
     ctrl = _ActionTestMixin()
     ctrl.copy_selected_pair()
@@ -261,6 +270,7 @@ def test_copy_selected_pair_secret_masked():
 
 # --- copy_selected_source_path ---
 
+
 def test_copy_selected_source_path_no_row():
     ctrl = _ActionTestMixin()
     ctrl.copy_selected_source_path()
@@ -276,6 +286,7 @@ def test_copy_selected_source_path():
 
 
 # --- open_selected_source ---
+
 
 def test_open_selected_source_no_row():
     ctrl = _ActionTestMixin()
@@ -298,12 +309,16 @@ def test_open_selected_source_success(tmp_path: Path):
     rec = _make_record(source_path=str(f))
     ctrl._selected = _make_row(rec)
 
-    with patch("env_inspector_gui.controller_actions.open_source_path", return_value=(True, None)):
+    with patch(
+        "env_inspector_gui.controller_actions.open_source_path",
+        return_value=(True, None),
+    ):
         ctrl.open_selected_source()
     ensure(any("Opened" in s for s in ctrl._status_calls))
 
 
 # --- export_records ---
+
 
 def test_export_records_json():
     ctrl = _ActionTestMixin()
@@ -355,6 +370,7 @@ def test_export_records_with_wsl_params(tmp_path: Path):
 
 # --- restore_backup ---
 
+
 def test_restore_backup_no_backups():
     ctrl = _ActionTestMixin()
     ctrl.service.list_backups = MagicMock(return_value=[])
@@ -380,7 +396,9 @@ def test_restore_backup_cancelled():
 def test_restore_backup_success():
     ctrl = _ActionTestMixin()
     ctrl.service.list_backups = MagicMock(return_value=["backup1.zip"])
-    ctrl.service.restore_backup = MagicMock(return_value={"success": True, "operation_id": "op-1"})
+    ctrl.service.restore_backup = MagicMock(
+        return_value={"success": True, "operation_id": "op-1"}
+    )
 
     with patch("env_inspector_gui.controller_actions.BackupPickerDialog") as MockDialog:
         instance = MagicMock()
@@ -397,7 +415,9 @@ def test_restore_backup_success():
 def test_restore_backup_failure():
     ctrl = _ActionTestMixin()
     ctrl.service.list_backups = MagicMock(return_value=["backup1.zip"])
-    ctrl.service.restore_backup = MagicMock(return_value={"success": False, "error_message": "corrupt"})
+    ctrl.service.restore_backup = MagicMock(
+        return_value={"success": False, "error_message": "corrupt"}
+    )
 
     with patch("env_inspector_gui.controller_actions.BackupPickerDialog") as MockDialog:
         instance = MagicMock()
@@ -412,6 +432,7 @@ def test_restore_backup_failure():
 
 # --- load_selected: secret loaded as masked (line 64 branch) ---
 
+
 def test_load_selected_secret_loaded_but_masked():
     """Line 64: record_is_secret and not raw — patched resolve_load_value returns (masked, False)."""
     ctrl = _ActionTestMixin()
@@ -419,13 +440,17 @@ def test_load_selected_secret_loaded_but_masked():
     rec = _make_record(name="TOKEN", value="secret123", is_secret=True)
     ctrl._selected = _make_row(rec)
 
-    with patch("env_inspector_gui.controller_actions.resolve_load_value", return_value=("***", False)):
+    with patch(
+        "env_inspector_gui.controller_actions.resolve_load_value",
+        return_value=("***", False),
+    ):
         ctrl.load_selected()
     ensure(ctrl.value_text.get() == "***")
     ensure(any("Loaded masked" in s for s in ctrl._status_calls))
 
 
 # --- _confirm_hidden_secret ---
+
 
 def test_confirm_hidden_secret():
     ctrl = _ActionTestMixin()
@@ -435,6 +460,7 @@ def test_confirm_hidden_secret():
 
 
 # --- _selected_record ---
+
 
 def test_selected_record_none():
     ctrl = _ActionTestMixin()

--- a/tests/test_gui_controller_coverage.py
+++ b/tests/test_gui_controller_coverage.py
@@ -66,7 +66,9 @@ def test_on_row_selected_update_details_none():
 def test_on_row_selected_update_details_with_row():
     """Test on row selected update details with row."""
     ctrl = _Harness()
-    rec = _make_record(name="MY_VAR", is_secret=True, is_persistent=True, is_mutable=False)
+    rec = _make_record(
+        name="MY_VAR", is_secret=True, is_persistent=True, is_mutable=False
+    )
     row = _make_row(rec)
     ctrl._on_row_selected_update_details(row)
     ensure(True in ctrl.view.details_enabled)
@@ -89,7 +91,9 @@ def test_clear_details():
 def test_set_detail_values():
     """Test set detail values."""
     ctrl = _Harness()
-    ctrl._set_detail_values({"name": "X", "context": "linux", "nonexistent_key": "ignored"})
+    ctrl._set_detail_values(
+        {"name": "X", "context": "linux", "nonexistent_key": "ignored"}
+    )
     ensure(ctrl.view.details_vars["name"].get() == "X")
     ensure(ctrl.view.details_vars["context"].get() == "linux")
 
@@ -98,7 +102,9 @@ def test_set_detail_values():
 def test_set_detail_pairs():
     """Test set detail pairs."""
     ctrl = _Harness()
-    ctrl._set_detail_pairs((("name", "A"), ("source", "dotenv"), ("bad_key", "ignored")))
+    ctrl._set_detail_pairs(
+        (("name", "A"), ("source", "dotenv"), ("bad_key", "ignored"))
+    )
     ensure(ctrl.view.details_vars["name"].get() == "A")
     ensure(ctrl.view.details_vars["source"].get() == "dotenv")
 
@@ -211,8 +217,10 @@ def test_choose_folder_selected(tmp_path: Path):
     ctrl.service.list_records_raw = MagicMock(return_value=[])
     ctrl.service.resolve_effective = MagicMock(return_value=None)
     ctrl.state_dir = Path("/var/state-fixture")
-    with patch("env_inspector_gui.controller.resolve_scan_root", return_value=tmp_path), \
-         patch("env_inspector_gui.controller.save_ui_state"):
+    with (
+        patch("env_inspector_gui.controller.resolve_scan_root", return_value=tmp_path),
+        patch("env_inspector_gui.controller.save_ui_state"),
+    ):
         ctrl.choose_folder()
     ensure(str(ctrl.root_path) == str(tmp_path))
 
@@ -395,7 +403,9 @@ def test_maybe_choose_dotenv_targets_multiple_selected():
         instance.win = MagicMock()
         MockDialog.return_value = instance
         ctrl.tk = MagicMock()
-        result = ctrl._maybe_choose_dotenv_targets("KEY", ["dotenv:/a", "dotenv:/b", "windows:user"])
+        result = ctrl._maybe_choose_dotenv_targets(
+            "KEY", ["dotenv:/a", "dotenv:/b", "windows:user"]
+        )
 
     ensure(result is not None)
     ensure("dotenv:/a" in result)

--- a/tests/test_gui_controller_operations_coverage.py
+++ b/tests/test_gui_controller_operations_coverage.py
@@ -166,8 +166,10 @@ def test_run_operation_diff_rejected():
     ctrl.service = MagicMock()
     ctrl.service.preview_set = MagicMock(return_value=[{"success": True}])
 
-    with patch.object(ctrl, "_maybe_choose_dotenv_targets", return_value=["a"]), \
-         patch.object(ctrl, "_confirm_diff", return_value=False):
+    with (
+        patch.object(ctrl, "_maybe_choose_dotenv_targets", return_value=["a"]),
+        patch.object(ctrl, "_confirm_diff", return_value=False),
+    ):
         ctrl._run_operation("set")
 
     # Apply should NOT be called
@@ -186,8 +188,10 @@ def test_run_operation_apply_fails():
     ctrl.service.preview_set = MagicMock(return_value=[{"success": True}])
     ctrl.service.set_key = MagicMock(side_effect=RuntimeError("boom"))
 
-    with patch.object(ctrl, "_maybe_choose_dotenv_targets", return_value=["a"]), \
-         patch.object(ctrl, "_confirm_diff", return_value=True):
+    with (
+        patch.object(ctrl, "_maybe_choose_dotenv_targets", return_value=["a"]),
+        patch.object(ctrl, "_confirm_diff", return_value=True),
+    ):
         ctrl._run_operation("set")
 
     ctrl.messagebox.showerror.assert_called()
@@ -321,8 +325,10 @@ def test_resolve_root_path_invalid():
 # --- EnvInspectorApp ---
 def test_env_inspector_app():
     """Test env inspector app."""
-    with patch.object(EnvInspectorController, "__init__", return_value=None), \
-         patch.object(EnvInspectorController, "run"):
+    with (
+        patch.object(EnvInspectorController, "__init__", return_value=None),
+        patch.object(EnvInspectorController, "run"),
+    ):
         app = EnvInspectorApp(Path.cwd())
         app._controller = MagicMock()
         app.run()
@@ -330,6 +336,7 @@ def test_env_inspector_app():
 
 
 # --- Real method tests (not overridden) ---
+
 
 def test_real_init_root_window():
     """Cover lines 72-73: _init_root_window with real implementation."""
@@ -349,9 +356,17 @@ def test_real_load_boot_state():
     ctrl.service.list_contexts = MagicMock(return_value=["linux"])
     ctrl.state_dir = Path("/var/nonexistent-state-dir-test")
     cwd = Path.cwd()
-    with patch("env_inspector_gui.controller.load_ui_state", return_value=PersistedUiState()), \
-         patch("env_inspector_gui.controller.resolve_scan_root", return_value=cwd), \
-         patch("env_inspector_gui.controller.sanitize_loaded_state", return_value=PersistedUiState(context="linux")):
+    with (
+        patch(
+            "env_inspector_gui.controller.load_ui_state",
+            return_value=PersistedUiState(),
+        ),
+        patch("env_inspector_gui.controller.resolve_scan_root", return_value=cwd),
+        patch(
+            "env_inspector_gui.controller.sanitize_loaded_state",
+            return_value=PersistedUiState(context="linux"),
+        ),
+    ):
         boot_state, _fallback = EnvInspectorController._load_boot_state(ctrl, cwd)
     ensure(isinstance(boot_state, PersistedUiState))
     ensure(boot_state.context == "linux")
@@ -410,6 +425,7 @@ def test_real_bind_shortcuts():
 def test_real_load_tk_modules():
     """Cover lines 56-63: _load_tk_modules with mocked tkinter."""
     import sys
+
     mock_filedialog = MagicMock()
     mock_messagebox = MagicMock()
     mock_ttk = MagicMock()
@@ -419,7 +435,12 @@ def test_real_load_tk_modules():
     mock_tkinter.ttk = mock_ttk
 
     saved = {}
-    for mod_name in ("tkinter", "tkinter.filedialog", "tkinter.messagebox", "tkinter.ttk"):
+    for mod_name in (
+        "tkinter",
+        "tkinter.filedialog",
+        "tkinter.messagebox",
+        "tkinter.ttk",
+    ):
         saved[mod_name] = sys.modules.get(mod_name)
 
     sys.modules["tkinter"] = mock_tkinter
@@ -438,6 +459,7 @@ def test_real_load_tk_modules():
 
 
 # --- refresh_data with view present for _on_row_selected (line 359, 360) ---
+
 
 def test_refresh_data_with_view_and_selected_row():
     """Cover lines 358-360: refresh_data when view exists and tree has selection."""
@@ -464,6 +486,7 @@ def test_refresh_data_with_view_and_selected_row():
 
 # --- _report_operation_result with no error and no status (line 485) ---
 
+
 def test_report_operation_result_no_message():
     """Cover line 485: result with no error and no status message."""
     ctrl = _Harness()
@@ -472,6 +495,7 @@ def test_report_operation_result_no_message():
 
 
 # --- Partial branch coverage ---
+
 
 def test_refresh_data_with_tk_none():
     """Cover branch 360->363: tk is None during refresh, skip _persist_state."""
@@ -493,8 +517,10 @@ def test_refresh_data_with_tk_none():
         original_render_table()
         ctrl.tk = None  # type: ignore[assignment]
 
-    with patch.object(ctrl, "_render_table", side_effect=render_then_clear_tk), \
-         patch("env_inspector_gui.controller.save_ui_state") as mock_save:
+    with (
+        patch.object(ctrl, "_render_table", side_effect=render_then_clear_tk),
+        patch("env_inspector_gui.controller.save_ui_state") as mock_save,
+    ):
         ctrl.refresh_data()
 
     ensure(ctrl.last_refresh_at is not None)
@@ -507,9 +533,14 @@ def test_report_operation_result_both_none():
     ctrl = _Harness()
     ctrl.messagebox = MagicMock()
     # Manually construct a result that produces both None
-    with patch("env_inspector_gui.controller.summarize_operation_result") as mock_summary:
+    with patch(
+        "env_inspector_gui.controller.summarize_operation_result"
+    ) as mock_summary:
         from env_inspector_gui.models import OperationResultSummary
-        mock_summary.return_value = OperationResultSummary(status_message=None, error_message=None)
+
+        mock_summary.return_value = OperationResultSummary(
+            status_message=None, error_message=None
+        )
         ctrl._report_operation_result("set", {"success": True})
     # Neither showerror nor _set_status should be called
     ctrl.messagebox.showerror.assert_not_called()

--- a/tests/test_gui_dialogs_coverage.py
+++ b/tests/test_gui_dialogs_coverage.py
@@ -34,25 +34,45 @@ def _mock_tk_module():
     """Build a mock tkinter module with all needed classes."""
     tk = MagicMock()
     tk.Toplevel = MagicMock(return_value=_make_mock_widget())
-    tk.BooleanVar = MagicMock(side_effect=lambda value=False: MagicMock(get=MagicMock(return_value=value), set=MagicMock(), trace_add=MagicMock()))
-    tk.StringVar = MagicMock(side_effect=lambda value="": MagicMock(get=MagicMock(return_value=value), set=MagicMock()))
-    tk.Canvas = MagicMock(return_value=_make_mock_widget(
-        create_window=MagicMock(),
-        bbox=MagicMock(return_value=(0, 0, 100, 100)),
-    ))
-    tk.Listbox = MagicMock(return_value=_make_mock_widget(
-        insert=MagicMock(),
-        curselection=MagicMock(return_value=()),
-        get=MagicMock(return_value="backup1.zip"),
-    ))
+    tk.BooleanVar = MagicMock(
+        side_effect=lambda value=False: MagicMock(
+            get=MagicMock(return_value=value), set=MagicMock(), trace_add=MagicMock()
+        )
+    )
+    tk.StringVar = MagicMock(
+        side_effect=lambda value="": MagicMock(
+            get=MagicMock(return_value=value), set=MagicMock()
+        )
+    )
+    tk.Canvas = MagicMock(
+        return_value=_make_mock_widget(
+            create_window=MagicMock(),
+            bbox=MagicMock(return_value=(0, 0, 100, 100)),
+        )
+    )
+    tk.Listbox = MagicMock(
+        return_value=_make_mock_widget(
+            insert=MagicMock(),
+            curselection=MagicMock(return_value=()),
+            get=MagicMock(return_value="backup1.zip"),
+        )
+    )
     return tk
 
 
 def _mock_ttk_module():
     """Handle  mock ttk module."""
     ttk = MagicMock()
-    for widget_name in ("Frame", "Label", "Button", "Entry", "Checkbutton",
-                        "Scrollbar", "Notebook", "LabelFrame"):
+    for widget_name in (
+        "Frame",
+        "Label",
+        "Button",
+        "Entry",
+        "Checkbutton",
+        "Scrollbar",
+        "Notebook",
+        "LabelFrame",
+    ):
         mock_cls = MagicMock(return_value=_make_mock_widget())
         setattr(ttk, widget_name, mock_cls)
     return ttk
@@ -95,6 +115,7 @@ def _install_mock_tkinter():
 
 # --- TargetPickerDialog ---
 
+
 class TestTargetPickerDialog:
     """Tests for TargetPickerDialog behaviour with mocked tkinter."""
 
@@ -106,12 +127,15 @@ class TestTargetPickerDialog:
 
         tk, ttk, font, scrolledtext = _install_mock_tkinter()
 
-        with patch.dict(sys.modules, {
-            "tkinter": tk,
-            "tkinter.ttk": ttk,
-            "tkinter.font": font,
-            "tkinter.scrolledtext": scrolledtext,
-        }):
+        with patch.dict(
+            sys.modules,
+            {
+                "tkinter": tk,
+                "tkinter.ttk": ttk,
+                "tkinter.font": font,
+                "tkinter.scrolledtext": scrolledtext,
+            },
+        ):
             # We need to import inside the patch context because the dialog
             # imports tkinter at class instantiation time
             from env_inspector_gui.dialogs import TargetPickerDialog
@@ -177,7 +201,9 @@ class TestTargetPickerDialog:
 
     def test_select_windows(self):
         """Test select windows."""
-        dialog = self._build(targets=["windows:user", "powershell:machine", "dotenv:/a"])
+        dialog = self._build(
+            targets=["windows:user", "powershell:machine", "dotenv:/a"]
+        )
         dialog._select_windows()
         dialog._vars["windows:user"].set.assert_called_with(True)
         dialog._vars["powershell:machine"].set.assert_called_with(True)
@@ -185,7 +211,9 @@ class TestTargetPickerDialog:
 
     def test_select_wsl(self):
         """Test select wsl."""
-        dialog = self._build(targets=["wsl:Ubuntu:bashrc", "wsl_dotenv:/a", "windows:user"])
+        dialog = self._build(
+            targets=["wsl:Ubuntu:bashrc", "wsl_dotenv:/a", "windows:user"]
+        )
         dialog._select_wsl()
         dialog._vars["wsl:Ubuntu:bashrc"].set.assert_called_with(True)
         dialog._vars["wsl_dotenv:/a"].set.assert_called_with(True)
@@ -247,6 +275,7 @@ class TestTargetPickerDialog:
 
 # --- DotenvTargetDialog ---
 
+
 class TestDotenvTargetDialog:
     """Tests for DotenvTargetDialog behaviour with mocked tkinter."""
 
@@ -258,11 +287,15 @@ class TestDotenvTargetDialog:
 
         tk, ttk, *_ = _install_mock_tkinter()
 
-        with patch.dict(sys.modules, {
-            "tkinter": tk,
-            "tkinter.ttk": ttk,
-        }):
+        with patch.dict(
+            sys.modules,
+            {
+                "tkinter": tk,
+                "tkinter.ttk": ttk,
+            },
+        ):
             from env_inspector_gui.dialogs import DotenvTargetDialog
+
             parent = _make_mock_widget()
             dialog = DotenvTargetDialog(parent, key, targets)
         return dialog
@@ -290,6 +323,7 @@ class TestDotenvTargetDialog:
 
 # --- DiffPreviewDialog ---
 
+
 class TestDiffPreviewDialog:
     """Tests for DiffPreviewDialog behaviour with mocked tkinter."""
 
@@ -314,15 +348,21 @@ class TestDiffPreviewDialog:
 
         tk, ttk, font, scrolledtext = _install_mock_tkinter()
 
-        with patch.dict(sys.modules, {
-            "tkinter": tk,
-            "tkinter.ttk": ttk,
-            "tkinter.font": font,
-            "tkinter.scrolledtext": scrolledtext,
-        }):
+        with patch.dict(
+            sys.modules,
+            {
+                "tkinter": tk,
+                "tkinter.ttk": ttk,
+                "tkinter.font": font,
+                "tkinter.scrolledtext": scrolledtext,
+            },
+        ):
             from env_inspector_gui.dialogs import DiffPreviewDialog
+
             parent = _make_mock_widget()
-            dialog = DiffPreviewDialog(parent, action=action, previews=previews, preview_only=preview_only)
+            dialog = DiffPreviewDialog(
+                parent, action=action, previews=previews, preview_only=preview_only
+            )
         return dialog
 
     def test_creates_dialog(self):
@@ -357,6 +397,7 @@ class TestDiffPreviewDialog:
     def test_diff_tag_static_method():
         """Test diff tag static method."""
         from env_inspector_gui.dialogs import DiffPreviewDialog
+
         ensure(DiffPreviewDialog._diff_tag("@@ -1,2 +1,3 @@") == "diff_hunk")
         ensure(DiffPreviewDialog._diff_tag("+added line") == "diff_add")
         ensure(DiffPreviewDialog._diff_tag("-removed line") == "diff_remove")
@@ -366,7 +407,9 @@ class TestDiffPreviewDialog:
 
     def test_no_diff_preview(self):
         """Tab with no diff_preview should show '(no textual diff)'."""
-        dialog = self._build(previews=[{"target": "t", "success": True, "diff_preview": None}])
+        dialog = self._build(
+            previews=[{"target": "t", "success": True, "diff_preview": None}]
+        )
         ensure(dialog.confirmed is False)
 
     def test_preview_missing_target(self):
@@ -376,6 +419,7 @@ class TestDiffPreviewDialog:
 
 
 # --- BackupPickerDialog ---
+
 
 class TestBackupPickerDialog:
     """Tests for BackupPickerDialog behaviour with mocked tkinter."""
@@ -388,11 +432,15 @@ class TestBackupPickerDialog:
 
         tk, ttk, *_ = _install_mock_tkinter()
 
-        with patch.dict(sys.modules, {
-            "tkinter": tk,
-            "tkinter.ttk": ttk,
-        }):
+        with patch.dict(
+            sys.modules,
+            {
+                "tkinter": tk,
+                "tkinter.ttk": ttk,
+            },
+        ):
             from env_inspector_gui.dialogs import BackupPickerDialog
+
             parent = _make_mock_widget()
             dialog = BackupPickerDialog(parent, backups)
         return dialog

--- a/tests/test_gui_models_coverage.py
+++ b/tests/test_gui_models_coverage.py
@@ -18,7 +18,12 @@ from env_inspector_gui.models import (
     select_theme_name,
     summarize_operation_result,
 )
-from env_inspector_gui.models import _coerce_text, _coerce_flag, _coerce_items, _coerce_number
+from env_inspector_gui.models import (
+    _coerce_text,
+    _coerce_flag,
+    _coerce_items,
+    _coerce_number,
+)
 
 from tests.assertions import ensure
 
@@ -329,28 +334,36 @@ def test_resolve_selected_targets_dotenv_scoping():
 
 # --- summarize_operation_result ---
 def test_summarize_batch_success():
-    result = summarize_operation_result("set", {"results": [{"success": True}, {"success": True}]})
+    result = summarize_operation_result(
+        "set", {"results": [{"success": True}, {"success": True}]}
+    )
     ensure(result.status_message is not None)
     ensure("2 targets" in result.status_message)
     ensure(result.error_message is None)
 
 
 def test_summarize_batch_failures():
-    result = summarize_operation_result("set", {"results": [{"success": False, "error_message": "oops"}]})
+    result = summarize_operation_result(
+        "set", {"results": [{"success": False, "error_message": "oops"}]}
+    )
     ensure(result.error_message is not None)
     ensure("oops" in result.error_message)
     ensure(result.status_message is None)
 
 
 def test_summarize_single_success():
-    result = summarize_operation_result("set", {"success": True, "operation_id": "op-1"})
+    result = summarize_operation_result(
+        "set", {"success": True, "operation_id": "op-1"}
+    )
     ensure(result.status_message is not None)
     ensure("op-1" in result.status_message)
     ensure(result.error_message is None)
 
 
 def test_summarize_single_failure():
-    result = summarize_operation_result("set", {"success": False, "error_message": "fail"})
+    result = summarize_operation_result(
+        "set", {"success": False, "error_message": "fail"}
+    )
     ensure(result.error_message is not None)
     ensure("fail" in result.error_message)
 
@@ -380,18 +393,24 @@ def test_select_target_dialog_result_with_values():
 
 # --- build_effective_value_text ---
 def test_build_effective_value_text_no_key():
-    result = build_effective_value_text(None, context="linux", key="", show_secrets=False)
+    result = build_effective_value_text(
+        None, context="linux", key="", show_secrets=False
+    )
     ensure("select key" in result)
 
 
 def test_build_effective_value_text_no_record():
-    result = build_effective_value_text(None, context="linux", key="MISS", show_secrets=False)
+    result = build_effective_value_text(
+        None, context="linux", key="MISS", show_secrets=False
+    )
     ensure("not found" in result)
 
 
 def test_build_effective_value_text_with_record():
     rec = _make_record(name="K", value="v")
-    result = build_effective_value_text(rec, context="linux", key="K", show_secrets=True)
+    result = build_effective_value_text(
+        rec, context="linux", key="K", show_secrets=True
+    )
     ensure("K=v" in result)
     ensure("linux" in result)
 

--- a/tests/test_gui_path_actions.py
+++ b/tests/test_gui_path_actions.py
@@ -7,6 +7,7 @@ from env_inspector_gui.path_actions import is_openable_local_path, open_source_p
 
 from tests.assertions import ensure
 
+
 def test_is_openable_local_path_handles_real_and_pseudo_paths(tmp_path: Path):
     local_file = tmp_path / ".env"
     local_file.write_text("A=1\n", encoding="utf-8")
@@ -14,6 +15,7 @@ def test_is_openable_local_path_handles_real_and_pseudo_paths(tmp_path: Path):
     ensure(is_openable_local_path(str(local_file)) is True)
     ensure(is_openable_local_path("wsl:Ubuntu:/etc/environment") is False)
     ensure(is_openable_local_path("registry:HKCU\\Environment") is False)
+
 
 def test_open_source_path_uses_resolved_file_uri(tmp_path: Path):
     local_file = tmp_path / "a.env"
@@ -31,7 +33,10 @@ def test_open_source_path_uses_resolved_file_uri(tmp_path: Path):
     ensure(err is None)
     ensure(calls == [local_file.resolve().as_uri()])
 
+
 def test_open_source_path_rejects_non_local_path():
-    ok, err = open_source_path("wsl:Ubuntu:/etc/environment", open_uri=lambda _uri: True)
+    ok, err = open_source_path(
+        "wsl:Ubuntu:/etc/environment", open_uri=lambda _uri: True
+    )
     ensure(ok is False)
     ensure("Cannot open" in (err or ""))

--- a/tests/test_gui_secret_policy.py
+++ b/tests/test_gui_secret_policy.py
@@ -1,9 +1,14 @@
 from __future__ import absolute_import, division
 
 from env_inspector_core.models import EnvRecord
-from env_inspector_gui.secret_policy import build_search_value, resolve_copy_payload, resolve_load_value
+from env_inspector_gui.secret_policy import (
+    build_search_value,
+    resolve_copy_payload,
+    resolve_load_value,
+)
 
 from tests.assertions import ensure
+
 
 def _secret_record() -> EnvRecord:
     return EnvRecord(
@@ -21,6 +26,7 @@ def _secret_record() -> EnvRecord:
         requires_privilege=False,
     )
 
+
 def test_search_value_uses_masked_representation_when_hidden():
     rec = _secret_record()
     hidden = build_search_value(rec, show_secrets=False)
@@ -29,22 +35,32 @@ def test_search_value_uses_masked_representation_when_hidden():
     ensure("supersecretvalue" not in hidden)
     ensure("supersecretvalue" in shown)
 
+
 def test_copy_payload_confirms_raw_secret_or_falls_back_to_masked():
     rec = _secret_record()
 
-    masked, masked_raw = resolve_copy_payload(rec, show_secrets=False, confirm_raw=lambda: False, as_pair=False)
-    raw, raw_used = resolve_copy_payload(rec, show_secrets=False, confirm_raw=lambda: True, as_pair=False)
+    masked, masked_raw = resolve_copy_payload(
+        rec, show_secrets=False, confirm_raw=lambda: False, as_pair=False
+    )
+    raw, raw_used = resolve_copy_payload(
+        rec, show_secrets=False, confirm_raw=lambda: True, as_pair=False
+    )
 
     ensure(masked_raw is False)
     ensure("supersecretvalue" not in masked)
     ensure(raw_used is True)
     ensure(raw == "supersecretvalue")
 
+
 def test_load_value_blocks_hidden_secret_without_confirmation():
     rec = _secret_record()
 
-    blocked, blocked_raw = resolve_load_value(rec, show_secrets=False, confirm_raw=lambda: False)
-    allowed, allowed_raw = resolve_load_value(rec, show_secrets=False, confirm_raw=lambda: True)
+    blocked, blocked_raw = resolve_load_value(
+        rec, show_secrets=False, confirm_raw=lambda: False
+    )
+    allowed, allowed_raw = resolve_load_value(
+        rec, show_secrets=False, confirm_raw=lambda: True
+    )
 
     ensure(blocked is None)
     ensure(blocked_raw is False)

--- a/tests/test_gui_state_store.py
+++ b/tests/test_gui_state_store.py
@@ -3,9 +3,14 @@ from __future__ import absolute_import, division
 from pathlib import Path
 
 from env_inspector_gui.models import PersistedUiState
-from env_inspector_gui.state_store import load_ui_state, save_ui_state, sanitize_loaded_state
+from env_inspector_gui.state_store import (
+    load_ui_state,
+    save_ui_state,
+    sanitize_loaded_state,
+)
 
 from tests.assertions import ensure
+
 
 def test_state_store_roundtrip(tmp_path: Path):
     state_dir = tmp_path / ".env-inspector-state"
@@ -31,6 +36,7 @@ def test_state_store_roundtrip(tmp_path: Path):
     ensure(loaded.selected_targets == ["windows:user", "dotenv:/tmp/.env"])
     ensure(loaded.sort_descending is True)
 
+
 def test_invalid_json_falls_back_to_defaults(tmp_path: Path):
     state_dir = tmp_path / ".env-inspector-state"
     state_dir.mkdir(parents=True, exist_ok=True)
@@ -41,6 +47,7 @@ def test_invalid_json_falls_back_to_defaults(tmp_path: Path):
     ensure(isinstance(loaded, PersistedUiState))
     ensure(loaded.filter_text == "")
     ensure(loaded.selected_targets == [])
+
 
 def test_sanitize_loaded_state_prunes_context_and_targets(tmp_path: Path):
     state = PersistedUiState(

--- a/tests/test_gui_state_store_coverage.py
+++ b/tests/test_gui_state_store_coverage.py
@@ -111,7 +111,9 @@ def test_sanitize_root_fallback(tmp_path: Path):
     ensure(str(result) == str(tmp_path))
 
 
-def test_sanitize_root_double_failure_returns_fallback_path(tmp_path: Path, monkeypatch):
+def test_sanitize_root_double_failure_returns_fallback_path(
+    tmp_path: Path, monkeypatch
+):
     """Lines 97-100: when both resolve attempts raise, return Path(fallback_root) verbatim.
 
     Mocking the resolver isolates this branch from pytest tmp layout —

--- a/tests/test_gui_table_logic.py
+++ b/tests/test_gui_table_logic.py
@@ -4,7 +4,12 @@ from typing import Dict
 
 from env_inspector_core.models import EnvRecord
 from env_inspector_gui.models import SortState
-from env_inspector_gui.table_logic import DisplayRowsRequest, build_display_rows, sort_display_rows, toggle_sort
+from env_inspector_gui.table_logic import (
+    DisplayRowsRequest,
+    build_display_rows,
+    sort_display_rows,
+    toggle_sort,
+)
 
 from tests.assertions import ensure
 
@@ -23,7 +28,9 @@ def _rec(name: str, value: str, **overrides: object) -> EnvRecord:
     source_type = str(payload["source_type"])
     source_path = str(payload["source_path"])
     raw_rank = payload["precedence_rank"]
-    precedence_rank = raw_rank if isinstance(raw_rank, int) and not isinstance(raw_rank, bool) else 50
+    precedence_rank = (
+        raw_rank if isinstance(raw_rank, int) and not isinstance(raw_rank, bool) else 50
+    )
     return EnvRecord(
         source_type=source_type,
         source_id=f"{source_type}:{source_path}",
@@ -46,7 +53,9 @@ def test_build_display_rows_filters_context_and_only_secrets():
             records=[
                 _rec("PUBLIC", "abc", context="windows", is_secret=False),
                 _rec("TOKEN", "supersecretvalue", context="windows", is_secret=True),
-                _rec("WSL_SECRET", "anothersecret", context="wsl:Ubuntu", is_secret=True),
+                _rec(
+                    "WSL_SECRET", "anothersecret", context="wsl:Ubuntu", is_secret=True
+                ),
             ],
             context="windows",
             query="",
@@ -102,7 +111,10 @@ def test_sort_toggle_and_stable_sort_behavior():
 
     state = SortState(column="name", descending=False)
     ordered = sort_display_rows(rows, state)
-    ensure([row.record.source_path for row in ordered[:2]] == ["/workspace/2.env", "/workspace/1.env"])
+    ensure(
+        [row.record.source_path for row in ordered[:2]]
+        == ["/workspace/2.env", "/workspace/1.env"]
+    )
 
     toggled = toggle_sort(state, "name")
     ensure(toggled.column == "name")

--- a/tests/test_gui_table_logic_coverage.py
+++ b/tests/test_gui_table_logic_coverage.py
@@ -30,7 +30,9 @@ def _rec(name: str, value: str, **overrides: object) -> EnvRecord:
     source_type = str(payload["source_type"])
     source_path = str(payload["source_path"])
     raw_rank = payload["precedence_rank"]
-    precedence_rank = raw_rank if isinstance(raw_rank, int) and not isinstance(raw_rank, bool) else 50
+    precedence_rank = (
+        raw_rank if isinstance(raw_rank, int) and not isinstance(raw_rank, bool) else 50
+    )
     return EnvRecord(
         source_type=source_type,
         source_id=f"{source_type}:{source_path}",
@@ -69,7 +71,9 @@ def test_sort_by_precedence_rank():
             show_secrets=True,
         )
     )
-    ordered = sort_display_rows(rows, SortState(column="precedence_rank", descending=False))
+    ordered = sort_display_rows(
+        rows, SortState(column="precedence_rank", descending=False)
+    )
     ensure(ordered[0].record.name == "B")
     ensure(ordered[1].record.name == "A")
 
@@ -88,6 +92,8 @@ def test_sort_by_unknown_column_falls_back_to_name():
             show_secrets=True,
         )
     )
-    ordered = sort_display_rows(rows, SortState(column="nonexistent_column", descending=False))
+    ordered = sort_display_rows(
+        rows, SortState(column="nonexistent_column", descending=False)
+    )
     ensure(ordered[0].record.name == "A")
     ensure(ordered[1].record.name == "B")

--- a/tests/test_gui_view_coverage.py
+++ b/tests/test_gui_view_coverage.py
@@ -287,9 +287,16 @@ def test_view_details_vars_created():
     """Test view details vars created."""
     view = _build_view()
     expected_keys = {
-        "name", "context", "source", "source_path",
-        "secret", "persistent", "mutable", "writable",
-        "requires_privilege", "precedence_rank",
+        "name",
+        "context",
+        "source",
+        "source_path",
+        "secret",
+        "persistent",
+        "mutable",
+        "writable",
+        "requires_privilege",
+        "precedence_rank",
     }
     ensure(set(view.details_vars.keys()) == expected_keys)
 
@@ -351,7 +358,13 @@ def test_set_mutation_actions_enabled():
     """Test set mutation actions enabled."""
     view = _build_view()
     view.set_mutation_actions_enabled(True)
-    for widget in (view.refresh_button, view.load_button, view.choose_targets_button, view.set_button, view.remove_button):
+    for widget in (
+        view.refresh_button,
+        view.load_button,
+        view.choose_targets_button,
+        view.set_button,
+        view.remove_button,
+    ):
         widget.configure.assert_called_with(state="normal")
 
 
@@ -359,7 +372,13 @@ def test_set_mutation_actions_disabled():
     """Test set mutation actions disabled."""
     view = _build_view()
     view.set_mutation_actions_enabled(False)
-    for widget in (view.refresh_button, view.load_button, view.choose_targets_button, view.set_button, view.remove_button):
+    for widget in (
+        view.refresh_button,
+        view.load_button,
+        view.choose_targets_button,
+        view.set_button,
+        view.remove_button,
+    ):
         widget.configure.assert_called_with(state="disabled")
 
 
@@ -377,7 +396,9 @@ def test_insert_table_row():
     view.tree.insert.return_value = "new_item"
     result = view.insert_table_row(("a", "b", "c"), striped=True)
     ensure(result == "new_item")
-    view.tree.insert.assert_called_with("", "end", values=("a", "b", "c"), tags=("row_even",))
+    view.tree.insert.assert_called_with(
+        "", "end", values=("a", "b", "c"), tags=("row_even",)
+    )
 
 
 def test_insert_table_row_odd():
@@ -410,8 +431,13 @@ def test_set_details_enabled():
     """Test set details enabled."""
     view = _build_view()
     view.set_details_enabled(True)
-    for widget in (view.copy_name_button, view.copy_value_button, view.copy_pair_button,
-                   view.copy_source_path_button, view.detail_open_button):
+    for widget in (
+        view.copy_name_button,
+        view.copy_value_button,
+        view.copy_pair_button,
+        view.copy_source_path_button,
+        view.detail_open_button,
+    ):
         widget.configure.assert_called_with(state="normal")
 
 
@@ -419,8 +445,13 @@ def test_set_details_disabled():
     """Test set details disabled."""
     view = _build_view()
     view.set_details_enabled(False)
-    for widget in (view.copy_name_button, view.copy_value_button, view.copy_pair_button,
-                   view.copy_source_path_button, view.detail_open_button):
+    for widget in (
+        view.copy_name_button,
+        view.copy_value_button,
+        view.copy_pair_button,
+        view.copy_source_path_button,
+        view.detail_open_button,
+    ):
         widget.configure.assert_called_with(state="disabled")
 
 

--- a/tests/test_linux_support.py
+++ b/tests/test_linux_support.py
@@ -327,9 +327,7 @@ def test_linux_etc_environment_write_uses_sudo_fallback_on_oserror(
 
     target = _patch_linux_etc_environment_reads(monkeypatch, etc_env)
 
-    def fake_write_text_file(
-        path: Path, text: str, *, ensure_parent: bool
-    ) -> None:
+    def fake_write_text_file(path: Path, text: str, *, ensure_parent: bool) -> None:
         """Raise `FileNotFoundError` for the redirected target write."""
         ensure(path == target)
         ensure(text == "A=2\n")
@@ -373,9 +371,7 @@ def test_linux_etc_environment_write_reports_oserror_with_failing_sudo(
 
     target = _patch_linux_etc_environment_reads(monkeypatch, etc_env)
 
-    def fake_write_text_file(
-        path: Path, _text: str, *, ensure_parent: bool
-    ) -> None:
+    def fake_write_text_file(path: Path, _text: str, *, ensure_parent: bool) -> None:
         """Raise an OSError for the redirected target write."""
         ensure(path == target)
         ensure(ensure_parent is False)

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -49,7 +49,9 @@ PATH="/usr/local/bin:/usr/bin"
 
 """
     parsed = parsing.parse_etc_environment(text)
-    _case().assertEqual(parsed, {"LANG": "en_US.UTF-8", "PATH": "/usr/local/bin:/usr/bin"})
+    _case().assertEqual(
+        parsed, {"LANG": "en_US.UTF-8", "PATH": "/usr/local/bin:/usr/bin"}
+    )
 
 
 def test_upsert_and_remove_export_roundtrip():

--- a/tests/test_path_security.py
+++ b/tests/test_path_security.py
@@ -12,12 +12,16 @@ from env_inspector_core.path_policy import (
 
 from tests.assertions import ensure
 
+
 def test_resolve_scan_root_rejects_null_byte(tmp_path: Path):
     bad = str(tmp_path) + "\x00suffix"
     with pytest.raises(PathPolicyError):
         resolve_scan_root(bad)
 
-def test_parse_scoped_dotenv_target_allows_path_inside_scope(tmp_path: Path, monkeypatch):
+
+def test_parse_scoped_dotenv_target_allows_path_inside_scope(
+    tmp_path: Path, monkeypatch
+):
     monkeypatch.chdir(tmp_path)
     project = tmp_path / "project"
     project.mkdir()
@@ -28,6 +32,7 @@ def test_parse_scoped_dotenv_target_allows_path_inside_scope(tmp_path: Path, mon
     scoped = parse_scoped_dotenv_target(f"dotenv:{env_file}", roots=roots)
 
     ensure(scoped.path == env_file.resolve())
+
 
 def test_parse_scoped_dotenv_target_rejects_outside_scope(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
@@ -42,7 +47,10 @@ def test_parse_scoped_dotenv_target_rejects_outside_scope(tmp_path: Path, monkey
     with pytest.raises(PathPolicyError):
         parse_scoped_dotenv_target(f"dotenv:{env_file}", roots=roots)
 
-def test_parse_scoped_dotenv_target_rejects_non_dotenv_filename(tmp_path: Path, monkeypatch):
+
+def test_parse_scoped_dotenv_target_rejects_non_dotenv_filename(
+    tmp_path: Path, monkeypatch
+):
     monkeypatch.chdir(tmp_path)
     folder = tmp_path / "folder"
     folder.mkdir()

--- a/tests/test_powershell_parsing.py
+++ b/tests/test_powershell_parsing.py
@@ -3,6 +3,7 @@ from env_inspector_core.providers import parse_powershell_profile_text
 
 from tests.assertions import ensure
 
+
 def test_parse_powershell_profile_env_assignments():
     text = """
 # comment

--- a/tests/test_pr39_owned_coverage.py
+++ b/tests/test_pr39_owned_coverage.py
@@ -203,9 +203,7 @@ def _assert_service_target_helpers(
     ensure(resolved is not None)
     ensure(resolved.name == "API_TOKEN")
     ensure(
-        svc._powershell_target_for_path(
-            r"C:\Program Files\PowerShell\7\profile.ps1"
-        )
+        svc._powershell_target_for_path(r"C:\Program Files\PowerShell\7\profile.ps1")
         == "powershell:all_users"
     )
     with pytest.raises(RuntimeError, match="Unsupported PowerShell target"):
@@ -408,8 +406,7 @@ def test_coverage_helpers_cover_source_normalization_and_fallback_xml(
         coverage_mod._normalize_source_path(str(outside_file)).endswith("outside.py")
     )
     ensure(
-        coverage_mod._normalize_source_path("./env_inspector.py")
-        == "env_inspector.py"
+        coverage_mod._normalize_source_path("./env_inspector.py") == "env_inspector.py"
     )
 
     bad_xml = tmp_path / "bad.xml"

--- a/tests/test_pr54_coverage_branches.py
+++ b/tests/test_pr54_coverage_branches.py
@@ -21,13 +21,17 @@ def test_list_records_rejects_request_and_kwargs(tmp_path: Path) -> None:
     svc = EnvInspectorService(state_dir=tmp_path / "state")
     request = service_module.ListRecordsRequest(root=tmp_path)
 
-    with pytest.raises(TypeError, match="Pass either a ListRecordsRequest or keyword arguments"):
+    with pytest.raises(
+        TypeError, match="Pass either a ListRecordsRequest or keyword arguments"
+    ):
         svc.list_records(request, root=tmp_path)
 
 
 def test_collect_wsl_rows_rejects_positional_and_unexpected_kwargs() -> None:
     """Test collect wsl rows rejects positional and unexpected kwargs."""
-    with pytest.raises(TypeError, match="collect_wsl_rows accepts keyword arguments only"):
+    with pytest.raises(
+        TypeError, match="collect_wsl_rows accepts keyword arguments only"
+    ):
         service_listing_module.collect_wsl_rows("bad-arg")
 
     wsl = SimpleNamespace(available=lambda: False)
@@ -51,7 +55,9 @@ def test_wsl_dotenv_rows_returns_empty_when_request_is_incomplete() -> None:
     calls = []
 
     rows = service_listing_module._wsl_dotenv_rows(
-        request=service_listing_module._WslDotenvRequest(distro=None, wsl_path="/home/user/.env", scan_depth=1),
+        request=service_listing_module._WslDotenvRequest(
+            distro=None, wsl_path="/home/user/.env", scan_depth=1
+        ),
         wsl=SimpleNamespace(),
         collect_wsl_dotenv_records_fn=lambda *_args, **_kwargs: calls.append("called"),
     )
@@ -80,7 +86,9 @@ def test_bridge_rows_without_current_linux_distro_uses_no_exclusions() -> None:
     ensure(calls == [(True, None)])
 
 
-def test_apply_row_filters_and_available_targets_cover_falsey_branches(tmp_path: Path) -> None:
+def test_apply_row_filters_and_available_targets_cover_falsey_branches(
+    tmp_path: Path,
+) -> None:
     """Test apply row filters and available targets cover falsey branches."""
     rows = [
         service_module.EnvRecord(
@@ -99,7 +107,10 @@ def test_apply_row_filters_and_available_targets_cover_falsey_branches(tmp_path:
         )
     ]
 
-    ensure(service_listing_module.apply_row_filters(rows, source=None, context=None) == rows)
+    ensure(
+        service_listing_module.apply_row_filters(rows, source=None, context=None)
+        == rows
+    )
 
     unknown_record = service_module.EnvRecord(
         source_type="unknown",
@@ -116,10 +127,17 @@ def test_apply_row_filters_and_available_targets_cover_falsey_branches(tmp_path:
         requires_privilege=False,
     )
 
-    ensure(service_listing_module.available_targets([unknown_record], context="wsl:Ubuntu", win_provider_present=False) == [])
+    ensure(
+        service_listing_module.available_targets(
+            [unknown_record], context="wsl:Ubuntu", win_provider_present=False
+        )
+        == []
+    )
 
 
-def test_write_linux_etc_environment_with_privilege_rejects_invalid_arguments(tmp_path: Path) -> None:
+def test_write_linux_etc_environment_with_privilege_rejects_invalid_arguments(
+    tmp_path: Path,
+) -> None:
     """Test write linux etc environment with privilege rejects invalid arguments."""
     target = tmp_path / "environment"
 
@@ -138,22 +156,35 @@ def test_write_linux_etc_environment_with_privilege_rejects_invalid_arguments(tm
 
 def test_restore_helpers_reject_positional_arguments(tmp_path: Path) -> None:
     """Test restore helpers reject positional arguments."""
-    with pytest.raises(TypeError, match="restore_dotenv_target accepts keyword arguments only"):
+    with pytest.raises(
+        TypeError, match="restore_dotenv_target accepts keyword arguments only"
+    ):
         service_restore_module.restore_dotenv_target("bad-arg")
 
-    with pytest.raises(TypeError, match="restore_linux_target accepts keyword arguments only"):
+    with pytest.raises(
+        TypeError, match="restore_linux_target accepts keyword arguments only"
+    ):
         service_restore_module.restore_linux_target("bad-arg")
 
-    with pytest.raises(TypeError, match="restore_wsl_target accepts keyword arguments only"):
+    with pytest.raises(
+        TypeError, match="restore_wsl_target accepts keyword arguments only"
+    ):
         service_restore_module.restore_wsl_target("bad-arg")
 
-    with pytest.raises(TypeError, match="restore_powershell_target accepts keyword arguments only"):
+    with pytest.raises(
+        TypeError, match="restore_powershell_target accepts keyword arguments only"
+    ):
         service_restore_module.restore_powershell_target("bad-arg")
 
-    with pytest.raises(TypeError, match="restore_windows_registry_target accepts keyword arguments only"):
+    with pytest.raises(
+        TypeError,
+        match="restore_windows_registry_target accepts keyword arguments only",
+    ):
         service_restore_module.restore_windows_registry_target("bad-arg")
 
-    with pytest.raises(TypeError, match="restore_target accepts keyword arguments only"):
+    with pytest.raises(
+        TypeError, match="restore_target accepts keyword arguments only"
+    ):
         service_restore_module.restore_target("bad-arg")
 
 
@@ -170,7 +201,9 @@ def _wsl_write_adapter() -> SimpleNamespace:
     )
 
 
-def test_restore_dotenv_target_rejects_unexpected_keyword_arguments(tmp_path: Path) -> None:
+def test_restore_dotenv_target_rejects_unexpected_keyword_arguments(
+    tmp_path: Path,
+) -> None:
     """Test restore dotenv target rejects unexpected keyword arguments."""
     scoped = _scoped_dotenv_target(tmp_path)
 
@@ -212,13 +245,17 @@ def test_restore_wsl_target_rejects_unexpected_keyword_arguments() -> None:
         )
 
 
-def test_restore_powershell_target_rejects_unexpected_keyword_arguments(tmp_path: Path) -> None:
+def test_restore_powershell_target_rejects_unexpected_keyword_arguments(
+    tmp_path: Path,
+) -> None:
     """Test restore powershell target rejects unexpected keyword arguments."""
     with pytest.raises(TypeError, match="Unexpected keyword argument"):
         service_restore_module.restore_powershell_target(
             target="powershell:current_user",
             text="$env:A='1'\n",
-            validated_powershell_restore_path_fn=lambda _target: tmp_path / "profile.ps1",
+            validated_powershell_restore_path_fn=lambda _target: (
+                tmp_path / "profile.ps1"
+            ),
             write_text_file_fn=lambda _path, _text: None,
             unexpected=True,
         )
@@ -235,7 +272,9 @@ def test_restore_windows_registry_target_rejects_unexpected_keyword_arguments() 
                 remove_scope_value=lambda *_args: None,
                 set_scope_value=lambda *_args: None,
             ),
-            windows_registry_provider_cls=SimpleNamespace(USER_SCOPE="User", MACHINE_SCOPE="Machine"),
+            windows_registry_provider_cls=SimpleNamespace(
+                USER_SCOPE="User", MACHINE_SCOPE="Machine"
+            ),
             unexpected=True,
         )
 
@@ -259,9 +298,13 @@ def test_restore_target_rejects_unexpected_keyword_arguments(tmp_path: Path) -> 
 def test_coerce_scan_request_covers_positional_branches() -> None:
     """Test coerce scan request covers positional branches."""
     auth_value = "auth-credential"
-    request = sentry_mod.SentryScanRequest(org="my-org", projects=["proj"], token=auth_value)
+    request = sentry_mod.SentryScanRequest(
+        org="my-org", projects=["proj"], token=auth_value
+    )
 
-    with pytest.raises(TypeError, match="Pass either a request object or keyword arguments"):
+    with pytest.raises(
+        TypeError, match="Pass either a request object or keyword arguments"
+    ):
         sentry_mod._coerce_scan_request(request, org="other")
 
     coerced = sentry_mod._coerce_scan_request("my-org", ("backend", "web"), auth_value)
@@ -290,7 +333,11 @@ def test_check_sentry_zero_script_does_not_duplicate_helper_root(monkeypatch) ->
     import sys
 
     helper_root = str(Path(sentry_mod.__file__).resolve().parent.parent)
-    monkeypatch.setattr(sys, "path", [helper_root] + [entry for entry in sys.path if entry != helper_root])
+    monkeypatch.setattr(
+        sys,
+        "path",
+        [helper_root] + [entry for entry in sys.path if entry != helper_root],
+    )
     monkeypatch.setattr(
         sys,
         "argv",
@@ -314,7 +361,9 @@ def test_check_sentry_zero_script_does_not_duplicate_helper_root(monkeypatch) ->
     ensure(sys.path.count(helper_root) == 1)
 
 
-def test_scan_projects_covers_request_object_and_keyword_request_paths(monkeypatch) -> None:
+def test_scan_projects_covers_request_object_and_keyword_request_paths(
+    monkeypatch,
+) -> None:
     """Test scan projects covers request object and keyword request paths."""
     auth_value = "auth-credential"
     monkeypatch.setattr(
@@ -323,7 +372,9 @@ def test_scan_projects_covers_request_object_and_keyword_request_paths(monkeypat
         lambda org, project, token: ([], {"x-hits": "0"}),
     )
 
-    request = sentry_mod.SentryScanRequest(org="my-org", projects=["proj"], token=auth_value)
+    request = sentry_mod.SentryScanRequest(
+        org="my-org", projects=["proj"], token=auth_value
+    )
     mode, results, findings, failures = sentry_mod._scan_projects(request)
     ensure(mode == "strict")
     ensure(results == [{"project": "proj", "unresolved": 0}])

--- a/tests/test_providers_branch_coverage.py
+++ b/tests/test_providers_branch_coverage.py
@@ -138,10 +138,7 @@ def test_collect_wsl_records_includes_bashrc_and_etc_pairs() -> None:
 
     case = _case()
     case.assertTrue(
-        any(
-            r.source_type == SOURCE_WSL_BASHRC and r.name == "API_TOKEN"
-            for r in rows
-        )
+        any(r.source_type == SOURCE_WSL_BASHRC and r.name == "API_TOKEN" for r in rows)
     )
     case.assertTrue(
         any(r.source_type == SOURCE_WSL_ETC_ENV and r.name == "LANG" for r in rows)

--- a/tests/test_quality_assert_coverage.py
+++ b/tests/test_quality_assert_coverage.py
@@ -10,35 +10,46 @@ from scripts import security_helpers as sec
 
 from tests.assertions import ensure
 
+
 def test_parse_named_path_accepts_workspace_file(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     coverage_file = tmp_path / "coverage.xml"
-    coverage_file.write_text("<coverage lines-valid=\"1\" lines-covered=\"1\" />\n", encoding="utf-8")
+    coverage_file.write_text(
+        '<coverage lines-valid="1" lines-covered="1" />\n', encoding="utf-8"
+    )
 
     name, path = coverage_mod.parse_named_path("python=coverage.xml")
 
     ensure(name == "python")
     ensure(path == coverage_file.resolve(strict=False))
 
+
 def test_parse_named_path_rejects_missing_format():
     with pytest.raises(ValueError, match="Expected format"):
         coverage_mod.parse_named_path("python")
 
+
 def test_parse_named_path_rejects_empty_name_format(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     coverage_file = tmp_path / "coverage.xml"
-    coverage_file.write_text("<coverage lines-valid=\"1\" lines-covered=\"1\" />\n", encoding="utf-8")
+    coverage_file.write_text(
+        '<coverage lines-valid="1" lines-covered="1" />\n', encoding="utf-8"
+    )
 
     with pytest.raises(ValueError, match="Expected format"):
         coverage_mod.parse_named_path("=coverage.xml")
 
+
 def test_parse_named_path_rejects_workspace_escape(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     outside = tmp_path.parent / "outside-coverage.xml"
-    outside.write_text("<coverage lines-valid=\"1\" lines-covered=\"1\" />\n", encoding="utf-8")
+    outside.write_text(
+        '<coverage lines-valid="1" lines-covered="1" />\n', encoding="utf-8"
+    )
 
     with pytest.raises(ValueError, match="escapes workspace root"):
         coverage_mod.parse_named_path(f"python={outside}")
+
 
 def test_parse_named_path_rejects_missing_file(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
@@ -46,7 +57,10 @@ def test_parse_named_path_rejects_missing_file(tmp_path: Path, monkeypatch):
     with pytest.raises(ValueError, match="Input file does not exist"):
         coverage_mod.parse_named_path("python=missing.xml")
 
-def test_safe_input_file_path_in_workspace_allows_relative_file(tmp_path: Path, monkeypatch):
+
+def test_safe_input_file_path_in_workspace_allows_relative_file(
+    tmp_path: Path, monkeypatch
+):
     monkeypatch.chdir(tmp_path)
     data = tmp_path / "data.txt"
     data.write_text("ok\n", encoding="utf-8")
@@ -54,6 +68,7 @@ def test_safe_input_file_path_in_workspace_allows_relative_file(tmp_path: Path, 
     resolved = sec.safe_input_file_path_in_workspace("data.txt")
 
     ensure(resolved == data.resolve(strict=False))
+
 
 def test_safe_input_file_path_in_workspace_rejects_escape(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
@@ -64,7 +79,9 @@ def test_safe_input_file_path_in_workspace_rejects_escape(tmp_path: Path, monkey
         sec.safe_input_file_path_in_workspace(str(outside))
 
 
-def test_normalize_source_path_handles_empty_and_workspace_absolute_paths(tmp_path: Path, monkeypatch):
+def test_normalize_source_path_handles_empty_and_workspace_absolute_paths(
+    tmp_path: Path, monkeypatch
+):
     monkeypatch.chdir(tmp_path)
     inside_file = tmp_path / "env_inspector.py"
     inside_file.write_text("print('ok')\n", encoding="utf-8")

--- a/tests/test_quality_branch_coverage.py
+++ b/tests/test_quality_branch_coverage.py
@@ -41,7 +41,9 @@ def test_codacy_extract_total_open_handles_nested_and_missing_counts():
     case.assertIsNone(codacy_mod.extract_total_open({"outer": [{"nested": "value"}]}))
 
 
-def test_codacy_main_returns_error_for_invalid_output_path(tmp_path: Path, monkeypatch, capsys):
+def test_codacy_main_returns_error_for_invalid_output_path(
+    tmp_path: Path, monkeypatch, capsys
+):
     monkeypatch.chdir(tmp_path)
     args = SimpleNamespace(
         provider="gh",
@@ -60,7 +62,9 @@ def test_codacy_main_returns_error_for_invalid_output_path(tmp_path: Path, monke
 
 
 def test_sentry_collect_projects_prefers_args_and_env_fallback():
-    args_with_projects = cast(argparse.Namespace, SimpleNamespace(project=["backend", "web"]))
+    args_with_projects = cast(
+        argparse.Namespace, SimpleNamespace(project=["backend", "web"])
+    )
     args_without_projects = cast(argparse.Namespace, SimpleNamespace(project=[]))
 
     ensure(sentry_mod._collect_projects(args_with_projects, {}) == ["backend", "web"])
@@ -77,9 +81,13 @@ def test_sentry_scan_projects_covers_header_fallback_and_failures(monkeypatch):
     def _fake_request_project_issues(org: str, project: str, token: str):
         return [{"id": "1"}], {}
 
-    monkeypatch.setattr(sentry_mod, "_request_project_issues", _fake_request_project_issues)
+    monkeypatch.setattr(
+        sentry_mod, "_request_project_issues", _fake_request_project_issues
+    )
 
-    mode, project_results, findings, failures = sentry_mod._scan_projects("org", ["proj"], "token")
+    mode, project_results, findings, failures = sentry_mod._scan_projects(
+        "org", ["proj"], "token"
+    )
 
     ensure(mode == "strict")
     ensure(project_results == [{"project": "proj", "unresolved": 1}])
@@ -93,7 +101,9 @@ def test_sentry_scan_projects_handles_http_404_and_http_500(monkeypatch):
         raise _http_error(404, "Not Found")
 
     monkeypatch.setattr(sentry_mod, "_request_project_issues", _raise_404)
-    mode_404, project_results_404, findings_404, failures_404 = sentry_mod._scan_projects("org", ["proj"], "token")
+    mode_404, project_results_404, findings_404, failures_404 = (
+        sentry_mod._scan_projects("org", ["proj"], "token")
+    )
 
     ensure(mode_404 == "skipped")
     ensure(project_results_404 == [])
@@ -104,7 +114,9 @@ def test_sentry_scan_projects_handles_http_404_and_http_500(monkeypatch):
         raise _http_error(500, "Err")
 
     monkeypatch.setattr(sentry_mod, "_request_project_issues", _raise_500)
-    mode_500, project_results_500, findings_500, failures_500 = sentry_mod._scan_projects("org", ["proj"], "token")
+    mode_500, project_results_500, findings_500, failures_500 = (
+        sentry_mod._scan_projects("org", ["proj"], "token")
+    )
 
     ensure(mode_500 == "error")
     ensure(project_results_500 == [])
@@ -126,7 +138,12 @@ def test_sentry_main_strict_mode_pass_and_fail(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(
         sentry_mod,
         "_scan_projects",
-        lambda org, projects, token: ("strict", [{"project": "proj", "unresolved": 0}], [], []),
+        lambda org, projects, token: (
+            "strict",
+            [{"project": "proj", "unresolved": 0}],
+            [],
+            [],
+        ),
     )
 
     ensure(sentry_mod.main() == 0)
@@ -135,6 +152,11 @@ def test_sentry_main_strict_mode_pass_and_fail(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(
         sentry_mod,
         "_scan_projects",
-        lambda org, projects, token: ("error", [{"project": "proj", "unresolved": 1}], [], ["failure"]),
+        lambda org, projects, token: (
+            "error",
+            [{"project": "proj", "unresolved": 1}],
+            [],
+            ["failure"],
+        ),
     )
     ensure(sentry_mod.main() == 1)

--- a/tests/test_quality_codacy_deepscan_branches.py
+++ b/tests/test_quality_codacy_deepscan_branches.py
@@ -26,7 +26,9 @@ def _empty_token() -> str:
 
 
 def _http_error(code: int) -> urllib.error.HTTPError:
-    return urllib.error.HTTPError(url="https://api.example", code=code, msg="err", hdrs=Message(), fp=None)
+    return urllib.error.HTTPError(
+        url="https://api.example", code=code, msg="err", hdrs=Message(), fp=None
+    )
 
 
 def _raise_http_error(code: int) -> NoReturn:
@@ -42,7 +44,9 @@ def _raise_url_error(reason: str = "network") -> NoReturn:
 
 
 def test_codacy_parse_args_accepts_required_repo_fields(monkeypatch):
-    monkeypatch.setattr(sys, "argv", ["prog", "--owner", "Prekzursil", "--repo", "env-inspector"])
+    monkeypatch.setattr(
+        sys, "argv", ["prog", "--owner", "Prekzursil", "--repo", "env-inspector"]
+    )
 
     args = codacy_mod._parse_args()
 
@@ -79,7 +83,9 @@ def test_codacy_request_json_rejects_non_dict_payload(monkeypatch):
     monkeypatch.setattr(codacy_mod, "request_json_https", lambda **_kwargs: ([], {}))
 
     with pytest.raises(RuntimeError, match="Unexpected Codacy response payload"):
-        codacy_mod._request_json(provider="gh", owner="Prekzursil", repo="env-inspector", token=_token())
+        codacy_mod._request_json(
+            provider="gh", owner="Prekzursil", repo="env-inspector", token=_token()
+        )
 
 
 def test_codacy_extract_helpers_cover_empty_and_fallback_paths():
@@ -87,7 +93,11 @@ def test_codacy_extract_helpers_cover_empty_and_fallback_paths():
     case.assertIsNone(codacy_mod.extract_total_open([]))
     case.assertEqual(codacy_mod._provider_candidates("gh"), ["gh", "github"])
     case.assertEqual(codacy_mod._first_text({"a": ""}, ("a", "b")), "")
-    case.assertIsNone(codacy_mod._format_issue_sample({"patternId": "", "filename": "", "message": ""}))
+    case.assertIsNone(
+        codacy_mod._format_issue_sample(
+            {"patternId": "", "filename": "", "message": ""}
+        )
+    )
     case.assertEqual(codacy_mod._sample_issue_findings({"data": "not-a-list"}), [])
 
 
@@ -149,7 +159,11 @@ def test_codacy_fetch_open_issues_handles_zero_and_non_zero(monkeypatch):
         calls["count"] += 1
         if calls["count"] == 1:
             return {"total": 2}
-        return {"data": [{"patternId": "C901", "filename": "a.py", "message": "too complex"}]}
+        return {
+            "data": [
+                {"patternId": "C901", "filename": "a.py", "message": "too complex"}
+            ]
+        }
 
     monkeypatch.setattr(codacy_mod, "_request_json", _fake_request_json)
     handled, open_issues, findings, error = codacy_mod._fetch_open_issues_for_provider(
@@ -166,7 +180,9 @@ def test_codacy_fetch_open_issues_handles_zero_and_non_zero(monkeypatch):
 
 
 def test_codacy_fetch_open_issues_handles_http_and_request_errors(monkeypatch):
-    monkeypatch.setattr(codacy_mod, "_request_json", lambda **_kwargs: _raise_http_error(404))
+    monkeypatch.setattr(
+        codacy_mod, "_request_json", lambda **_kwargs: _raise_http_error(404)
+    )
     handled, open_issues, findings, error = codacy_mod._fetch_open_issues_for_provider(
         provider="gh",
         owner="Prekzursil",
@@ -180,7 +196,9 @@ def test_codacy_fetch_open_issues_handles_http_and_request_errors(monkeypatch):
     case.assertEqual(findings, [])
     case.assertIsInstance(error, urllib.error.HTTPError)
 
-    monkeypatch.setattr(codacy_mod, "_request_json", lambda **_kwargs: _raise_http_error(500))
+    monkeypatch.setattr(
+        codacy_mod, "_request_json", lambda **_kwargs: _raise_http_error(500)
+    )
     handled, open_issues, findings, error = codacy_mod._fetch_open_issues_for_provider(
         provider="gh",
         owner="Prekzursil",
@@ -194,7 +212,9 @@ def test_codacy_fetch_open_issues_handles_http_and_request_errors(monkeypatch):
     case.assertIn("HTTP 500", findings[0])
     case.assertIsInstance(error, urllib.error.HTTPError)
 
-    monkeypatch.setattr(codacy_mod, "_request_json", lambda **_kwargs: _raise_value_error("bad"))
+    monkeypatch.setattr(
+        codacy_mod, "_request_json", lambda **_kwargs: _raise_value_error("bad")
+    )
     handled, open_issues, findings, error = codacy_mod._fetch_open_issues_for_provider(
         provider="gh",
         owner="Prekzursil",
@@ -210,13 +230,19 @@ def test_codacy_fetch_open_issues_handles_http_and_request_errors(monkeypatch):
 
 
 def test_codacy_query_open_issues_fallback_and_last_error(monkeypatch):
-    monkeypatch.setattr(codacy_mod, "_provider_candidates", lambda _preferred: ["gh", "github"])
+    monkeypatch.setattr(
+        codacy_mod, "_provider_candidates", lambda _preferred: ["gh", "github"]
+    )
 
     responses: List[Tuple[bool, Optional[int], List[str], Optional[Exception]]] = [
         (False, None, [], _http_error(404)),
         (True, 0, [], None),
     ]
-    monkeypatch.setattr(codacy_mod, "_fetch_open_issues_for_provider", lambda **_kwargs: responses.pop(0))
+    monkeypatch.setattr(
+        codacy_mod,
+        "_fetch_open_issues_for_provider",
+        lambda **_kwargs: responses.pop(0),
+    )
 
     open_issues, findings = codacy_mod._query_open_issues(
         provider="gh",
@@ -230,7 +256,11 @@ def test_codacy_query_open_issues_fallback_and_last_error(monkeypatch):
     case.assertEqual(open_issues, 0)
     case.assertEqual(findings, [])
 
-    monkeypatch.setattr(codacy_mod, "_fetch_open_issues_for_provider", lambda **_kwargs: (False, None, [], _http_error(404)))
+    monkeypatch.setattr(
+        codacy_mod,
+        "_fetch_open_issues_for_provider",
+        lambda **_kwargs: (False, None, [], _http_error(404)),
+    )
     open_issues, findings = codacy_mod._query_open_issues(
         provider="gh",
         owner="Prekzursil",
@@ -251,7 +281,9 @@ def test_deepscan_extract_total_open_and_request_guard(monkeypatch):
 
     monkeypatch.setattr(deepscan_mod, "request_json_https", lambda **_kwargs: ([], {}))
     with pytest.raises(RuntimeError, match="Unexpected DeepScan response payload"):
-        deepscan_mod._request_json(host="deepscan.io", path="/api", query={}, token=_token())
+        deepscan_mod._request_json(
+            host="deepscan.io", path="/api", query={}, token=_token()
+        )
 
 
 def test_deepscan_resolve_and_fetch_open_issues_paths(monkeypatch):
@@ -281,7 +313,9 @@ def test_deepscan_resolve_and_fetch_open_issues_paths(monkeypatch):
     case.assertIn("DeepScan API request failed", findings[0])
 
     findings.clear()
-    monkeypatch.setattr(deepscan_mod, "_request_json", lambda **_kwargs: {"open_issues": 2})
+    monkeypatch.setattr(
+        deepscan_mod, "_request_json", lambda **_kwargs: {"open_issues": 2}
+    )
     open_issues = deepscan_mod._fetch_open_issues(
         host="deepscan.io",
         path="/api",
@@ -296,7 +330,9 @@ def test_deepscan_resolve_and_fetch_open_issues_paths(monkeypatch):
 
 def test_deepscan_fetch_open_issues_handles_unparseable_total(monkeypatch):
     findings: List[str] = []
-    monkeypatch.setattr(deepscan_mod, "_request_json", lambda **_kwargs: {"meta": {"count": "n/a"}})
+    monkeypatch.setattr(
+        deepscan_mod, "_request_json", lambda **_kwargs: {"meta": {"count": "n/a"}}
+    )
 
     open_issues = deepscan_mod._fetch_open_issues(
         host="deepscan.io",
@@ -315,13 +351,23 @@ def test_deepscan_fetch_open_issues_handles_unparseable_total(monkeypatch):
 def test_deepscan_main_runs_fetch_when_inputs_present(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("DEEPSCAN_API_TOKEN", _token())
-    monkeypatch.setenv("DEEPSCAN_OPEN_ISSUES_URL", "https://deepscan.io/api/projects/1/issues/open")
+    monkeypatch.setenv(
+        "DEEPSCAN_OPEN_ISSUES_URL", "https://deepscan.io/api/projects/1/issues/open"
+    )
 
     def _deepscan_args():
-        return type("Args", (), {"token": _empty_token(), "out_json": "o/deep.json", "out_md": "o/deep.md"})()
+        return type(
+            "Args",
+            (),
+            {"token": _empty_token(), "out_json": "o/deep.json", "out_md": "o/deep.md"},
+        )()
 
     monkeypatch.setattr(deepscan_mod, "_parse_args", _deepscan_args)
-    monkeypatch.setattr(deepscan_mod, "_resolve_deepscan_endpoint", lambda _url: ("deepscan.io", "/api", {}))
+    monkeypatch.setattr(
+        deepscan_mod,
+        "_resolve_deepscan_endpoint",
+        lambda _url: ("deepscan.io", "/api", {}),
+    )
     monkeypatch.setattr(deepscan_mod, "_fetch_open_issues", lambda **_kwargs: 0)
 
     rc = deepscan_mod.main()

--- a/tests/test_quality_http_builders.py
+++ b/tests/test_quality_http_builders.py
@@ -18,7 +18,9 @@ def _fixture_token() -> str:
 def test_codacy_request_json_uses_fixed_host_and_validated_segments(monkeypatch):
     captured: Dict[str, object] = {}
 
-    def _fake_request_json_https(**kwargs: object) -> Tuple[Dict[str, int], Dict[str, str]]:
+    def _fake_request_json_https(
+        **kwargs: object,
+    ) -> Tuple[Dict[str, int], Dict[str, str]]:
         captured.update(kwargs)
         return {"total": 0}, {}
 
@@ -34,7 +36,10 @@ def test_codacy_request_json_uses_fixed_host_and_validated_segments(monkeypatch)
 
     ensure(payload == {"total": 0})
     ensure(captured["host"] == "api.codacy.com")
-    ensure(captured["path"] == "/api/v3/analysis/organizations/gh/Prekzursil/repositories/env-inspector/issues/search")
+    ensure(
+        captured["path"]
+        == "/api/v3/analysis/organizations/gh/Prekzursil/repositories/env-inspector/issues/search"
+    )
     ensure(captured["query"] == {"limit": "1"})
 
 
@@ -53,7 +58,9 @@ def test_codacy_request_json_rejects_unsafe_identifier():
 def test_deepscan_request_json_uses_fixed_host(monkeypatch):
     captured: Dict[str, object] = {}
 
-    def _fake_request_json_https(**kwargs: object) -> Tuple[Dict[str, int], Dict[str, str]]:
+    def _fake_request_json_https(
+        **kwargs: object,
+    ) -> Tuple[Dict[str, int], Dict[str, str]]:
         captured.update(kwargs)
         return {"open_issues": 0}, {}
 
@@ -74,12 +81,16 @@ def test_deepscan_request_json_uses_fixed_host(monkeypatch):
 def test_sentry_request_project_issues_uses_fixed_host(monkeypatch):
     captured: Dict[str, object] = {}
 
-    def _fake_request_json_https(**kwargs: object) -> Tuple[List[object], Dict[str, str]]:
+    def _fake_request_json_https(
+        **kwargs: object,
+    ) -> Tuple[List[object], Dict[str, str]]:
         captured.update(kwargs)
         return [], {"x-hits": "0"}
 
     monkeypatch.setattr(sentry_mod, "request_json_https", _fake_request_json_https)
-    issues, headers = sentry_mod._request_project_issues("my-org", "my-project", "token")
+    issues, headers = sentry_mod._request_project_issues(
+        "my-org", "my-project", "token"
+    )
 
     ensure(issues == [])
     ensure(headers["x-hits"] == "0")

--- a/tests/test_quality_script_outputs.py
+++ b/tests/test_quality_script_outputs.py
@@ -14,14 +14,18 @@ from tests.assertions import ensure
 def _empty_token() -> str:
     return str()
 
+
 def test_parse_coverage_xml_reads_standard_attributes(tmp_path: Path):
     xml_path = tmp_path / "coverage.xml"
-    xml_path.write_text('<coverage lines-valid="2" lines-covered="1"/>\n', encoding="utf-8")
+    xml_path.write_text(
+        '<coverage lines-valid="2" lines-covered="1"/>\n', encoding="utf-8"
+    )
 
     stats = coverage_mod.parse_coverage_xml("python", xml_path)
 
     ensure(stats.total == 2)
     ensure(stats.covered == 1)
+
 
 def test_parse_lcov_reads_totals(tmp_path: Path):
     lcov_path = tmp_path / "coverage.lcov"
@@ -31,6 +35,7 @@ def test_parse_lcov_reads_totals(tmp_path: Path):
 
     ensure(stats.total == 2)
     ensure(stats.covered == 1)
+
 
 def test_assert_coverage_main_writes_outputs(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
@@ -94,6 +99,7 @@ def test_assert_coverage_main_rejects_tests_only_report(tmp_path: Path, monkeypa
     ensure("tests/" in report_text)
     ensure("missing required source path" in report_text)
 
+
 def test_codacy_main_writes_outputs_without_token(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("CODACY_API_TOKEN", raising=False)
@@ -113,6 +119,7 @@ def test_codacy_main_writes_outputs_without_token(tmp_path: Path, monkeypatch):
     ensure((tmp_path / "reports" / "codacy.json").exists())
     ensure((tmp_path / "reports" / "codacy.md").exists())
 
+
 def test_deepscan_main_writes_outputs_without_inputs(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("DEEPSCAN_API_TOKEN", raising=False)
@@ -129,6 +136,7 @@ def test_deepscan_main_writes_outputs_without_inputs(tmp_path: Path, monkeypatch
     ensure(rc == 1)
     ensure((tmp_path / "reports" / "deepscan.json").exists())
     ensure((tmp_path / "reports" / "deepscan.md").exists())
+
 
 def test_sentry_main_writes_outputs_in_skipped_mode(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)

--- a/tests/test_quality_security_imports.py
+++ b/tests/test_quality_security_imports.py
@@ -20,13 +20,16 @@ def test_security_imports_reloads_and_exposes_helpers():
     case.assertTrue(callable(reloaded.safe_output_path_in_workspace))
 
 
-
 def test_security_imports_fallback_loader_inserts_helper_root(monkeypatch):
     import types
 
     case = _case()
     helper_root = str(Path(security_imports.__file__).resolve().parent.parent)
-    monkeypatch.setattr(security_imports.sys, "path", [entry for entry in security_imports.sys.path if entry != helper_root])
+    monkeypatch.setattr(
+        security_imports.sys,
+        "path",
+        [entry for entry in security_imports.sys.path if entry != helper_root],
+    )
 
     def _fake_import_module(name: str):
         if name == "scripts.security_helpers":
@@ -40,7 +43,9 @@ def test_security_imports_fallback_loader_inserts_helper_root(monkeypatch):
             split_validated_https_url=lambda *args, **kwargs: ("host", "/", {}),
         )
 
-    monkeypatch.setattr(security_imports.importlib, "import_module", _fake_import_module)
+    monkeypatch.setattr(
+        security_imports.importlib, "import_module", _fake_import_module
+    )
 
     loaded = security_imports._load_helpers_module()
 

--- a/tests/test_security_helpers.py
+++ b/tests/test_security_helpers.py
@@ -73,11 +73,17 @@ def test_request_json_https_success(monkeypatch):
             recorded["timeout"] = timeout
             recorded["method"] = request.get_method()
             recorded["headers"] = dict(request.header_items())
-            recorded["body"] = request.data.decode("utf-8") if request.data is not None else None
+            recorded["body"] = (
+                request.data.decode("utf-8") if request.data is not None else None
+            )
             return _Response()
 
-    monkeypatch.setattr(sec.urllib.request, "build_opener", lambda _handler: _FakeOpener())
-    monkeypatch.setattr(sec.urllib.request, "HTTPSHandler", lambda context=None: context)
+    monkeypatch.setattr(
+        sec.urllib.request, "build_opener", lambda _handler: _FakeOpener()
+    )
+    monkeypatch.setattr(
+        sec.urllib.request, "HTTPSHandler", lambda context=None: context
+    )
     real_secure_context = sec._secure_ssl_context
 
     def _fake_secure_context():
@@ -105,11 +111,14 @@ def test_request_json_https_success(monkeypatch):
     ensure(recorded["body"] == '{"x": 1}')
     ensure(recorded["closed"] is True)
     ensure("value" in captured_context)
-    ensure(getattr(captured_context["value"], "protocol", None) == sec.ssl.PROTOCOL_TLSv1_2)
+    ensure(
+        getattr(captured_context["value"], "protocol", None) == sec.ssl.PROTOCOL_TLSv1_2
+    )
 
 
 def test_request_json_https_http_error(monkeypatch):
     """Re-raise HTTP errors emitted by the HTTPS request helper."""
+
     class _FakeOpener:
         """Opener stub that always raises an HTTP error."""
 
@@ -125,8 +134,12 @@ def test_request_json_https_http_error(monkeypatch):
                 fp=io.BytesIO(b'{"error":"denied"}'),
             )
 
-    monkeypatch.setattr(sec.urllib.request, "build_opener", lambda _handler: _FakeOpener())
-    monkeypatch.setattr(sec.urllib.request, "HTTPSHandler", lambda context=None: context)
+    monkeypatch.setattr(
+        sec.urllib.request, "build_opener", lambda _handler: _FakeOpener()
+    )
+    monkeypatch.setattr(
+        sec.urllib.request, "HTTPSHandler", lambda context=None: context
+    )
 
     with pytest.raises(urllib.error.HTTPError, match="Forbidden") as exc_info:
         sec.request_json_https(
@@ -172,4 +185,6 @@ def test_validate_hostname_allowlists_accepts_none_suffixes():
 def test_validate_hostname_allowlists_rejects_mismatched_suffix():
     """Reject hostnames that do not match the configured suffix allowlist."""
     with pytest.raises(ValueError, match="suffix allowlist"):
-        sec._validate_hostname_allowlists("api.codacy.com", allowed_host_suffixes={"example.com"})
+        sec._validate_hostname_allowlists(
+            "api.codacy.com", allowed_host_suffixes={"example.com"}
+        )

--- a/tests/test_service_coverage_branches.py
+++ b/tests/test_service_coverage_branches.py
@@ -21,7 +21,13 @@ import env_inspector_core.service as service_module
 from tests.assertions import ensure
 
 
-def _record(source_type: str, source_path: str, *, context: str = "linux", source_id: str = "Ubuntu") -> EnvRecord:
+def _record(
+    source_type: str,
+    source_path: str,
+    *,
+    context: str = "linux",
+    source_id: str = "Ubuntu",
+) -> EnvRecord:
     """Record."""
     return EnvRecord(
         source_type=source_type,
@@ -114,7 +120,9 @@ def _assert_powershell_preview_skips_writes(
     ensure(requires_priv is False)
 
 
-def test_collect_wsl_rows_uses_linux_exclusion_and_dotenv(monkeypatch, tmp_path: Path) -> None:
+def test_collect_wsl_rows_uses_linux_exclusion_and_dotenv(
+    monkeypatch, tmp_path: Path
+) -> None:
     """Test collect wsl rows uses linux exclusion and dotenv."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
     svc.runtime_context = "linux"
@@ -123,18 +131,37 @@ def test_collect_wsl_rows_uses_linux_exclusion_and_dotenv(monkeypatch, tmp_path:
 
     calls: Dict[str, object] = {}
 
-    def _fake_collect_wsl_records(wsl, include_etc: bool, exclude_distros) -> List[EnvRecord]:
+    def _fake_collect_wsl_records(
+        wsl, include_etc: bool, exclude_distros
+    ) -> List[EnvRecord]:
         """Fake collect wsl records."""
         calls["exclude"] = exclude_distros
-        return [_record(SOURCE_WSL_BASHRC, "~/.bashrc", context="wsl:Debian", source_id="Debian")]
+        return [
+            _record(
+                SOURCE_WSL_BASHRC, "~/.bashrc", context="wsl:Debian", source_id="Debian"
+            )
+        ]
 
-    def _fake_collect_wsl_dotenv_records(wsl, distro: str, root_path: str, max_depth: int) -> List[EnvRecord]:
+    def _fake_collect_wsl_dotenv_records(
+        wsl, distro: str, root_path: str, max_depth: int
+    ) -> List[EnvRecord]:
         """Fake collect wsl dotenv records."""
         calls["dotenv"] = (distro, root_path, max_depth)
-        return [_record(SOURCE_WSL_DOTENV, "Debian:/home/user/.env", context="wsl:Debian", source_id="Debian")]
+        return [
+            _record(
+                SOURCE_WSL_DOTENV,
+                "Debian:/home/user/.env",
+                context="wsl:Debian",
+                source_id="Debian",
+            )
+        ]
 
-    monkeypatch.setattr(service_module, "collect_wsl_records", _fake_collect_wsl_records)
-    monkeypatch.setattr(service_module, "collect_wsl_dotenv_records", _fake_collect_wsl_dotenv_records)
+    monkeypatch.setattr(
+        service_module, "collect_wsl_records", _fake_collect_wsl_records
+    )
+    monkeypatch.setattr(
+        service_module, "collect_wsl_dotenv_records", _fake_collect_wsl_dotenv_records
+    )
 
     rows = svc._collect_wsl_rows(scan_depth=3, distro="Debian", wsl_path="/home/user")
 
@@ -143,7 +170,9 @@ def test_collect_wsl_rows_uses_linux_exclusion_and_dotenv(monkeypatch, tmp_path:
     ensure(len(rows) == 2)
 
 
-def test_collect_wsl_rows_swallows_collection_errors(monkeypatch, tmp_path: Path) -> None:
+def test_collect_wsl_rows_swallows_collection_errors(
+    monkeypatch, tmp_path: Path
+) -> None:
     """Test collect wsl rows swallows collection errors."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
     monkeypatch.setattr(svc.wsl, "available", lambda: True)
@@ -153,14 +182,18 @@ def test_collect_wsl_rows_swallows_collection_errors(monkeypatch, tmp_path: Path
         raise RuntimeError("boom")
 
     monkeypatch.setattr(service_module, "collect_wsl_records", _raise_runtime_error)
-    monkeypatch.setattr(service_module, "collect_wsl_dotenv_records", _raise_runtime_error)
+    monkeypatch.setattr(
+        service_module, "collect_wsl_dotenv_records", _raise_runtime_error
+    )
 
     rows = svc._collect_wsl_rows(scan_depth=2, distro="Ubuntu", wsl_path="/home/user")
 
     ensure(rows == [])
 
 
-def test_list_records_accepts_request_without_kwargs(monkeypatch, tmp_path: Path) -> None:
+def test_list_records_accepts_request_without_kwargs(
+    monkeypatch, tmp_path: Path
+) -> None:
     """Test list records accepts request without kwargs."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
     request = service_module.ListRecordsRequest(root=tmp_path, include_raw_secrets=True)
@@ -192,11 +225,26 @@ def test_available_targets_maps_all_known_sources_and_filters_context(tmp_path: 
         _record(SOURCE_DOTENV, str(tmp_path / ".env"), context="linux"),
         _record(SOURCE_LINUX_BASHRC, str(tmp_path / ".bashrc"), context="linux"),
         _record(SOURCE_LINUX_ETC_ENV, "/etc/environment", context="linux"),
-        _record(SOURCE_WSL_DOTENV, "Ubuntu:/home/u/.env", context="linux", source_id="Ubuntu"),
+        _record(
+            SOURCE_WSL_DOTENV,
+            "Ubuntu:/home/u/.env",
+            context="linux",
+            source_id="Ubuntu",
+        ),
         _record(SOURCE_WSL_BASHRC, "~/.bashrc", context="linux", source_id="Ubuntu"),
-        _record(SOURCE_WSL_ETC_ENV, "/etc/environment", context="linux", source_id="Ubuntu"),
-        _record(SOURCE_POWERSHELL_PROFILE, r"C:\Program Files\PowerShell\7\profile.ps1", context="linux"),
-        _record(SOURCE_POWERSHELL_PROFILE, r"C:\Users\me\Documents\PowerShell\profile.ps1", context="linux"),
+        _record(
+            SOURCE_WSL_ETC_ENV, "/etc/environment", context="linux", source_id="Ubuntu"
+        ),
+        _record(
+            SOURCE_POWERSHELL_PROFILE,
+            r"C:\Program Files\PowerShell\7\profile.ps1",
+            context="linux",
+        ),
+        _record(
+            SOURCE_POWERSHELL_PROFILE,
+            r"C:\Users\me\Documents\PowerShell\profile.ps1",
+            context="linux",
+        ),
         _record(SOURCE_DOTENV, "ignored.env", context="wsl:Ubuntu"),
     ]
 
@@ -229,7 +277,13 @@ def test_update_helpers_cover_dispatch_and_error_branches(monkeypatch, tmp_path:
     svc = EnvInspectorService(state_dir=tmp_path / "state")
 
     with pytest.raises(RuntimeError, match="Unsupported Linux target"):
-        svc._update_linux_file(target="linux:unknown", key="A", value="1", action="set", apply_changes=False)
+        svc._update_linux_file(
+            target="linux:unknown",
+            key="A",
+            value="1",
+            action="set",
+            apply_changes=False,
+        )
 
     wsl_writes: List[Tuple[str, str, str]] = []
     monkeypatch.setattr(svc.wsl, "read_file", lambda distro, path: "")
@@ -238,11 +292,23 @@ def test_update_helpers_cover_dispatch_and_error_branches(monkeypatch, tmp_path:
         "write_file_with_privilege",
         lambda distro, path, text: wsl_writes.append((distro, path, text)),
     )
-    svc._update_wsl_file(target="wsl:Ubuntu:etc_environment", key="A", value="1", action="set", apply_changes=True)
+    svc._update_wsl_file(
+        target="wsl:Ubuntu:etc_environment",
+        key="A",
+        value="1",
+        action="set",
+        apply_changes=True,
+    )
     ensure(wsl_writes and wsl_writes[0][0] == "Ubuntu")
 
     with pytest.raises(RuntimeError, match="Unsupported WSL target"):
-        svc._update_wsl_file(target="wsl:Ubuntu:profile", key="A", value="1", action="set", apply_changes=False)
+        svc._update_wsl_file(
+            target="wsl:Ubuntu:profile",
+            key="A",
+            value="1",
+            action="set",
+            apply_changes=False,
+        )
 
     with pytest.raises(RuntimeError, match="Unsupported WSL dotenv target path"):
         svc._update_wsl_file(
@@ -254,7 +320,11 @@ def test_update_helpers_cover_dispatch_and_error_branches(monkeypatch, tmp_path:
         )
 
     profile = tmp_path / "profile.ps1"
-    monkeypatch.setattr(EnvInspectorService, "_powershell_target_path_and_roots", lambda _self, _target: (profile, [tmp_path], False))
+    monkeypatch.setattr(
+        EnvInspectorService,
+        "_powershell_target_path_and_roots",
+        lambda _self, _target: (profile, [tmp_path], False),
+    )
     _before, _after, out_path, _requires_priv, _ = svc._update_powershell_file(
         target="powershell:current_user",
         key="A",
@@ -275,8 +345,23 @@ def test_update_helpers_cover_dispatch_and_error_branches(monkeypatch, tmp_path:
         "_update_powershell_file",
         lambda **kwargs: ("before", "after", "ps", False, None),
     )
-    ensure(svc._file_update("wsl:Ubuntu:bashrc", "A", "1", "set", apply_changes=False, scope_roots=[])[2] == "wsl")
-    ensure(svc._file_update("powershell:current_user", "A", "1", "set", apply_changes=False, scope_roots=[])[2] == "ps")
+    ensure(
+        svc._file_update(
+            "wsl:Ubuntu:bashrc", "A", "1", "set", apply_changes=False, scope_roots=[]
+        )[2]
+        == "wsl"
+    )
+    ensure(
+        svc._file_update(
+            "powershell:current_user",
+            "A",
+            "1",
+            "set",
+            apply_changes=False,
+            scope_roots=[],
+        )[2]
+        == "ps"
+    )
 
 
 def test_update_wsl_preview_skips_writes_when_apply_changes_is_false(
@@ -310,7 +395,9 @@ def test_mutate_shell_content_preview_remove_keeps_other_keys(
     ensure("B=2" in removed)
 
 
-def test_restore_helpers_cover_linux_and_wsl_targets(tmp_path: Path, monkeypatch) -> None:
+def test_restore_helpers_cover_linux_and_wsl_targets(
+    tmp_path: Path, monkeypatch
+) -> None:
     """Test restore helpers cover linux and wsl targets."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
     fake_home = tmp_path / "home"
@@ -321,7 +408,9 @@ def test_restore_helpers_cover_linux_and_wsl_targets(tmp_path: Path, monkeypatch
     ensure((fake_home / ".bashrc").read_text(encoding="utf-8") == "export A=1\n")
 
     etc_calls: List[str] = []
-    monkeypatch.setattr(svc, "_write_linux_etc_environment_with_privilege", etc_calls.append)
+    monkeypatch.setattr(
+        svc, "_write_linux_etc_environment_with_privilege", etc_calls.append
+    )
     svc._restore_linux_target(target="linux:etc_environment", text="A=1\n")
     ensure(etc_calls == ["A=1\n"])
 
@@ -341,16 +430,24 @@ def test_restore_helpers_cover_linux_and_wsl_targets(tmp_path: Path, monkeypatch
         svc._restore_wsl_target(target="wsl:Ubuntu:unknown", text="x")
 
 
-def test_restore_helpers_cover_powershell_and_registry(tmp_path: Path, monkeypatch) -> None:
+def test_restore_helpers_cover_powershell_and_registry(
+    tmp_path: Path, monkeypatch
+) -> None:
     """Test restore helpers cover powershell and registry."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
     fake_home = tmp_path / "home"
     fake_home.mkdir(parents=True, exist_ok=True)
     profile = fake_home / "Documents" / "PowerShell" / "ps-profile.ps1"
     monkeypatch.setattr(service_module.Path, "home", lambda: fake_home)
-    monkeypatch.setattr(EnvInspectorService, "_validated_powershell_restore_path", lambda _self, _target: profile)
-    svc._restore_powershell_target(target="powershell:current_user", text="$env:A=\"1\"\n")
-    ensure(profile.read_text(encoding="utf-8") == "$env:A=\"1\"\n")
+    monkeypatch.setattr(
+        EnvInspectorService,
+        "_validated_powershell_restore_path",
+        lambda _self, _target: profile,
+    )
+    svc._restore_powershell_target(
+        target="powershell:current_user", text='$env:A="1"\n'
+    )
+    ensure(profile.read_text(encoding="utf-8") == '$env:A="1"\n')
 
     svc.win_provider = None
     with pytest.raises(RuntimeError, match="provider unavailable"):
@@ -379,7 +476,9 @@ def test_restore_helpers_cover_powershell_and_registry(tmp_path: Path, monkeypat
 
     fake = _FakeWinProvider()
     svc.win_provider = fake
-    svc._restore_windows_registry_target(target="windows:user", text="{\"KEEP\":\"1\",\"NEW\":\"3\"}")
+    svc._restore_windows_registry_target(
+        target="windows:user", text='{"KEEP":"1","NEW":"3"}'
+    )
     ensure(fake.removed and fake.removed[0][1] == "DROP")
     ensure(any(key == "NEW" for _scope, key, _value in fake.sets))
 
@@ -388,9 +487,17 @@ def test_restore_helpers_cover_dispatch(tmp_path: Path, monkeypatch) -> None:
     """Test restore helpers cover dispatch."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
     calls: List[str] = []
-    monkeypatch.setattr(svc, "_restore_linux_target", lambda **kwargs: calls.append("linux"))
-    monkeypatch.setattr(svc, "_restore_powershell_target", lambda **kwargs: calls.append("powershell"))
-    monkeypatch.setattr(svc, "_restore_windows_registry_target", lambda **kwargs: calls.append("windows"))
+    monkeypatch.setattr(
+        svc, "_restore_linux_target", lambda **kwargs: calls.append("linux")
+    )
+    monkeypatch.setattr(
+        svc, "_restore_powershell_target", lambda **kwargs: calls.append("powershell")
+    )
+    monkeypatch.setattr(
+        svc,
+        "_restore_windows_registry_target",
+        lambda **kwargs: calls.append("windows"),
+    )
     svc._restore_target(target="linux:bashrc", text="x", scope_roots=[])
     svc._restore_target(target="powershell:current_user", text="x", scope_roots=[])
     svc._restore_target(target="windows:user", text="x", scope_roots=[])
@@ -400,7 +507,9 @@ def test_restore_helpers_cover_dispatch(tmp_path: Path, monkeypatch) -> None:
         svc._restore_target(target="custom:target", text="x", scope_roots=[])
 
 
-def test_restore_dotenv_target_rejects_outside_scope(tmp_path: Path, monkeypatch) -> None:
+def test_restore_dotenv_target_rejects_outside_scope(
+    tmp_path: Path, monkeypatch
+) -> None:
     """Test restore dotenv target rejects outside scope."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
     allowed = tmp_path / "allowed"
@@ -417,7 +526,11 @@ def test_restore_dotenv_target_rejects_outside_scope(tmp_path: Path, monkeypatch
             self.path = path
             self.roots = [allowed]
 
-    monkeypatch.setattr(service_module, "parse_scoped_dotenv_target", lambda target, roots: _Scoped(env_path))
+    monkeypatch.setattr(
+        service_module,
+        "parse_scoped_dotenv_target",
+        lambda target, roots: _Scoped(env_path),
+    )
 
     with pytest.raises(RuntimeError, match="outside approved roots"):
         svc._restore_dotenv_target(
@@ -450,12 +563,14 @@ def test_registry_write_machine_requires_privilege_and_user_scope(tmp_path: Path
         "set",
         apply_changes=False,
     )
-    _before_machine, _after_machine, _path_machine, machine_requires_priv, _ = svc._registry_write(
-        "windows:machine",
-        "A",
-        "2",
-        "set",
-        apply_changes=False,
+    _before_machine, _after_machine, _path_machine, machine_requires_priv, _ = (
+        svc._registry_write(
+            "windows:machine",
+            "A",
+            "2",
+            "set",
+            apply_changes=False,
+        )
     )
 
     import unittest
@@ -507,23 +622,31 @@ def test_registry_write_noop_and_preview_remove_paths(tmp_path: Path):
     ensure(before == after)
     ensure(requires_priv is False)
 
-    _before_remove, after_remove, _path_remove, _requires_priv_remove, _ = svc._registry_write(
-        "windows:user",
-        "A",
-        None,
-        "remove",
-        apply_changes=False,
+    _before_remove, after_remove, _path_remove, _requires_priv_remove, _ = (
+        svc._registry_write(
+            "windows:user",
+            "A",
+            None,
+            "remove",
+            apply_changes=False,
+        )
     )
     ensure('"A": "1"' not in after_remove)
     ensure(remove_calls == [])
 
 
-def test_powershell_profile_path_returns_expected_target_paths(tmp_path: Path, monkeypatch):
+def test_powershell_profile_path_returns_expected_target_paths(
+    tmp_path: Path, monkeypatch
+):
     """Test powershell profile path returns expected target paths."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
     current = tmp_path / "current.ps1"
     all_users = tmp_path / "all.ps1"
-    monkeypatch.setattr(EnvInspectorService, "get_powershell_profile_paths", staticmethod(lambda: [current, all_users]))
+    monkeypatch.setattr(
+        EnvInspectorService,
+        "get_powershell_profile_paths",
+        staticmethod(lambda: [current, all_users]),
+    )
 
     import unittest
 

--- a/tests/test_service_path_guards.py
+++ b/tests/test_service_path_guards.py
@@ -11,10 +11,15 @@ import env_inspector_core.service_paths as service_paths_module
 
 from tests.assertions import ensure
 
+
 def test_is_path_within_returns_false_for_unrelated_roots(tmp_path: Path):
     """Test is path within returns false for unrelated roots."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
-    ensure(svc._is_path_within(tmp_path / "outside" / ".env", tmp_path / "allowed") is False)
+    ensure(
+        svc._is_path_within(tmp_path / "outside" / ".env", tmp_path / "allowed")
+        is False
+    )
+
 
 def test_validate_path_in_roots_raises_for_outside_path(tmp_path: Path):
     """Test validate path in roots raises for outside path."""
@@ -23,7 +28,10 @@ def test_validate_path_in_roots_raises_for_outside_path(tmp_path: Path):
     outside.parent.mkdir(parents=True, exist_ok=True)
 
     with pytest.raises(RuntimeError, match="outside approved roots"):
-        svc._validate_path_in_roots(outside, [tmp_path / "allowed"], label="dotenv target")
+        svc._validate_path_in_roots(
+            outside, [tmp_path / "allowed"], label="dotenv target"
+        )
+
 
 def test_validated_powershell_restore_path_rejects_unsupported_target(tmp_path: Path):
     """Test validated powershell restore path rejects unsupported target."""
@@ -32,31 +40,50 @@ def test_validated_powershell_restore_path_rejects_unsupported_target(tmp_path: 
     with pytest.raises(RuntimeError, match="Unsupported PowerShell target"):
         svc._validated_powershell_restore_path("powershell:unsupported")
 
-def test_validated_powershell_restore_path_current_user_success(tmp_path: Path, monkeypatch):
+
+def test_validated_powershell_restore_path_current_user_success(
+    tmp_path: Path, monkeypatch
+):
     """Test validated powershell restore path current user success."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
     fake_home = tmp_path / "home"
     fake_home.mkdir(parents=True, exist_ok=True)
-    fake_profile = fake_home / "Documents" / "PowerShell" / "Microsoft.PowerShell_profile.ps1"
+    fake_profile = (
+        fake_home / "Documents" / "PowerShell" / "Microsoft.PowerShell_profile.ps1"
+    )
 
     monkeypatch.setattr(service_module.Path, "home", lambda: fake_home)
-    monkeypatch.setattr(EnvInspectorService, "_powershell_profile_path", lambda _self, _target: fake_profile)
+    monkeypatch.setattr(
+        EnvInspectorService,
+        "_powershell_profile_path",
+        lambda _self, _target: fake_profile,
+    )
 
     resolved = svc._validated_powershell_restore_path("powershell:current_user")
 
     ensure(resolved == fake_profile.resolve(strict=False))
 
-def test_validated_powershell_restore_path_all_users_rejects_outside_root(tmp_path: Path, monkeypatch):
+
+def test_validated_powershell_restore_path_all_users_rejects_outside_root(
+    tmp_path: Path, monkeypatch
+):
     """Test validated powershell restore path all users rejects outside root."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
     bad_profile = tmp_path / "not-program-files" / "profile.ps1"
 
-    monkeypatch.setattr(EnvInspectorService, "_powershell_profile_path", lambda _self, _target: bad_profile)
+    monkeypatch.setattr(
+        EnvInspectorService,
+        "_powershell_profile_path",
+        lambda _self, _target: bad_profile,
+    )
 
     with pytest.raises(RuntimeError, match="outside approved roots"):
         svc._validated_powershell_restore_path("powershell:all_users")
 
-def test_linux_etc_environment_path_guard_handles_platform_semantics(tmp_path: Path, monkeypatch):
+
+def test_linux_etc_environment_path_guard_handles_platform_semantics(
+    tmp_path: Path, monkeypatch
+):
     """Test linux etc environment path guard handles platform semantics."""
     _ = EnvInspectorService(state_dir=tmp_path / "state")
     monkeypatch.setattr(EnvInspectorService, "_LINUX_ETC_ENV_PATH", r"\etc\environment")
@@ -69,7 +96,10 @@ def test_linux_etc_environment_path_guard_handles_platform_semantics(tmp_path: P
     resolved = EnvInspectorService._linux_etc_environment_path()
     ensure(resolved.as_posix() == r"\etc\environment")
 
-def test_write_linux_etc_environment_with_privilege_rejects_non_fixed_path(tmp_path: Path, monkeypatch):
+
+def test_write_linux_etc_environment_with_privilege_rejects_non_fixed_path(
+    tmp_path: Path, monkeypatch
+):
     """Test write linux etc environment with privilege rejects non fixed path."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
     monkeypatch.setattr(EnvInspectorService, "_LINUX_ETC_ENV_PATH", r"\etc\environment")
@@ -77,7 +107,10 @@ def test_write_linux_etc_environment_with_privilege_rejects_non_fixed_path(tmp_p
     with pytest.raises(RuntimeError, match="Unexpected /etc/environment resolution"):
         svc._write_linux_etc_environment_with_privilege("A=1\n")
 
-def test_restore_dotenv_path_checks_continue_until_matching_root(tmp_path: Path, monkeypatch):
+
+def test_restore_dotenv_path_checks_continue_until_matching_root(
+    tmp_path: Path, monkeypatch
+):
     """Test restore dotenv path checks continue until matching root."""
     monkeypatch.chdir(tmp_path)
     svc = EnvInspectorService(state_dir=tmp_path / "state")
@@ -88,7 +121,11 @@ def test_restore_dotenv_path_checks_continue_until_matching_root(tmp_path: Path,
     fail_root.mkdir(parents=True, exist_ok=True)
     env_file = outside_root / ".env"
 
-    monkeypatch.setattr(svc, "_effective_scope_roots", lambda _scope_roots=None: [fail_root, outside_root])
+    monkeypatch.setattr(
+        svc,
+        "_effective_scope_roots",
+        lambda _scope_roots=None: [fail_root, outside_root],
+    )
 
     backup_path = svc.backup_mgr.backup_text(f"dotenv:{env_file}", "A=1\n")
     result = svc.restore_backup(backup=str(backup_path), scope_roots=[outside_root])
@@ -96,19 +133,27 @@ def test_restore_dotenv_path_checks_continue_until_matching_root(tmp_path: Path,
     ensure(result["success"] is True)
     ensure(env_file.read_text(encoding="utf-8") == "A=1\n")
 
+
 def test_restore_wsl_dotenv_backup_uses_wsl_write_file(tmp_path: Path, monkeypatch):
     """Test restore wsl dotenv backup uses wsl write file."""
     monkeypatch.chdir(tmp_path)
     svc = EnvInspectorService(state_dir=tmp_path / "state")
 
     calls: List[Tuple[str, str, str]] = []
-    monkeypatch.setattr(svc.wsl, "write_file", lambda distro, path, text: calls.append((distro, path, text)))
+    monkeypatch.setattr(
+        svc.wsl,
+        "write_file",
+        lambda distro, path, text: calls.append((distro, path, text)),
+    )
 
-    backup_path = svc.backup_mgr.backup_text("wsl_dotenv:Ubuntu:/home/user/.env", "A=1\n")
+    backup_path = svc.backup_mgr.backup_text(
+        "wsl_dotenv:Ubuntu:/home/user/.env", "A=1\n"
+    )
     result = svc.restore_backup(backup=str(backup_path))
 
     ensure(result["success"] is True)
     ensure(calls == [("Ubuntu", "/home/user/.env", "A=1\n")])
+
 
 def test_restore_wsl_bashrc_backup_uses_wsl_write_file(tmp_path: Path, monkeypatch):
     """Test restore wsl bashrc backup uses wsl write file."""
@@ -116,7 +161,11 @@ def test_restore_wsl_bashrc_backup_uses_wsl_write_file(tmp_path: Path, monkeypat
     svc = EnvInspectorService(state_dir=tmp_path / "state")
 
     calls: List[Tuple[str, str, str]] = []
-    monkeypatch.setattr(svc.wsl, "write_file", lambda distro, path, text: calls.append((distro, path, text)))
+    monkeypatch.setattr(
+        svc.wsl,
+        "write_file",
+        lambda distro, path, text: calls.append((distro, path, text)),
+    )
 
     backup_path = svc.backup_mgr.backup_text("wsl:Ubuntu:bashrc", "export A='1'\n")
     result = svc.restore_backup(backup=str(backup_path))
@@ -124,7 +173,10 @@ def test_restore_wsl_bashrc_backup_uses_wsl_write_file(tmp_path: Path, monkeypat
     ensure(result["success"] is True)
     ensure(calls == [("Ubuntu", "~/.bashrc", "export A='1'\n")])
 
-def test_linux_etc_environment_path_guard_non_windows_branch(tmp_path: Path, monkeypatch):
+
+def test_linux_etc_environment_path_guard_non_windows_branch(
+    tmp_path: Path, monkeypatch
+):
     """Test linux etc environment path guard non windows branch."""
     _ = EnvInspectorService(state_dir=tmp_path / "state")
     monkeypatch.setattr(service_paths_module.os, "name", "posix", raising=False)
@@ -134,20 +186,28 @@ def test_linux_etc_environment_path_guard_non_windows_branch(tmp_path: Path, mon
 
     ensure(resolved.as_posix() == r"\etc\environment")
 
+
 def test_restore_wsl_dotenv_backup_rejects_path_traversal(tmp_path: Path, monkeypatch):
     """Test restore wsl dotenv backup rejects path traversal."""
     monkeypatch.chdir(tmp_path)
     svc = EnvInspectorService(state_dir=tmp_path / "state")
 
     calls: List[Tuple[str, str, str]] = []
-    monkeypatch.setattr(svc.wsl, "write_file", lambda distro, path, text: calls.append((distro, path, text)))
+    monkeypatch.setattr(
+        svc.wsl,
+        "write_file",
+        lambda distro, path, text: calls.append((distro, path, text)),
+    )
 
-    backup_path = svc.backup_mgr.backup_text("wsl_dotenv:Ubuntu:/home/user/../outside.env", "A=1\n")
+    backup_path = svc.backup_mgr.backup_text(
+        "wsl_dotenv:Ubuntu:/home/user/../outside.env", "A=1\n"
+    )
     result = svc.restore_backup(backup=str(backup_path))
 
     ensure(result["success"] is False)
     ensure("Unsupported WSL dotenv target path" in (result["error_message"] or ""))
     ensure(calls == [])
+
 
 def test_validate_target_for_operation_rejects_unknown_target(tmp_path: Path):
     """Test validate target for operation rejects unknown target."""
@@ -155,6 +215,7 @@ def test_validate_target_for_operation_rejects_unknown_target(tmp_path: Path):
 
     with pytest.raises(RuntimeError, match="Unsupported target"):
         svc._validate_target_for_operation("custom:target", scope_roots=[tmp_path])
+
 
 def test_validate_target_for_operation_rejects_dotenv_outside_scope(tmp_path: Path):
     """Test validate target for operation rejects dotenv outside scope."""
@@ -165,26 +226,40 @@ def test_validate_target_for_operation_rejects_dotenv_outside_scope(tmp_path: Pa
     outside.mkdir(parents=True, exist_ok=True)
 
     with pytest.raises(Exception, match="outside approved roots"):
-        svc._validate_target_for_operation(f"dotenv:{outside / '.env'}", scope_roots=[allowed])
+        svc._validate_target_for_operation(
+            f"dotenv:{outside / '.env'}", scope_roots=[allowed]
+        )
+
 
 def test_validate_target_for_operation_accepts_wsl_variants(tmp_path: Path):
     """Test validate target for operation accepts wsl variants."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
 
-    svc._validate_target_for_operation("wsl_dotenv:Ubuntu:/home/user/.env", scope_roots=[tmp_path])
+    svc._validate_target_for_operation(
+        "wsl_dotenv:Ubuntu:/home/user/.env", scope_roots=[tmp_path]
+    )
     svc._validate_target_for_operation("wsl:Ubuntu:bashrc", scope_roots=[tmp_path])
 
-def test_restore_powershell_target_all_users_uses_program_files_root(tmp_path: Path, monkeypatch):
+
+def test_restore_powershell_target_all_users_uses_program_files_root(
+    tmp_path: Path, monkeypatch
+):
     """Test restore powershell target all users uses program files root."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
     profile = tmp_path / "program_files" / "PowerShell" / "7" / "profile.ps1"
 
     writes: Dict[str, object] = {}
-    monkeypatch.setattr(EnvInspectorService, "_validated_powershell_restore_path", lambda _self, _target: profile)
+    monkeypatch.setattr(
+        EnvInspectorService,
+        "_validated_powershell_restore_path",
+        lambda _self, _target: profile,
+    )
     monkeypatch.setattr(
         svc,
         "_write_text_file",
-        lambda path, text, ensure_parent: writes.update({"path": path, "text": text, "ensure_parent": ensure_parent}),
+        lambda path, text, ensure_parent: writes.update(
+            {"path": path, "text": text, "ensure_parent": ensure_parent}
+        ),
     )
 
     svc._restore_powershell_target(target="powershell:all_users", text="$env:A='1'\n")

--- a/tests/test_service_preview.py
+++ b/tests/test_service_preview.py
@@ -19,11 +19,16 @@ _ORIGINAL_PATH_HOME = service_module.Path.home
 @pytest.fixture(autouse=True)
 def _reset_service_globals(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(service_module, "_path_exists", _ORIGINAL_PATH_EXISTS)
-    monkeypatch.setattr(service_module, "_read_text_if_exists", _ORIGINAL_READ_TEXT_IF_EXISTS)
-    monkeypatch.setattr(EnvInspectorService, "_write_text_file", staticmethod(_ORIGINAL_WRITE_TEXT_FILE))
+    monkeypatch.setattr(
+        service_module, "_read_text_if_exists", _ORIGINAL_READ_TEXT_IF_EXISTS
+    )
+    monkeypatch.setattr(
+        EnvInspectorService, "_write_text_file", staticmethod(_ORIGINAL_WRITE_TEXT_FILE)
+    )
     monkeypatch.setattr(service_module, "which", _ORIGINAL_WHICH)
     monkeypatch.setattr(service_module, "run", _ORIGINAL_RUN)
     monkeypatch.setattr(service_module.Path, "home", _ORIGINAL_PATH_HOME)
+
 
 def test_preview_set_does_not_mutate_file(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
@@ -32,17 +37,28 @@ def test_preview_set_does_not_mutate_file(tmp_path: Path, monkeypatch):
 
     svc = EnvInspectorService(state_dir=tmp_path / "state")
 
-    previews = svc.preview_set(key="API_TOKEN", value="x", targets=[f"dotenv:{env_file}"], scope_roots=[tmp_path])
+    previews = svc.preview_set(
+        key="API_TOKEN",
+        value="x",
+        targets=[f"dotenv:{env_file}"],
+        scope_roots=[tmp_path],
+    )
     ensure(previews[0]["success"] is True)
 
     text_after_preview = env_file.read_text(encoding="utf-8")
     ensure(text_after_preview == "A=1\n")
 
-    result = svc.set_key(key="API_TOKEN", value="x", targets=[f"dotenv:{env_file}"], scope_roots=[tmp_path])
+    result = svc.set_key(
+        key="API_TOKEN",
+        value="x",
+        targets=[f"dotenv:{env_file}"],
+        scope_roots=[tmp_path],
+    )
     ensure(result["success"] is True)
 
     text_after_apply = env_file.read_text(encoding="utf-8")
     ensure("API_TOKEN=x" in text_after_apply)
+
 
 def test_set_does_not_write_when_backup_fails(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
@@ -56,10 +72,13 @@ def test_set_does_not_write_when_backup_fails(tmp_path: Path, monkeypatch):
 
     monkeypatch.setattr(svc.backup_mgr, "backup_text", fail_backup)
 
-    result = svc.set_key(key="A", value="2", targets=[f"dotenv:{env_file}"], scope_roots=[tmp_path])
+    result = svc.set_key(
+        key="A", value="2", targets=[f"dotenv:{env_file}"], scope_roots=[tmp_path]
+    )
     ensure(result["success"] is False)
     ensure("backup write failed" in result["error_message"])
     ensure(env_file.read_text(encoding="utf-8") == "A=1\n")
+
 
 def test_audit_log_redacts_secret_diff(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
@@ -67,12 +86,18 @@ def test_audit_log_redacts_secret_diff(tmp_path: Path, monkeypatch):
     env_file.write_text("API_TOKEN=old\n", encoding="utf-8")
 
     svc = EnvInspectorService(state_dir=tmp_path / "state")
-    result = svc.set_key(key="API_TOKEN", value="supersecretvalue", targets=[f"dotenv:{env_file}"], scope_roots=[tmp_path])
+    result = svc.set_key(
+        key="API_TOKEN",
+        value="supersecretvalue",
+        targets=[f"dotenv:{env_file}"],
+        scope_roots=[tmp_path],
+    )
     ensure(result["success"] is True)
 
     log_text = (tmp_path / "state" / "audit.log").read_text(encoding="utf-8")
     ensure("[secret diff masked]" in log_text)
     ensure("supersecretvalue" not in log_text)
+
 
 def test_set_rejects_dotenv_target_outside_approved_roots(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
@@ -84,7 +109,9 @@ def test_set_rejects_dotenv_target_outside_approved_roots(tmp_path: Path, monkey
     env_file.write_text("A=1\n", encoding="utf-8")
 
     svc = EnvInspectorService(state_dir=tmp_path / "state")
-    result = svc.set_key(key="A", value="2", targets=[f"dotenv:{env_file}"], scope_roots=[allowed_root])
+    result = svc.set_key(
+        key="A", value="2", targets=[f"dotenv:{env_file}"], scope_roots=[allowed_root]
+    )
 
     ensure(result["success"] is False)
     ensure("outside approved roots" in (result["error_message"] or ""))

--- a/tests/test_workflow_pinning.py
+++ b/tests/test_workflow_pinning.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from tests.assertions import ensure
 
+
 def test_release_workflow_pins_third_party_actions_to_shas():
     """Require third-party workflow actions to be pinned to commit SHAs."""
     workflow = Path(".github/workflows/env-inspector-exe-release.yml")

--- a/tests/test_wsl_privilege.py
+++ b/tests/test_wsl_privilege.py
@@ -1,4 +1,5 @@
 """Tests for privileged WSL file writes and availability probing."""
+
 from __future__ import absolute_import, division
 from subprocess import CompletedProcess  # nosec B404
 from pathlib import Path
@@ -11,9 +12,13 @@ from env_inspector_core.providers import WslProvider
 from tests.assertions import ensure
 
 
-def _proc(returncode: int, stdout: bytes = b"", stderr: bytes = b"") -> CompletedProcess:
+def _proc(
+    returncode: int, stdout: bytes = b"", stderr: bytes = b""
+) -> CompletedProcess:
     """Build a lightweight completed-process stub for WSL runner tests."""
-    return CompletedProcess(args=["wsl"], returncode=returncode, stdout=stdout, stderr=stderr)
+    return CompletedProcess(
+        args=["wsl"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
 
 
 def test_write_file_with_privilege_root_success() -> None:
@@ -62,6 +67,7 @@ def test_write_file_with_privilege_falls_back_to_sudo() -> None:
 
 def test_write_file_with_privilege_raises_when_root_and_sudo_fail() -> None:
     """Raise when both privileged write strategies fail."""
+
     def runner(_cmd, **_kwargs) -> CompletedProcess:
         """Return a failed process result for every privileged attempt."""
         return _proc(1, stderr=b"fail")
@@ -76,7 +82,9 @@ def test_write_file_with_privilege_raises_when_root_and_sudo_fail() -> None:
     ensure("root and sudo fallback" in str(exc.value))
 
 
-def test_available_probes_command_and_returns_false_when_probe_fails(tmp_path: Path) -> None:
+def test_available_probes_command_and_returns_false_when_probe_fails(
+    tmp_path: Path,
+) -> None:
     """Return false when the WSL availability probe exits unsuccessfully."""
     calls: List[List[str]] = []
     fake_wsl = tmp_path / "wsl.exe"


### PR DESCRIPTION
## **User description**
Follow-up to #69. Brings down the post-merge Codacy/Sonar baseline.

## Summary
- ruff format pass over the entire Python tree (79 files reformatted) to clear the bulk of PyLintPython3 C0301 / Prospector_pycodestyle line-length findings.
- Replace sorted(...)[0] with min() in resolver.py for Sonar S6395.

## Test plan
- [ ] env-inspector-ci verify (ubuntu + windows) stays green
- [ ] Coverage 100 Gate stays at 100%
- [ ] Codacy Zero open-issue count drops materially

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Runs `ruff format` across the Python codebase and switches a resolver selection to `min()` to reduce Codacy/Sonar issues. No functional changes intended; CI and 100% coverage should remain green.

- **Refactors**
  - Applied `ruff format --line-length 88` across all Python modules to clear line-length lint findings.
  - Replaced `sorted(...)[0]` with `min(..., key=...)` in `env_inspector_core/resolver.py` to satisfy Sonar S6395 and avoid unnecessary sorting.

<sup>Written for commit 7c5466cb39e232533498d3a5edf29b6f8cf78a77. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reformat codebase and simplify resolver selection**

### What Changed
- Reformatted Python code across the app, GUI, tests, and quality scripts without changing normal app behavior
- Resolver selection now chooses the best matching value directly instead of sorting all matches first
- Kept WSL, path, backup, export, and quality-gate flows aligned with the same user-facing behavior

### Impact
`✅ Fewer lint and style failures`
`✅ Slightly faster resolver selection`
`✅ Cleaner maintenance builds`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=c4zvcaEskf0E82IxY3x1Uw5QZvgzUftH9HAt09y6a9s&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
