### PR TITLE
fix(codacy): downgrade PEP 585 generics for E1136 false positives

### DIFF
--- a/env_inspector.py
+++ b/env_inspector.py
@@ -46,7 +46,7 @@ def _legacy_print_secrets(root: str | Path) -> int:
     return 0
 
 
-def _parse_gui_args(argv: list[str]) -> argparse.Namespace:
+def _parse_gui_args(argv: List[str]) -> argparse.Namespace:
     """Parse gui args."""
     parser = argparse.ArgumentParser(description="Env Inspector GUI")
     parser.add_argument(

--- a/env_inspector_core/cli.py
+++ b/env_inspector_core/cli.py
@@ -89,7 +89,7 @@ def _is_successful_payload(item: dict) -> bool:
     return bool(item.get("success", False))
 
 
-def _list_payload_success(payload: list[object]) -> bool:
+def _list_payload_success(payload: List[object]) -> bool:
     """Return whether every payload item reports success."""
     items = [item for item in payload if isinstance(item, dict)]
     return bool(items) and all(_is_successful_payload(item) for item in items)
@@ -114,9 +114,9 @@ def _reject_raw_secret_stdout(args: argparse.Namespace) -> None:
         )
 
 
-def _sanitize_stdout_row(row: dict[str, Any]) -> dict[str, Any]:
+def _sanitize_stdout_row(row: Dict[str, Any]) -> Dict[str, Any]:
     """Mask secret values before writing rows to stdout."""
-    safe_row: dict[str, Any] = {}
+    safe_row: Dict[str, Any] = {}
     for key in _SAFE_EXPORT_KEYS:
         if key == "value":
             safe_row[key] = (
@@ -129,7 +129,7 @@ def _sanitize_stdout_row(row: dict[str, Any]) -> dict[str, Any]:
 
 def _stdout_safe_rows(
     service: SupportsListRecords, args: argparse.Namespace
-) -> list[dict[str, Any]]:
+) -> List[Dict[str, Any]]:
     """Collect rows that are safe to emit directly to stdout."""
     rows = service.list_records(
         include_raw_secrets=False,
@@ -140,13 +140,13 @@ def _stdout_safe_rows(
         distro=args.distro,
         scan_depth=args.scan_depth,
     )
-    safe_rows: list[dict[str, Any]] = []
+    safe_rows: List[Dict[str, Any]] = []
     for row in rows:
         safe_rows.append(_sanitize_stdout_row(row))
     return safe_rows
 
 
-def _emit_stdout_rows(rows: list[dict[str, Any]], *, output: str) -> None:
+def _emit_stdout_rows(rows: List[Dict[str, Any]], *, output: str) -> None:
     """Emit rows in the requested stdout format."""
     if output == "json":
         sys.stdout.write(json.dumps(rows, ensure_ascii=True, indent=2))

--- a/env_inspector_core/models.py
+++ b/env_inspector_core/models.py
@@ -22,7 +22,7 @@ class EnvRecord:
     requires_privilege: bool
     last_error: str | None = None
 
-    def to_dict(self, include_value: bool = True) -> dict[str, Any]:
+    def to_dict(self, include_value: bool = True) -> Dict[str, Any]:
         """To dict."""
         payload = asdict(self)
         if not include_value:
@@ -43,6 +43,6 @@ class OperationResult:
     error_message: str | None
     value_masked: str | None = None
 
-    def to_dict(self) -> dict[str, Any]:
+    def to_dict(self) -> Dict[str, Any]:
         """To dict."""
         return asdict(self)

--- a/env_inspector_core/parsing.py
+++ b/env_inspector_core/parsing.py
@@ -38,7 +38,7 @@ def shell_single_quote(value: str) -> str:
     return "'" + value.replace("'", "'\"'\"'") + "'"
 
 
-def _render_upsert(lines: list[str], had_trailing_newline: bool) -> str:
+def _render_upsert(lines: List[str], had_trailing_newline: bool) -> str:
     """Render updated content while preserving a trailing newline."""
     text = "\n".join(lines)
     if had_trailing_newline or lines:
@@ -46,7 +46,7 @@ def _render_upsert(lines: list[str], had_trailing_newline: bool) -> str:
     return text
 
 
-def _render_remove(lines: list[str], had_trailing_newline: bool) -> str:
+def _render_remove(lines: List[str], had_trailing_newline: bool) -> str:
     """Render removed content while preserving trailing-newline semantics."""
     text = "\n".join(lines)
     if had_trailing_newline and lines:
@@ -54,7 +54,7 @@ def _render_remove(lines: list[str], had_trailing_newline: bool) -> str:
     return text
 
 
-def _append_with_optional_blank(lines: list[str], new_line: str) -> None:
+def _append_with_optional_blank(lines: List[str], new_line: str) -> None:
     """Append a line, inserting a blank separator when needed."""
     if lines and lines[-1].strip():
         lines.append("")
@@ -62,13 +62,13 @@ def _append_with_optional_blank(lines: list[str], new_line: str) -> None:
 
 
 def _replace_first_match(
-    lines: list[str],
+    lines: List[str],
     *,
     replacement: str,
     matcher: Callable[[str], bool],
-) -> tuple[list[str], bool]:
+) -> Tuple[List[str], bool]:
     """Replace the first matching line and drop any later duplicates."""
-    out: list[str] = []
+    out: List[str] = []
     replaced = False
     for line in lines:
         if matcher(line):
@@ -111,9 +111,9 @@ def _matches_powershell_key(line: str, key: str) -> bool:
     return bool(match and match.group(1).lower() == key.lower())
 
 
-def parse_dotenv_text(text: str) -> list[tuple[str, str]]:
+def parse_dotenv_text(text: str) -> List[Tuple[str, str]]:
     """Parse dotenv-style text into ordered key/value pairs."""
-    rows: list[tuple[str, str]] = []
+    rows: List[Tuple[str, str]] = []
     for line in text.splitlines():
         stripped = line.strip()
         if not stripped or stripped.startswith("#"):
@@ -131,9 +131,9 @@ def parse_dotenv_text(text: str) -> list[tuple[str, str]]:
     return rows
 
 
-def parse_bash_exports(text: str) -> dict[str, str]:
+def parse_bash_exports(text: str) -> Dict[str, str]:
     """Parse `export KEY=value` lines into a mapping."""
-    values: dict[str, str] = {}
+    values: Dict[str, str] = {}
     for line in text.splitlines():
         match = EXPORT_LINE_RE.match(line)
         if not match:
@@ -143,9 +143,9 @@ def parse_bash_exports(text: str) -> dict[str, str]:
     return values
 
 
-def parse_etc_environment(text: str) -> dict[str, str]:
+def parse_etc_environment(text: str) -> Dict[str, str]:
     """Parse `/etc/environment`-style assignments into a mapping."""
-    values: dict[str, str] = {}
+    values: Dict[str, str] = {}
     for line in text.splitlines():
         stripped = line.strip()
         if not stripped or stripped.startswith("#"):

--- a/env_inspector_core/path_policy.py
+++ b/env_inspector_core/path_policy.py
@@ -16,7 +16,7 @@ class ScopedPath:
     """A filesystem path constrained to approved scope roots."""
 
     path: Path
-    roots: tuple[Path, ...]
+    roots: Tuple[Path, ...]
 
 
 def _contains_null(raw: str) -> bool:
@@ -40,10 +40,10 @@ def _normalize_path_text(value: str | Path, *, field_name: str) -> str:
     return os.path.normpath(os.path.abspath(os.path.expanduser(raw)))
 
 
-def normalize_scope_roots(roots: Iterable[str | Path]) -> list[Path]:
+def normalize_scope_roots(roots: Iterable[str | Path]) -> List[Path]:
     """Normalize scope roots."""
-    normalized: list[Path] = []
-    seen: set[str] = set()
+    normalized: List[Path] = []
+    seen: Set[str] = set()
     workspace_root = Path.cwd()
     workspace_text = str(workspace_root)
     for root in roots:
@@ -98,7 +98,7 @@ def _validate_dotenv_name(path: Path) -> None:
     )
 
 
-def parse_scoped_dotenv_target(target: str, *, roots: list[Path]) -> ScopedPath:
+def parse_scoped_dotenv_target(target: str, *, roots: List[Path]) -> ScopedPath:
     """Parse scoped dotenv target."""
     if not target.startswith("dotenv:"):
         raise PathPolicyError("Expected target with 'dotenv:' prefix.")

--- a/env_inspector_core/providers.py
+++ b/env_inspector_core/providers.py
@@ -5,7 +5,7 @@ import os
 import re
 from contextlib import suppress
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, cast
+from typing import Any, Dict, List, Optional, TYPE_CHECKING, Tuple, cast
 from collections.abc import Callable
 
 from .constants import (
@@ -41,8 +41,8 @@ if TYPE_CHECKING:
         REG_EXPAND_SZ: int
         REG_SZ: int
         OpenKey: Callable[[Any, str, int, int], Any]
-        EnumValue: Callable[[Any, int], tuple[str, Any, Any]]
-        QueryInfoKey: Callable[[Any], tuple[int, int, int]]
+        EnumValue: Callable[[Any, int], Tuple[str, Any, Any]]
+        QueryInfoKey: Callable[[Any], Tuple[int, int, int]]
         SetValueEx: Callable[[Any, str, int, int, str], None]
         DeleteValue: Callable[[Any, str], None]
 
@@ -50,9 +50,9 @@ if TYPE_CHECKING:
         """Protocol for the WSL interop client."""
 
         available: Callable[[], bool]
-        list_distros: Callable[[], list[str]]
+        list_distros: Callable[[], List[str]]
         read_file: Callable[[str, str], str]
-        scan_dotenv_files: Callable[[str, str, int], list[str]]
+        scan_dotenv_files: Callable[[str, str, int], List[str]]
 else:
     WinregModule = Any
     WslClient = Any
@@ -121,9 +121,9 @@ def _dotenv_matches(filename: str) -> bool:
     return filename == ".env" or filename.startswith(".env.")
 
 
-def _iter_dotenv_candidates(root: Path, max_depth: int) -> list[Path]:
+def _iter_dotenv_candidates(root: Path, max_depth: int) -> List[Path]:
     """Iter dotenv candidates."""
-    files: list[Path] = []
+    files: List[Path] = []
     for current, dirs, filenames in os.walk(
         root
     ):  # codeql[py/path-injection] root constrained to workspace scope
@@ -141,7 +141,7 @@ def _iter_dotenv_candidates(root: Path, max_depth: int) -> list[Path]:
     return files
 
 
-def discover_dotenv_files(root: Path, max_depth: int = 5) -> list[Path]:
+def discover_dotenv_files(root: Path, max_depth: int = 5) -> List[Path]:
     """Discover dotenv files."""
     try:
         safe_root = resolve_scan_root(root)
@@ -150,9 +150,9 @@ def discover_dotenv_files(root: Path, max_depth: int = 5) -> list[Path]:
     return sorted(_iter_dotenv_candidates(safe_root, max_depth=max_depth))
 
 
-def collect_process_records(context: str = "windows") -> list[EnvRecord]:
+def collect_process_records(context: str = "windows") -> List[EnvRecord]:
     """Collect process records."""
-    rows: list[EnvRecord] = []
+    rows: List[EnvRecord] = []
     for key, value in sorted(os.environ.items(), key=lambda kv: kv[0].lower()):
         rows.append(
             EnvRecord(
@@ -185,7 +185,7 @@ class WindowsRegistryProvider:
             raise RuntimeError("Windows registry provider only available on Windows.")
 
     @staticmethod
-    def _scope_details(scope: str, access: int) -> tuple[Any, str, int]:
+    def _scope_details(scope: str, access: int) -> Tuple[Any, str, int]:
         """Scope details."""
         if scope not in {
             WindowsRegistryProvider.USER_SCOPE,
@@ -209,12 +209,12 @@ class WindowsRegistryProvider:
         return root, path, scoped_access
 
     @staticmethod
-    def _scope_to_key(scope: str) -> tuple[Any, str]:
+    def _scope_to_key(scope: str) -> Tuple[Any, str]:
         """Scope to key."""
         root, path, _ = WindowsRegistryProvider._scope_details(scope, 0)
         return root, path
 
-    def list_scope(self, scope: str) -> dict[str, str]:
+    def list_scope(self, scope: str) -> Dict[str, str]:
         """List scope."""
         registry = _require_winreg()
         root, path, access = self._scope_details(scope, registry.KEY_READ)
@@ -245,9 +245,9 @@ class WindowsRegistryProvider:
             registry.DeleteValue(regkey, key)
 
 
-def build_registry_records(provider: WindowsRegistryProvider) -> list[EnvRecord]:
+def build_registry_records(provider: WindowsRegistryProvider) -> List[EnvRecord]:
     """Build registry records."""
-    rows: list[EnvRecord] = []
+    rows: List[EnvRecord] = []
     for (
         source_type,
         source_id,
@@ -309,7 +309,7 @@ def _is_valid_powershell_env_key(key: str) -> bool:
     return re.fullmatch(r"[A-Za-z_]\w*", key) is not None
 
 
-def _parse_powershell_assignment(line: str) -> tuple[str, str] | None:
+def _parse_powershell_assignment(line: str) -> Tuple[str, str] | None:
     """Parse powershell assignment."""
     stripped = line.lstrip()
     if not stripped or stripped.startswith("#") or not stripped.startswith("$env:"):
@@ -325,9 +325,9 @@ def _parse_powershell_assignment(line: str) -> tuple[str, str] | None:
     return key, _normalize_powershell_assignment_value(value)
 
 
-def parse_powershell_profile_text(text: str) -> list[tuple[str, str]]:
+def parse_powershell_profile_text(text: str) -> List[Tuple[str, str]]:
     """Parse powershell profile text."""
-    rows: list[tuple[str, str]] = []
+    rows: List[Tuple[str, str]] = []
     for line in text.splitlines():
         entry = _parse_powershell_assignment(line)
         if entry:
@@ -337,9 +337,9 @@ def parse_powershell_profile_text(text: str) -> list[tuple[str, str]]:
 
 def collect_dotenv_records(
     root: Path, max_depth: int = 5, context: str = "windows"
-) -> list[EnvRecord]:
+) -> List[EnvRecord]:
     """Collect dotenv records."""
-    rows: list[EnvRecord] = []
+    rows: List[EnvRecord] = []
     for path in discover_dotenv_files(root, max_depth=max_depth):
         try:
             text = path.read_text(encoding="utf-8")
@@ -366,9 +366,9 @@ def collect_dotenv_records(
     return rows
 
 
-def collect_powershell_profile_records(profile_paths: list[Path]) -> list[EnvRecord]:
+def collect_powershell_profile_records(profile_paths: List[Path]) -> List[EnvRecord]:
     """Collect powershell profile records."""
-    rows: list[EnvRecord] = []
+    rows: List[EnvRecord] = []
     for path in profile_paths:
         if not path.exists():
             continue
@@ -400,9 +400,9 @@ def collect_linux_records(
     bashrc_path: Path | None = None,
     etc_environment_path: Path | None = None,
     context: str = "linux",
-) -> list[EnvRecord]:
+) -> List[EnvRecord]:
     """Collect linux records."""
-    rows: list[EnvRecord] = []
+    rows: List[EnvRecord] = []
 
     bashrc = bashrc_path or (Path.home() / ".bashrc")
     etc_env = etc_environment_path or Path("/etc/environment")

--- a/env_inspector_core/providers_wsl.py
+++ b/env_inspector_core/providers_wsl.py
@@ -86,7 +86,7 @@ class WslProvider:
                 return data.decode(errors="ignore")
         return data.decode(errors="ignore")
 
-    def _run(self, args: list[str], input_text: str | None = None) -> str:
+    def _run(self, args: List[str], input_text: str | None = None) -> str:
         """Run."""
         if not self.available():
             raise RuntimeError("wsl.exe not available")
@@ -107,7 +107,7 @@ class WslProvider:
             )
         return out
 
-    def list_distros(self) -> list[str]:
+    def list_distros(self) -> List[str]:
         """List distros."""
         text = self._run(["-l", "-q"])
         return list(
@@ -121,7 +121,7 @@ class WslProvider:
             )
         )
 
-    def list_distros_for_ui(self) -> list[str]:
+    def list_distros_for_ui(self) -> List[str]:
         """List distros for ui."""
         return [d for d in self.list_distros() if not _HELPER_DISTRO_RE.match(d)]
 
@@ -167,7 +167,7 @@ class WslProvider:
 
     def scan_dotenv_files(
         self, distro: str, root_path: str, max_depth: int
-    ) -> list[str]:
+    ) -> List[str]:
         """Scan dotenv files."""
         quoted_root = shlex.quote(root_path)
         command = (
@@ -186,12 +186,12 @@ class _WslRecordBatch:
     context: str
     source_type: str
     source_path: str
-    pairs: dict[str, str]
+    pairs: Dict[str, str]
     precedence_rank: int
     requires_privilege: bool
 
 
-def _append_wsl_records(rows: list[EnvRecord], batch: _WslRecordBatch) -> None:
+def _append_wsl_records(rows: List[EnvRecord], batch: _WslRecordBatch) -> None:
     """Append wsl records."""
     for key, value in batch.pairs.items():
         rows.append(
@@ -216,10 +216,10 @@ def _append_wsl_records(rows: list[EnvRecord], batch: _WslRecordBatch) -> None:
 def collect_wsl_records(
     wsl: WslProvider,
     include_etc: bool = True,
-    exclude_distros: set[str] | None = None,
-) -> list[EnvRecord]:
+    exclude_distros: Set[str] | None = None,
+) -> List[EnvRecord]:
     """Collect wsl records."""
-    rows: list[EnvRecord] = []
+    rows: List[EnvRecord] = []
     if not wsl.available():
         return rows
 
@@ -255,9 +255,9 @@ def collect_wsl_records(
 
 def collect_wsl_dotenv_records(
     wsl: WslProvider, distro: str, root_path: str, max_depth: int
-) -> list[EnvRecord]:
+) -> List[EnvRecord]:
     """Collect wsl dotenv records."""
-    rows: list[EnvRecord] = []
+    rows: List[EnvRecord] = []
     if not wsl.available():
         return rows
     for path in wsl.scan_dotenv_files(distro, root_path, max_depth):

--- a/env_inspector_core/rendering.py
+++ b/env_inspector_core/rendering.py
@@ -24,7 +24,7 @@ def audit_safe_result(result: OperationResult, *, redact: bool) -> OperationResu
     )
 
 
-def export_rows(rows: list[dict[str, Any]], *, output: str) -> str:
+def export_rows(rows: List[Dict[str, Any]], *, output: str) -> str:
     """Export rows."""
     if output == "json":
         return json.dumps(rows, ensure_ascii=True, indent=2)

--- a/env_inspector_core/resolver.py
+++ b/env_inspector_core/resolver.py
@@ -29,7 +29,7 @@ LINUX_PRECEDENCE = {
 
 
 def resolve_effective_value(
-    records: list[EnvRecord], key: str, context: str
+    records: List[EnvRecord], key: str, context: str
 ) -> EnvRecord | None:
     """Resolve effective value."""
     key_norm = key.strip().lower()
@@ -48,7 +48,7 @@ def resolve_effective_value(
     else:
         table = WINDOWS_PRECEDENCE
 
-    def rank(rec: EnvRecord) -> tuple[int, int, str]:
+    def rank(rec: EnvRecord) -> Tuple[int, int, str]:
         """Rank."""
         source_rank = table.get(rec.source_type, rec.precedence_rank)
         return (source_rank, rec.precedence_rank, rec.source_path)

--- a/env_inspector_core/service.py
+++ b/env_inspector_core/service.py
@@ -227,7 +227,7 @@ class EnvInspectorService:
         """Resolve `/etc/environment` through the class seam."""
         return _service_aliases.linux_etc_environment_path(cls)
 
-    def bridge_distros(self) -> list[str]:
+    def bridge_distros(self) -> List[str]:
         """Return available WSL bridge distros."""
         return self._bridge_distros()
 
@@ -238,7 +238,7 @@ class EnvInspectorService:
     def validate_path_in_roots(
         self,
         path: Path,
-        roots: list[Path],
+        roots: List[Path],
         *,
         label: str,
     ) -> Path:
@@ -253,7 +253,7 @@ class EnvInspectorService:
         self,
         *,
         candidate_path: Path,
-        allowed_roots: list[Path],
+        allowed_roots: List[Path],
         text: str,
         label: str,
     ) -> Path:
@@ -353,8 +353,8 @@ class EnvInspectorService:
 
     def effective_scope_roots(
         self,
-        scope_roots: list[str | Path] | None = None,
-    ) -> list[Path]:
+        scope_roots: List[str | Path] | None = None,
+    ) -> List[Path]:
         """Resolve scope roots through the bound helper."""
         return self._effective_scope_roots(scope_roots)
 
@@ -384,10 +384,10 @@ class EnvInspectorService:
 
     def _effective_scope_roots(
         self,
-        scope_roots: list[str | Path] | None = None,
-    ) -> list[Path]:
+        scope_roots: List[str | Path] | None = None,
+    ) -> List[Path]:
         """Return the default scope roots plus any validated overrides."""
-        roots: list[Path] = list(self.default_scope_roots)
+        roots: List[Path] = list(self.default_scope_roots)
         if scope_roots:
             roots.extend(normalize_scope_roots(scope_roots))
         return normalize_scope_roots(roots)
@@ -396,12 +396,12 @@ class EnvInspectorService:
     def resolve_effective(
         key: str,
         context: str,
-        records: list[EnvRecord],
+        records: List[EnvRecord],
     ) -> EnvRecord | None:
         """Resolve the effective record for a key within a context."""
         return resolve_effective_value(records, key, context)
 
-    def _collect_host_rows(self, root_path: Path, scan_depth: int) -> list[EnvRecord]:
+    def _collect_host_rows(self, root_path: Path, scan_depth: int) -> List[EnvRecord]:
         """Collect host-visible records for the active runtime context."""
         return _collect_host_rows_helper(
             request=HostCollectionRequest(
@@ -428,7 +428,7 @@ class EnvInspectorService:
         scan_depth: int,
         distro: str | None,
         wsl_path: str | None,
-    ) -> list[EnvRecord]:
+    ) -> List[EnvRecord]:
         """Collect records from the requested WSL distro and optional dotenv path."""
         return _collect_wsl_rows_helper(
             runtime_context=self.runtime_context,
@@ -445,7 +445,7 @@ class EnvInspectorService:
         self,
         request: ListRecordsRequest | None = None,
         **kwargs: Any,
-    ) -> list[dict[str, Any]]:
+    ) -> List[Dict[str, Any]]:
         """Collect records, apply filters, and serialize the result payload."""
         if request is None:
             request = ListRecordsRequest(**kwargs)
@@ -481,7 +481,7 @@ class EnvInspectorService:
         *,
         target: str,
         text: str,
-        scope_roots: list[Path],
+        scope_roots: List[Path],
     ) -> None:
         """Restore a scoped dotenv target from backup text."""
         _restore_dotenv_target_helper(
@@ -542,7 +542,7 @@ class EnvInspectorService:
         *,
         target: str,
         text: str,
-        scope_roots: list[Path],
+        scope_roots: List[Path],
     ) -> None:
         """Dispatch backup restoration to the target-specific helper."""
         _restore_target_helper(
@@ -560,8 +560,8 @@ class EnvInspectorService:
         self,
         *,
         backup: str,
-        scope_roots: list[str | Path] | None = None,
-    ) -> dict[str, Any]:
+        scope_roots: List[str | Path] | None = None,
+    ) -> Dict[str, Any]:
         """Restore a recorded backup payload to its original target."""
         operation_id = f"restore-{uuid.uuid4().hex[:10]}"
         path = Path(backup)

--- a/env_inspector_core/service_aliases.py
+++ b/env_inspector_core/service_aliases.py
@@ -55,7 +55,7 @@ def registry_write(self, *args: Any, apply_changes: bool, **kwargs: Any):
     return before, after, None, requires_priv, None
 
 
-def bridge_distros(self) -> list[str]:
+def bridge_distros(self) -> List[str]:
     """Return bridge distros, excluding the active Linux-host distro."""
     if not self.wsl.available():
         return []
@@ -66,7 +66,7 @@ def bridge_distros(self) -> list[str]:
     return distros
 
 
-def list_contexts(self) -> list[str]:
+def list_contexts(self) -> List[str]:
     """Return the runtime context plus any available WSL bridge contexts."""
     contexts = [self.runtime_context]
     if self.wsl.available():
@@ -75,7 +75,7 @@ def list_contexts(self) -> list[str]:
     return contexts
 
 
-def get_powershell_profile_paths() -> list[Path]:
+def get_powershell_profile_paths() -> List[Path]:
     """Return the PowerShell profile paths exposed by the path helper."""
     return _get_powershell_profile_paths()
 
@@ -107,9 +107,9 @@ def linux_etc_environment_path(cls) -> Path:
 
 def available_targets(
     self,
-    records: list[EnvRecord],
+    records: List[EnvRecord],
     context: str | None = None,
-) -> list[str]:
+) -> List[str]:
     """Return the set of editable targets visible for the provided records."""
     return _available_targets_helper(
         records,
@@ -118,7 +118,7 @@ def available_targets(
     )
 
 
-def list_records_raw(self, **kwargs: Any) -> list[EnvRecord]:
+def list_records_raw(self, **kwargs: Any) -> List[EnvRecord]:
     """Return raw `EnvRecord` instances instead of serialized payload rows."""
     payload = self.list_records(include_raw_secrets=True, **kwargs)
     return [EnvRecord(**item) for item in payload]
@@ -129,9 +129,9 @@ def preview_set(
     *,
     key: str,
     value: str,
-    targets: list[str],
+    targets: List[str],
     scope_roots=None,
-) -> list[dict]:
+) -> List[dict]:
     """Preview a set operation and serialize the results."""
     return [
         r.to_dict()
@@ -150,9 +150,9 @@ def preview_remove(
     self,
     *,
     key: str,
-    targets: list[str],
+    targets: List[str],
     scope_roots=None,
-) -> list[dict]:
+) -> List[dict]:
     """Preview a remove operation and serialize the results."""
     return [
         r.to_dict()
@@ -177,7 +177,7 @@ def _results_payload(results):
     }
 
 
-def set_key(self, *, key: str, value: str, targets: list[str], scope_roots=None):
+def set_key(self, *, key: str, value: str, targets: List[str], scope_roots=None):
     """Apply a set operation and return the legacy payload shape."""
     results = self.apply(
         action="set",
@@ -190,7 +190,7 @@ def set_key(self, *, key: str, value: str, targets: list[str], scope_roots=None)
     return _results_payload(results)
 
 
-def remove_key(self, *, key: str, targets: list[str], scope_roots=None):
+def remove_key(self, *, key: str, targets: List[str], scope_roots=None):
     """Apply a remove operation and return the legacy payload shape."""
     results = self.apply(
         action="remove",
@@ -215,7 +215,7 @@ def export_records(
     return export_rows(rows, output=output)
 
 
-def list_backups(self, *, target: str | None = None) -> list[str]:
+def list_backups(self, *, target: str | None = None) -> List[str]:
     """Return backup paths, optionally scoped to a single target."""
     if target:
         return [str(p) for p in self.backup_mgr.list_backups(target)]

--- a/env_inspector_core/service_listing.py
+++ b/env_inspector_core/service_listing.py
@@ -33,18 +33,18 @@ class HostCollectionRequest:
     root_path: Path
     scan_depth: int
     win_provider: Any
-    powershell_profile_paths: list[Path]
+    powershell_profile_paths: List[Path]
 
 
 @dataclass(frozen=True)
 class HostRowCollectors:
     """Callable references for each host record collection strategy."""
 
-    collect_process_records_fn: Callable[..., list[EnvRecord]]
-    collect_dotenv_records_fn: Callable[..., list[EnvRecord]]
-    build_registry_records_fn: Callable[[Any], list[EnvRecord]]
-    collect_powershell_profile_records_fn: Callable[[list[Path]], list[EnvRecord]]
-    collect_linux_records_fn: Callable[..., list[EnvRecord]]
+    collect_process_records_fn: Callable[..., List[EnvRecord]]
+    collect_dotenv_records_fn: Callable[..., List[EnvRecord]]
+    build_registry_records_fn: Callable[[Any], List[EnvRecord]]
+    collect_powershell_profile_records_fn: Callable[[List[Path]], List[EnvRecord]]
+    collect_linux_records_fn: Callable[..., List[EnvRecord]]
 
 
 @dataclass(frozen=True)
@@ -60,9 +60,9 @@ def collect_host_rows(
     *,
     request: HostCollectionRequest,
     collectors: HostRowCollectors,
-) -> list[EnvRecord]:
+) -> List[EnvRecord]:
     """Collect host rows."""
-    rows: list[EnvRecord] = []
+    rows: List[EnvRecord] = []
     rows.extend(collectors.collect_process_records_fn(context=request.runtime_context))
     rows.extend(
         collectors.collect_dotenv_records_fn(
@@ -93,7 +93,7 @@ def collect_host_rows(
     return rows
 
 
-def collect_wsl_rows(*args: Any, **kwargs: Any) -> list[EnvRecord]:
+def collect_wsl_rows(*args: Any, **kwargs: Any) -> List[EnvRecord]:
     """Collect wsl rows."""
     if args:
         raise TypeError("collect_wsl_rows accepts keyword arguments only.")
@@ -137,10 +137,10 @@ def _bridge_rows(
     current_wsl_distro: str | None,
     wsl: Any,
     collect_wsl_records_fn,
-) -> list[EnvRecord]:
+) -> List[EnvRecord]:
     """Bridge rows."""
     try:
-        exclude_distros: set[str] | None = None
+        exclude_distros: Set[str] | None = None
         if runtime_context == "linux" and current_wsl_distro:
             exclude_distros = {current_wsl_distro}
         return collect_wsl_records_fn(
@@ -152,7 +152,7 @@ def _bridge_rows(
 
 def _wsl_dotenv_rows(
     *, request: _WslDotenvRequest, wsl: Any, collect_wsl_dotenv_records_fn
-) -> list[EnvRecord]:
+) -> List[EnvRecord]:
     """Wsl dotenv rows."""
     if not (request.distro and request.wsl_path):
         return []
@@ -168,11 +168,11 @@ def _wsl_dotenv_rows(
 
 
 def apply_row_filters(
-    rows: list[EnvRecord],
+    rows: List[EnvRecord],
     *,
-    source: list[str] | None,
+    source: List[str] | None,
     context: str | None,
-) -> list[EnvRecord]:
+) -> List[EnvRecord]:
     """Apply row filters."""
     if source:
         source_set = set(source)
@@ -197,7 +197,7 @@ def record_target(record: EnvRecord) -> str | None:
         SOURCE_LINUX_BASHRC: TARGET_LINUX_BASHRC,
         SOURCE_LINUX_ETC_ENV: TARGET_LINUX_ETC_ENV,
     }
-    dynamic_targets: dict[str, Callable[[EnvRecord], str]] = {
+    dynamic_targets: Dict[str, Callable[[EnvRecord], str]] = {
         SOURCE_DOTENV: lambda rec: f"dotenv:{rec.source_path}",
         SOURCE_WSL_DOTENV: lambda rec: f"wsl_dotenv:{rec.source_path}",
         SOURCE_WSL_BASHRC: lambda rec: f"wsl:{rec.source_id}:bashrc",
@@ -215,13 +215,13 @@ def record_target(record: EnvRecord) -> str | None:
 
 
 def available_targets(
-    records: list[EnvRecord],
+    records: List[EnvRecord],
     *,
     context: str | None,
     win_provider_present: bool,
-) -> list[str]:
+) -> List[str]:
     """Available targets."""
-    targets: set[str] = set()
+    targets: Set[str] = set()
     for record in records:
         if context and record.context != context:
             continue
@@ -238,10 +238,10 @@ def available_targets(
 
 
 def rows_to_payload(
-    rows: list[EnvRecord], *, include_raw_secrets: bool
-) -> list[dict[str, Any]]:
+    rows: List[EnvRecord], *, include_raw_secrets: bool
+) -> List[Dict[str, Any]]:
     """Rows to payload."""
-    payload: list[dict[str, Any]] = []
+    payload: List[Dict[str, Any]] = []
     for record in rows:
         item = record.to_dict(include_value=True)
         if bool(item.get("is_secret")) and not include_raw_secrets:

--- a/env_inspector_core/service_models.py
+++ b/env_inspector_core/service_models.py
@@ -26,8 +26,8 @@ class TargetOperationBatch:
     action: str
     key: str
     value: str | None
-    targets: list[str]
-    scope_roots: list[str | Path] | None = None
+    targets: List[str]
+    scope_roots: List[str | Path] | None = None
 
 
 @dataclass(frozen=True)
@@ -36,7 +36,7 @@ class ListRecordsRequest:
 
     root: str | Path | None = None
     context: str | None = None
-    source: list[str] | None = None
+    source: List[str] | None = None
     wsl_path: str | None = None
     distro: str | None = None
     scan_depth: int = DEFAULT_SCAN_DEPTH

--- a/env_inspector_core/service_mutations.py
+++ b/env_inspector_core/service_mutations.py
@@ -61,7 +61,7 @@ TARGET_POWERSHELL_ALL_USERS = "powershell:all_users"
 DOTENV_TARGET_PREFIX = "dotenv:"
 WSL_DOTENV_TARGET_PREFIX = "wsl_dotenv:"
 LINUX_ETC_ENV_PATH = "/etc/environment"
-PlannedMutation = tuple[str, str, str | None, bool, str | None]
+PlannedMutation = Tuple[str, str, str | None, bool, str | None]
 
 
 def _coerce_target_request(*args: Any, **kwargs: Any) -> TargetOperationRequest:
@@ -198,7 +198,7 @@ def write_linux_etc_environment_with_privilege(self, text: str) -> None:
     )
 
 
-def parse_wsl_dotenv_target(self, target: str) -> tuple[str, str]:
+def parse_wsl_dotenv_target(self, target: str) -> Tuple[str, str]:
     """Parse and validate a WSL dotenv target."""
     return _parse_wsl_dotenv_target_helper(
         target,
@@ -208,7 +208,7 @@ def parse_wsl_dotenv_target(self, target: str) -> tuple[str, str]:
     )
 
 
-def resolve_wsl_target(self, target: str) -> tuple[str, str, str, bool]:
+def resolve_wsl_target(self, target: str) -> Tuple[str, str, str, bool]:
     """Resolve a WSL mutation target into concrete file details."""
     return _resolve_wsl_target_helper(
         target,
@@ -309,7 +309,7 @@ def validate_target_for_operation(
     self,
     target: str,
     *,
-    scope_roots: list[Path],
+    scope_roots: List[Path],
 ) -> None:
     """Validate that a target can participate in a mutation."""
     if target in {
@@ -333,7 +333,7 @@ def validate_target_for_operation(
     raise RuntimeError(f"Unsupported target: {target}")
 
 
-def preview_target_diff(self, *args: Any, **kwargs: Any) -> tuple[str, str]:
+def preview_target_diff(self, *args: Any, **kwargs: Any) -> Tuple[str, str]:
     """Return the original text and preview diff for a target mutation."""
     request = _coerce_target_request(*args, **kwargs)
     validate_target_for_operation(
@@ -411,7 +411,7 @@ def apply(
     *args: Any,
     preview_only: bool = False,
     **kwargs: Any,
-) -> list[OperationResult]:
+) -> List[OperationResult]:
     """Apply a normalized batch of mutations across selected targets."""
     request = _coerce_target_batch(*args, **kwargs)
     validate_env_key(request.key)
@@ -420,7 +420,7 @@ def apply(
 
     secret_operation = looks_secret(request.key, request.value or "")
     resolved_scope_roots = self.effective_scope_roots(request.scope_roots)
-    results: list[OperationResult] = []
+    results: List[OperationResult] = []
     for target in request.targets:
         target_request = TargetOperationRequest(
             target=target,

--- a/env_inspector_core/service_ops.py
+++ b/env_inspector_core/service_ops.py
@@ -69,7 +69,7 @@ def operation_result(payload: OperationResultInput) -> OperationResult:
     return make_operation_result(payload)
 
 
-def operation_error_types() -> tuple[type[BaseException], ...]:
+def operation_error_types() -> Tuple[Type[BaseException], ...]:
     """Operation error types."""
     return (
         RuntimeError,

--- a/env_inspector_core/service_ops_request.py
+++ b/env_inspector_core/service_ops_request.py
@@ -10,9 +10,9 @@ def _raise_mixed_request_usage() -> None:
 
 def _extract_request_object(
     *,
-    args: tuple[Any, ...],
-    kwargs: dict[str, Any],
-    required_attributes: tuple[str, ...],
+    args: Tuple[Any, ...],
+    kwargs: Dict[str, Any],
+    required_attributes: Tuple[str, ...],
 ) -> Any | None:
     """Extract request object."""
     if "request" in kwargs:
@@ -30,7 +30,7 @@ def _extract_request_object(
     return None
 
 
-def _target_operation_payload(request: Any) -> dict[str, Any]:
+def _target_operation_payload(request: Any) -> Dict[str, Any]:
     """Target operation payload."""
     return {
         "target": request.target,
@@ -41,7 +41,7 @@ def _target_operation_payload(request: Any) -> dict[str, Any]:
     }
 
 
-def _target_operation_batch_payload(request: Any) -> dict[str, Any]:
+def _target_operation_batch_payload(request: Any) -> Dict[str, Any]:
     """Target operation batch payload."""
     return {
         "action": request.action,
@@ -71,10 +71,10 @@ def _require_values(message: str, **values: Any) -> None:
 
 
 def _resolve_operation_inputs(
-    args: tuple[Any, ...],
-    kwargs: dict[str, Any],
-    field_names: tuple[str, ...],
-) -> tuple[Any, ...]:
+    args: Tuple[Any, ...],
+    kwargs: Dict[str, Any],
+    field_names: Tuple[str, ...],
+) -> Tuple[Any, ...]:
     """Resolve operation inputs."""
     if args and isinstance(args[0], str):
         return tuple(
@@ -84,7 +84,7 @@ def _resolve_operation_inputs(
     return tuple(kwargs.pop(name, None) for name in field_names)
 
 
-def normalize_target_operation_request(*args: Any, **kwargs: Any) -> dict[str, Any]:
+def normalize_target_operation_request(*args: Any, **kwargs: Any) -> Dict[str, Any]:
     """Normalize target operation request."""
     request = _extract_request_object(
         args=args,
@@ -114,7 +114,7 @@ def normalize_target_operation_request(*args: Any, **kwargs: Any) -> dict[str, A
     }
 
 
-def normalize_target_operation_batch(*args: Any, **kwargs: Any) -> dict[str, Any]:
+def normalize_target_operation_batch(*args: Any, **kwargs: Any) -> Dict[str, Any]:
     """Normalize target operation batch."""
     request = _extract_request_object(
         args=args,

--- a/env_inspector_core/service_paths.py
+++ b/env_inspector_core/service_paths.py
@@ -6,7 +6,7 @@ from typing import List, Tuple
 from collections.abc import Callable, Sequence
 
 
-def get_powershell_profile_paths() -> list[Path]:
+def get_powershell_profile_paths() -> List[Path]:
     """Get powershell profile paths."""
     docs = Path.home() / "Documents"
     current = docs / "PowerShell" / "Microsoft.PowerShell_profile.ps1"
@@ -60,7 +60,7 @@ def powershell_target_path_and_roots(
     profile_resolver: Callable[[str], Path],
     current_user_target: str,
     all_users_target: str,
-) -> tuple[Path, list[Path], bool]:
+) -> Tuple[Path, List[Path], bool]:
     """Powershell target path and roots."""
     if target == current_user_target:
         profile = profile_resolver(current_user_target).resolve(strict=False)

--- a/env_inspector_core/service_wsl.py
+++ b/env_inspector_core/service_wsl.py
@@ -31,7 +31,7 @@ def parse_wsl_dotenv_target(
     prefix: str,
     validate_distro_name_fn,
     validate_dotenv_path_fn,
-) -> tuple[str, str]:
+) -> Tuple[str, str]:
     """Parse wsl dotenv target."""
     raw = target[len(prefix) :]
     try:
@@ -41,7 +41,7 @@ def parse_wsl_dotenv_target(
     return validate_distro_name_fn(distro), validate_dotenv_path_fn(path)
 
 
-def _split_wsl_target(target: str) -> tuple[str, str]:
+def _split_wsl_target(target: str) -> Tuple[str, str]:
     """Split wsl target."""
     parts = target.split(":", 2)
     if len(parts) != 3:
@@ -55,7 +55,7 @@ def _resolve_standard_wsl_target(
     *,
     validate_distro_name_fn,
     linux_etc_env_path: str,
-) -> tuple[str, str, str, bool]:
+) -> Tuple[str, str, str, bool]:
     """Resolve standard wsl target."""
     distro, suffix = _split_wsl_target(target)
     distro_name = validate_distro_name_fn(distro)
@@ -66,7 +66,7 @@ def _resolve_standard_wsl_target(
     raise RuntimeError(f"Unsupported WSL target: {target}")
 
 
-def resolve_wsl_target(*args, **kwargs) -> tuple[str, str, str, bool]:
+def resolve_wsl_target(*args, **kwargs) -> Tuple[str, str, str, bool]:
     """Resolve wsl target."""
     if not args:
         raise TypeError("resolve_wsl_target requires a target argument.")

--- a/env_inspector_core/storage.py
+++ b/env_inspector_core/storage.py
@@ -52,7 +52,7 @@ class BackupManager:
         self._enforce_retention(target)
         return path
 
-    def _next_backup_path(self) -> tuple[str, Path]:
+    def _next_backup_path(self) -> Tuple[str, Path]:
         """Next backup path."""
         timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
 
@@ -80,16 +80,16 @@ class BackupManager:
         for old in files[self.retention :]:
             old.unlink(missing_ok=True)
 
-    def list_backups(self, target: str) -> list[Path]:
+    def list_backups(self, target: str) -> List[Path]:
         """List backups."""
-        backups: list[Path] = []
+        backups: List[Path] = []
         for backup in self.list_all_backups():
             payload = self._load_backup_payload(backup)
             if payload is not None and str(payload.get("target", "")) == target:
                 backups.append(backup)
         return sorted(backups, reverse=True)
 
-    def list_all_backups(self) -> list[Path]:
+    def list_all_backups(self) -> List[Path]:
         """List all backups."""
         return sorted(
             (
@@ -117,7 +117,7 @@ class BackupManager:
         return str(payload["text"])
 
     @staticmethod
-    def read_backup_payload(backup_path: Path) -> dict[str, str]:
+    def read_backup_payload(backup_path: Path) -> Dict[str, str]:
         """Read backup payload."""
         payload = json.loads(_read_text(Path(backup_path)))
         return {"target": str(payload["target"]), "text": str(payload["text"])}

--- a/env_inspector_gui/controller.py
+++ b/env_inspector_gui/controller.py
@@ -47,10 +47,10 @@ class EnvInspectorController(EnvInspectorControllerActionsMixin):
         self.tk: Any = None
         self.view: Any = None
         self.root_path: Path = root_path
-        self.records_raw: list[EnvRecord] = []
-        self.displayed_rows: list[DisplayedRow] = []
-        self.rows_by_item: dict[str, DisplayedRow] = {}
-        self.selected_targets: list[str] = []
+        self.records_raw: List[EnvRecord] = []
+        self.displayed_rows: List[DisplayedRow] = []
+        self.rows_by_item: Dict[str, DisplayedRow] = {}
+        self.selected_targets: List[str] = []
         self.last_refresh_at: datetime | None = None
         self.filter_text: Any = None
         self.show_secrets: Any = None
@@ -111,7 +111,7 @@ class EnvInspectorController(EnvInspectorControllerActionsMixin):
         self.tk = tk.Tk()
         self.tk.title(f"{APP_NAME} (Core + GUI)")
 
-    def _load_boot_state(self, root_path: Path) -> tuple[PersistedUiState, Path]:
+    def _load_boot_state(self, root_path: Path) -> Tuple[PersistedUiState, Path]:
         """Load boot state."""
         loaded = load_ui_state(self.state_dir)
         fallback_root = resolve_scan_root(root_path)
@@ -306,13 +306,13 @@ class EnvInspectorController(EnvInspectorControllerActionsMixin):
         self.view.update_details_value("")
         self.view.set_details_enabled(False)
 
-    def _set_detail_values(self, values: dict[str, str]) -> None:
+    def _set_detail_values(self, values: Dict[str, str]) -> None:
         """Set detail values."""
         for key, value in values.items():
             if key in self.view.details_vars:
                 self.view.details_vars[key].set(value)
 
-    def _set_detail_pairs(self, pairs: tuple[tuple[str, str], ...]) -> None:
+    def _set_detail_pairs(self, pairs: Tuple[Tuple[str, str], ...]) -> None:
         """Set detail pairs."""
         for key, value in pairs:
             if key in self.view.details_vars:
@@ -455,7 +455,7 @@ class EnvInspectorController(EnvInspectorControllerActionsMixin):
             )
         )
 
-    def choose_targets(self) -> list[str] | None:
+    def choose_targets(self) -> List[str] | None:
         """Choose targets."""
         available = self.service.available_targets(
             self.records_raw, context=self.context_var.get()
@@ -482,8 +482,8 @@ class EnvInspectorController(EnvInspectorControllerActionsMixin):
         return list(self.selected_targets)
 
     def _maybe_choose_dotenv_targets(
-        self, key: str, targets: list[str]
-    ) -> list[str] | None:
+        self, key: str, targets: List[str]
+    ) -> List[str] | None:
         """Maybe choose dotenv targets."""
         dotenv_targets = self._collect_dotenv_targets(targets)
         if len(dotenv_targets) <= 1 or not self._has_multiple_dotenv_matches(key):
@@ -502,7 +502,7 @@ class EnvInspectorController(EnvInspectorControllerActionsMixin):
         ]
 
     @staticmethod
-    def _collect_dotenv_targets(targets: list[str]) -> list[str]:
+    def _collect_dotenv_targets(targets: List[str]) -> List[str]:
         """Collect dotenv targets."""
         return [
             target
@@ -515,8 +515,8 @@ class EnvInspectorController(EnvInspectorControllerActionsMixin):
         return has_multiple_dotenv_matches(self.records_raw, key)
 
     def _preview_operation(
-        self, action: str, key: str, value: str, targets: list[str]
-    ) -> list[dict[str, Any]]:
+        self, action: str, key: str, value: str, targets: List[str]
+    ) -> List[Dict[str, Any]]:
         """Preview operation."""
         if action == "set":
             return self.service.preview_set(
@@ -527,7 +527,7 @@ class EnvInspectorController(EnvInspectorControllerActionsMixin):
         )
 
     def _confirm_diff(
-        self, action: str, previews: list[dict[str, Any]], preview_only: bool = False
+        self, action: str, previews: List[Dict[str, Any]], preview_only: bool = False
     ) -> bool:
         """Confirm diff."""
         dialog = DiffPreviewDialog(
@@ -537,8 +537,8 @@ class EnvInspectorController(EnvInspectorControllerActionsMixin):
         return bool(dialog.confirmed)
 
     def _apply_operation(
-        self, action: str, key: str, value: str, targets: list[str]
-    ) -> dict[str, Any]:
+        self, action: str, key: str, value: str, targets: List[str]
+    ) -> Dict[str, Any]:
         """Apply operation."""
         if action == "set":
             return self.service.set_key(
@@ -569,7 +569,7 @@ class EnvInspectorController(EnvInspectorControllerActionsMixin):
         self._report_operation_result(action, result)
         self.refresh_data()
 
-    def _resolve_operation_inputs(self) -> tuple[str, str, list[str]] | None:
+    def _resolve_operation_inputs(self) -> Tuple[str, str, List[str]] | None:
         """Resolve operation inputs."""
         key = self.key_text.get().strip()
         value = self.value_text.get()
@@ -588,8 +588,8 @@ class EnvInspectorController(EnvInspectorControllerActionsMixin):
         return key, value, scoped_targets
 
     def _safe_preview(
-        self, action: str, key: str, value: str, targets: list[str]
-    ) -> list[dict[str, Any]] | None:
+        self, action: str, key: str, value: str, targets: List[str]
+    ) -> List[Dict[str, Any]] | None:
         """Safe preview."""
         try:
             return self._preview_operation(action, key, value, targets)
@@ -598,8 +598,8 @@ class EnvInspectorController(EnvInspectorControllerActionsMixin):
             return None
 
     def _safe_apply(
-        self, action: str, key: str, value: str, targets: list[str]
-    ) -> dict[str, Any] | None:
+        self, action: str, key: str, value: str, targets: List[str]
+    ) -> Dict[str, Any] | None:
         """Safe apply."""
         try:
             return self._apply_operation(action, key, value, targets)
@@ -607,7 +607,7 @@ class EnvInspectorController(EnvInspectorControllerActionsMixin):
             self.messagebox.showerror(APP_NAME, f"{action.title()} failed: {exc}")
             return None
 
-    def _report_operation_result(self, action: str, result: dict[str, Any]) -> None:
+    def _report_operation_result(self, action: str, result: Dict[str, Any]) -> None:
         """Report operation result."""
         summary = summarize_operation_result(action, result)
         if summary.error_message is not None:

--- a/env_inspector_gui/dialogs.py
+++ b/env_inspector_gui/dialogs.py
@@ -17,15 +17,15 @@ class TargetPickerDialog:
     """Modal dialog for selecting mutation targets."""
 
     def __init__(
-        self, parent: Any, targets: list[str], selected: list[str] | None = None
+        self, parent: Any, targets: List[str], selected: List[str] | None = None
     ) -> None:
         import tkinter as tk
         from tkinter import ttk
 
-        self.result: list[str] | None = None
+        self.result: List[str] | None = None
         self._targets = list(targets)
-        self._vars: dict[str, tk.BooleanVar] = {}
-        self._checks: dict[str, Any] = {}
+        self._vars: Dict[str, tk.BooleanVar] = {}
+        self._checks: Dict[str, Any] = {}
         self.search_var: Any = None
         self.search_entry: Any = None
         self.selected_count_label: Any = None
@@ -105,7 +105,7 @@ class TargetPickerDialog:
         )
 
     def _build_target_checks(
-        self, body: Any, selected_set: set[str], has_selected: bool, tk: Any, ttk: Any
+        self, body: Any, selected_set: Set[str], has_selected: bool, tk: Any, ttk: Any
     ) -> None:
         """Build target checks."""
         for target in self._targets:
@@ -205,12 +205,12 @@ class TargetPickerDialog:
 class DotenvTargetDialog:
     """Modal dialog for choosing among multiple dotenv file targets."""
 
-    def __init__(self, parent: Any, key: str, targets: list[str]) -> None:
+    def __init__(self, parent: Any, key: str, targets: List[str]) -> None:
         import tkinter as tk
         from tkinter import ttk
 
-        self.result: list[str] | None = None
-        self._vars: list[tuple[str, tk.BooleanVar]] = []
+        self.result: List[str] | None = None
+        self._vars: List[Tuple[str, tk.BooleanVar]] = []
 
         self.win = tk.Toplevel(parent)
         self.win.title("Select .env Targets")
@@ -257,7 +257,7 @@ class DiffPreviewDialog:
         parent: Any,
         *,
         action: str,
-        previews: list[dict[str, Any]],
+        previews: List[Dict[str, Any]],
         preview_only: bool = False,
     ) -> None:
         import tkinter as tk
@@ -292,7 +292,7 @@ class DiffPreviewDialog:
     def _build_preview_tabs(
         self,
         notebook: Any,
-        previews: list[dict[str, Any]],
+        previews: List[Dict[str, Any]],
         deps: _PreviewTabDeps,
     ) -> None:
         """Build preview tabs."""
@@ -303,7 +303,7 @@ class DiffPreviewDialog:
         self,
         notebook: Any,
         idx: int,
-        preview: dict[str, Any],
+        preview: Dict[str, Any],
         deps: _PreviewTabDeps,
     ) -> None:
         """Build preview tab."""
@@ -324,7 +324,7 @@ class DiffPreviewDialog:
 
     @staticmethod
     def _build_summary(
-        tab: Any, preview: dict[str, Any], target: str, ttk: Any
+        tab: Any, preview: Dict[str, Any], target: str, ttk: Any
     ) -> None:
         """Build summary."""
         summary = ttk.Frame(tab)
@@ -383,7 +383,7 @@ class DiffPreviewDialog:
 class BackupPickerDialog:
     """Modal dialog for selecting a backup file to restore."""
 
-    def __init__(self, parent: Any, backups: list[str]) -> None:
+    def __init__(self, parent: Any, backups: List[str]) -> None:
         import tkinter as tk
         from tkinter import ttk
 

--- a/env_inspector_gui/models.py
+++ b/env_inspector_gui/models.py
@@ -9,18 +9,18 @@ from env_inspector_core.models import EnvRecord
 from .secret_policy import resolve_copy_payload
 
 
-def _coerce_text(payload: dict[str, object], key: str, default: str) -> str:
+def _coerce_text(payload: Dict[str, object], key: str, default: str) -> str:
     """Coerce text."""
     value = payload.get(key, default)
     return str(value or default)
 
 
-def _coerce_flag(payload: dict[str, object], key: str, default: bool = False) -> bool:
+def _coerce_flag(payload: Dict[str, object], key: str, default: bool = False) -> bool:
     """Coerce flag."""
     return bool(payload.get(key, default))
 
 
-def _coerce_items(payload: dict[str, object], key: str) -> list[str]:
+def _coerce_items(payload: Dict[str, object], key: str) -> List[str]:
     """Coerce items."""
     value = payload.get(key) or []
     if not isinstance(value, list):
@@ -28,7 +28,7 @@ def _coerce_items(payload: dict[str, object], key: str) -> list[str]:
     return [str(item) for item in value if isinstance(item, str)]
 
 
-def _coerce_number(payload: dict[str, object], key: str, default: int) -> int:
+def _coerce_number(payload: Dict[str, object], key: str, default: int) -> int:
     """Coerce number."""
     value = payload.get(key, default)
     result = default
@@ -67,19 +67,19 @@ class PersistedUiState:
     show_secrets: bool = False
     only_secrets: bool = False
     filter_text: str = ""
-    selected_targets: list[str] = field(default_factory=list)
+    selected_targets: List[str] = field(default_factory=list)
     sort_column: str = "name"
     sort_descending: bool = False
     wsl_distro: str = ""
     wsl_path: str = ""
     scan_depth: int = 5
 
-    def to_dict(self) -> dict[str, object]:
+    def to_dict(self) -> Dict[str, object]:
         """To dict."""
         return asdict(self)
 
     @classmethod
-    def from_dict(cls, payload: dict[str, object]) -> "PersistedUiState":
+    def from_dict(cls, payload: Dict[str, object]) -> "PersistedUiState":
         """From dict."""
         return cls(
             version=_coerce_number(payload, "version", 1),
@@ -120,7 +120,7 @@ class ContextSelection:
 
     context: str
     wsl_distro: str
-    distros: list[str]
+    distros: List[str]
 
 
 @dataclass(frozen=True)
@@ -175,7 +175,7 @@ def resolve_context_selection(
 
 def reconcile_selected_targets(
     selected_targets: Sequence[str], available_targets: Sequence[str]
-) -> list[str]:
+) -> List[str]:
     """Reconcile selected targets."""
     if not selected_targets:
         return list(available_targets)
@@ -205,10 +205,10 @@ def build_status_line(shown: int, total: int, context: str, last_refresh_at) -> 
 def resolve_selected_targets(
     *,
     selected_targets: Sequence[str],
-    choose_targets: Callable[[], list[str] | None],
+    choose_targets: Callable[[], List[str] | None],
     key: str,
-    maybe_choose_dotenv_targets: Callable[[str, list[str]], list[str] | None],
-) -> list[str] | None:
+    maybe_choose_dotenv_targets: Callable[[str, List[str]], List[str] | None],
+) -> List[str] | None:
     """Resolve selected targets."""
     targets = list(selected_targets)
     if not targets:
@@ -248,7 +248,7 @@ def summarize_operation_result(
     )
 
 
-def _batch_failures(results: Any) -> list[Mapping[str, Any]]:
+def _batch_failures(results: Any) -> List[Mapping[str, Any]]:
     """Batch failures."""
     return [
         item for item in results if isinstance(item, dict) and not item.get("success")
@@ -256,8 +256,8 @@ def _batch_failures(results: Any) -> list[Mapping[str, Any]]:
 
 
 def select_target_dialog_result(
-    result: list[str] | None, *, messagebox: Any, app_name: str
-) -> list[str] | None:
+    result: List[str] | None, *, messagebox: Any, app_name: str
+) -> List[str] | None:
     """Select target dialog result."""
     if result is None:
         return None

--- a/env_inspector_gui/path_actions.py
+++ b/env_inspector_gui/path_actions.py
@@ -32,7 +32,7 @@ def open_source_path(
     source_path: str,
     *,
     open_uri: Callable[[str], bool] | None = None,
-) -> tuple[bool, str | None]:
+) -> Tuple[bool, str | None]:
     """Open source path."""
     if not is_openable_local_path(source_path):
         return False, "Cannot open non-local source path"

--- a/env_inspector_gui/secret_policy.py
+++ b/env_inspector_gui/secret_policy.py
@@ -40,7 +40,7 @@ def resolve_copy_payload(
     show_secrets: bool,
     confirm_raw: Callable[[], bool],
     as_pair: bool,
-) -> tuple[str, bool]:
+) -> Tuple[str, bool]:
     """Resolve copy payload."""
     record_is_secret = is_record_secret(record)
     use_raw = show_secrets or not record_is_secret
@@ -57,7 +57,7 @@ def resolve_load_value(
     *,
     show_secrets: bool,
     confirm_raw: Callable[[], bool],
-) -> tuple[str | None, bool]:
+) -> Tuple[str | None, bool]:
     """Resolve load value."""
     record_is_secret = is_record_secret(record)
     if show_secrets or not record_is_secret:

--- a/env_inspector_gui/state_store.py
+++ b/env_inspector_gui/state_store.py
@@ -77,8 +77,8 @@ def save_ui_state(state_dir: Path, state: PersistedUiState) -> Path:
 def sanitize_loaded_state(
     state: PersistedUiState,
     *,
-    available_contexts: list[str],
-    available_targets: list[str],
+    available_contexts: List[str],
+    available_targets: List[str],
     fallback_root: Path,
 ) -> PersistedUiState:
     """Sanitize loaded state."""
@@ -109,7 +109,7 @@ def _sanitize_root(root_path: str, fallback_root: Path) -> Path:
     return Path(fallback_root)
 
 
-def _sanitize_context(context: str, available_contexts: list[str]) -> str:
+def _sanitize_context(context: str, available_contexts: List[str]) -> str:
     """Sanitize context."""
     if not available_contexts:
         return ""
@@ -119,8 +119,8 @@ def _sanitize_context(context: str, available_contexts: list[str]) -> str:
 
 
 def _sanitize_targets(
-    selected_targets: list[str], available_targets: list[str]
-) -> list[str]:
+    selected_targets: List[str], available_targets: List[str]
+) -> List[str]:
     """Sanitize targets."""
     available_set = set(available_targets)
     return [target for target in selected_targets if target in available_set]

--- a/env_inspector_gui/table_logic.py
+++ b/env_inspector_gui/table_logic.py
@@ -10,12 +10,12 @@ from .models import DisplayedRow, SortState
 from .secret_policy import build_search_value, build_visible_value
 
 
-def _record_payload(rec: EnvRecord) -> dict[str, object]:
+def _record_payload(rec: EnvRecord) -> Dict[str, object]:
     """Return a normalized payload for analyzer-friendly flag access."""
     return rec.to_dict()
 
 
-def _record_flag(rec_payload: dict[str, object], key: str) -> bool:
+def _record_flag(rec_payload: Dict[str, object], key: str) -> bool:
     """Return a boolean flag from a serialized record payload."""
     return bool(rec_payload.get(key, False))
 
@@ -74,9 +74,9 @@ class DisplayRowsRequest:
     show_secrets: bool
 
 
-def build_display_rows(request: DisplayRowsRequest) -> list[DisplayedRow]:
+def build_display_rows(request: DisplayRowsRequest) -> List[DisplayedRow]:
     """Build the filtered GUI rows for the current table request."""
-    rows: list[DisplayedRow] = []
+    rows: List[DisplayedRow] = []
     query_text = request.query.strip().lower()
 
     for idx, rec in enumerate(request.records):
@@ -140,9 +140,9 @@ def _sort_key(row: DisplayedRow, column: str):
 
 
 def sort_display_rows(
-    rows: list[DisplayedRow],
+    rows: List[DisplayedRow],
     sort_state: SortState,
-) -> list[DisplayedRow]:
+) -> List[DisplayedRow]:
     """Return rows sorted by the active GUI sort state."""
     column = sort_state.column or "name"
     return sorted(

--- a/env_inspector_gui/view.py
+++ b/env_inspector_gui/view.py
@@ -17,7 +17,7 @@ class EnvInspectorView:
         self.filter_entry: Any = None
         self.details_value_text: Any = None
         self.details_value_scroll_x: Any = None
-        self.details_vars: dict[str, Any] = {}
+        self.details_vars: Dict[str, Any] = {}
 
         self.context_combo: Any = None
         self.wsl_distro_combo: Any = None
@@ -241,7 +241,7 @@ class EnvInspectorView:
             "<<TreeviewSelect>>", lambda _e: self.controller.on_tree_selected()
         )
 
-    def _create_details_var_map(self) -> dict[str, Any]:
+    def _create_details_var_map(self) -> Dict[str, Any]:
         """Create details var map."""
         self.details_vars = {
             "name": self.tkmod.StringVar(value=""),
@@ -376,11 +376,11 @@ class EnvInspectorView:
         self.status = ttk.Label(bottom, text="")
         self.status.pack(side="right")
 
-    def set_context_values(self, contexts: list[str]) -> None:
+    def set_context_values(self, contexts: List[str]) -> None:
         """Set context values."""
         self.context_combo.configure(values=contexts)
 
-    def set_wsl_distros(self, distros: list[str], *, enabled: bool) -> None:
+    def set_wsl_distros(self, distros: List[str], *, enabled: bool) -> None:
         """Set wsl distros."""
         self.wsl_distro_combo.configure(values=distros)
         self.wsl_distro_combo.configure(state=("readonly" if enabled else "disabled"))
@@ -424,7 +424,7 @@ class EnvInspectorView:
         for item in self.tree.get_children():
             self.tree.delete(item)
 
-    def insert_table_row(self, values: tuple[Any, ...], *, striped: bool) -> str:
+    def insert_table_row(self, values: Tuple[Any, ...], *, striped: bool) -> str:
         """Insert table row."""
         tag = "row_even" if striped else "row_odd"
         return str(self.tree.insert("", "end", values=values, tags=(tag,)))

--- a/scripts/quality/_codacy_zero_impl.py
+++ b/scripts/quality/_codacy_zero_impl.py
@@ -5,7 +5,7 @@ import argparse
 import sys
 import urllib.error
 from dataclasses import replace
-from typing import TYPE_CHECKING, Any, List, Tuple
+from typing import Any, List, TYPE_CHECKING, Tuple
 
 try:
     from . import _codacy_zero_support as _support
@@ -83,7 +83,7 @@ def extract_total_open(payload: Any) -> int | None:
         if total is not None:
             return total
 
-    stack: list[Any] = [payload]
+    stack: List[Any] = [payload]
     while stack:
         node = stack.pop()
         if isinstance(node, dict):
@@ -101,7 +101,7 @@ def extract_total_open(payload: Any) -> int | None:
 def _fetch_open_issues_for_provider(
     request: CodacyRequest | None = None,
     **kwargs: Any,
-) -> tuple[bool, int | None, list[str], Exception | None]:
+) -> Tuple[bool, int | None, List[str], Exception | None]:
     """Fetch open issues for provider."""
     request = _resolve_codacy_request(request, kwargs)
 
@@ -124,9 +124,9 @@ def _fetch_open_issues_for_provider(
 def _attempt_issue_total(
     request: CodacyRequest,
     request_json_fn: Any,
-) -> tuple[bool, int | None, list[str], Exception | None]:
+) -> Tuple[bool, int | None, List[str], Exception | None]:
     """Attempt issue total."""
-    findings: list[str] = []
+    findings: List[str] = []
 
     try:
         return True, _request_issue_total(request, request_json_fn), findings, None
@@ -158,8 +158,8 @@ def _request_issue_total(request: CodacyRequest, request_json_fn: Any) -> int | 
 
 
 def _handle_http_error(
-    exc: urllib.error.HTTPError, findings: list[str]
-) -> tuple[bool, Exception]:
+    exc: urllib.error.HTTPError, findings: List[str]
+) -> Tuple[bool, Exception]:
     """Handle http error."""
     if exc.code == 404:
         return False, exc
@@ -172,7 +172,7 @@ def _non_zero_issue_findings(
     open_issues: int,
     request_json_fn: Any,
     sample_findings_fn: Any,
-) -> list[str]:
+) -> List[str]:
     """Non zero issue findings."""
     findings = [f"Codacy reports {open_issues} open issues (expected 0)."]
     sample_payload = request_json_fn(
@@ -188,7 +188,7 @@ def _issue_total_findings(
     handled: bool,
     request_json_fn: Any,
     sample_findings_fn: Any,
-) -> list[str]:
+) -> List[str]:
     """Issue total findings."""
     if not handled:
         return []
@@ -203,7 +203,7 @@ def _issue_total_findings(
 
 def _query_open_issues(
     request: CodacyRequest | None = None, **kwargs: Any
-) -> tuple[int | None, list[str]]:
+) -> Tuple[int | None, List[str]]:
     """Query open issues."""
     if request is None:
         request = CodacyRequest(**kwargs)

--- a/scripts/quality/_codacy_zero_support.py
+++ b/scripts/quality/_codacy_zero_support.py
@@ -13,7 +13,7 @@ TOTAL_KEYS = ("total", "totalItems", "total_items", "count", "hits", "open_issue
 CODACY_API_HOST = "api.codacy.com"
 CODACY_REQUEST_EXCEPTIONS = (urllib.error.URLError, ValueError, TypeError, RuntimeError)
 
-RequestJsonHttps = Callable[..., tuple[Any, dict[str, str]]]
+RequestJsonHttps = Callable[..., Tuple[Any, Dict[str, str]]]
 EncodeIdentifier = Callable[..., str]
 SafeOutputPathInWorkspace = Callable[..., Path]
 
@@ -29,7 +29,7 @@ class CodacyRequest:
     branch: str = ""
     limit: int = 1
     method: str = "GET"
-    data: dict[str, Any] | None = None
+    data: Dict[str, Any] | None = None
 
 
 def _load_security_imports() -> Any:
@@ -77,7 +77,7 @@ __all__ = [
 
 def _request_json(
     request: CodacyRequest | None = None, **kwargs: Any
-) -> dict[str, Any]:
+) -> Dict[str, Any]:
     """Request json."""
     if request is None:
         request = CodacyRequest(**kwargs)
@@ -104,7 +104,7 @@ def _request_json(
     owner_slug = encode_identifier_fn(request.owner, field_name="Codacy owner")
     repo_slug = encode_identifier_fn(request.repo, field_name="Codacy repository")
 
-    payload_data: dict[str, Any] = dict(request.data or {})
+    payload_data: Dict[str, Any] = dict(request.data or {})
     branch_name = str(request.branch or "").strip()
     if branch_name:
         payload_data = {**payload_data, "branchName": branch_name}
@@ -122,13 +122,13 @@ def _request_json(
     return payload
 
 
-def _provider_candidates(preferred: str) -> list[str]:
+def _provider_candidates(preferred: str) -> List[str]:
     """Provider candidates."""
     values = [preferred, "gh", "github"]
     return list(dict.fromkeys(item for item in values if item))
 
 
-def _first_text(issue: dict[str, Any], keys: tuple[str, ...]) -> str:
+def _first_text(issue: Dict[str, Any], keys: Tuple[str, ...]) -> str:
     """First text."""
     for key in keys:
         value = str(issue.get(key) or "").strip()
@@ -151,13 +151,13 @@ def _format_issue_sample(issue: dict) -> str | None:
     return f"Sample issue: `{identity}` at `{location}`{suffix}"
 
 
-def _sample_issue_findings(payload: dict, limit: int = 5) -> list[str]:
+def _sample_issue_findings(payload: dict, limit: int = 5) -> List[str]:
     """Sample issue findings."""
     data = payload.get("data")
     if not isinstance(data, list):
         return []
 
-    findings: list[str] = []
+    findings: List[str] = []
     for item in data:
         if not isinstance(item, dict):
             continue

--- a/scripts/quality/_coverage_assert_support.py
+++ b/scripts/quality/_coverage_assert_support.py
@@ -36,7 +36,7 @@ class CoverageStats:
         return (self.covered / self.total) * 100.0
 
 
-def parse_named_path(value: str, safe_input_file_path_in_workspace) -> tuple[str, Path]:
+def parse_named_path(value: str, safe_input_file_path_in_workspace) -> Tuple[str, Path]:
     """Parse named path."""
     match = _PAIR_RE.match(value.strip())
     if not match:
@@ -89,10 +89,10 @@ def normalize_source_path(raw_path: str) -> str:
     return _normalize_source_path(raw_path)
 
 
-def coverage_sources_from_xml(path: Path) -> set[str]:
+def coverage_sources_from_xml(path: Path) -> Set[str]:
     """Coverage sources from xml."""
     text = path.read_text(encoding="utf-8")  # lgtm [py/path-injection]
-    covered_sources: set[str] = set()
+    covered_sources: Set[str] = set()
     for match in _XML_FILENAME_RE.finditer(text):
         filename = _normalize_source_path(match.group("value"))
         if filename:
@@ -117,9 +117,9 @@ def parse_lcov(name: str, path: Path) -> CoverageStats:
     return CoverageStats(name=name, path=str(path), covered=covered, total=total)
 
 
-def coverage_sources_from_lcov(path: Path) -> set[str]:
+def coverage_sources_from_lcov(path: Path) -> Set[str]:
     """Coverage sources from lcov."""
-    covered_sources: set[str] = set()
+    covered_sources: Set[str] = set()
     for raw in path.read_text(
         encoding="utf-8"
     ).splitlines():  # lgtm [py/path-injection]
@@ -143,10 +143,10 @@ def _matches_required_source(source_path: str, required_source: str) -> bool:
 
 
 def _find_missing_required_sources(
-    reported_sources: set[str], required_sources: list[str]
-) -> list[str]:
+    reported_sources: Set[str], required_sources: List[str]
+) -> List[str]:
     """Find missing required sources."""
-    missing: list[str] = []
+    missing: List[str] = []
     for required_source in required_sources:
         normalized_required = _normalize_source_path(required_source).rstrip("/")
         if not normalized_required:
@@ -160,7 +160,7 @@ def _find_missing_required_sources(
     return missing
 
 
-def _is_tests_only_report(reported_sources: set[str]) -> bool:
+def _is_tests_only_report(reported_sources: Set[str]) -> bool:
     """Is tests only report."""
     return bool(reported_sources) and all(
         source_path == "tests" or source_path.startswith("tests/")
@@ -168,9 +168,9 @@ def _is_tests_only_report(reported_sources: set[str]) -> bool:
     )
 
 
-def _coverage_findings(stats: list[CoverageStats], min_percent: float) -> list[str]:
+def _coverage_findings(stats: List[CoverageStats], min_percent: float) -> List[str]:
     """Coverage findings."""
-    findings: list[str] = []
+    findings: List[str] = []
     for item in stats:
         if item.percent < min_percent:
             findings.append(
@@ -190,10 +190,10 @@ def _coverage_findings(stats: list[CoverageStats], min_percent: float) -> list[s
 
 
 def _source_findings(
-    reported_sources: set[str], required_sources: list[str]
-) -> list[str]:
+    reported_sources: Set[str], required_sources: List[str]
+) -> List[str]:
     """Source findings."""
-    findings: list[str] = []
+    findings: List[str] = []
     if _is_tests_only_report(reported_sources):
         findings.append(
             "coverage inputs only reference tests/ paths; first-party sources are missing."
@@ -207,12 +207,12 @@ def _source_findings(
 
 
 def evaluate(
-    stats: list[CoverageStats],
+    stats: List[CoverageStats],
     min_percent: float,
     *,
-    required_sources: list[str] | None = None,
-    reported_sources: set[str] | None = None,
-) -> tuple[str, list[str]]:
+    required_sources: List[str] | None = None,
+    reported_sources: Set[str] | None = None,
+) -> Tuple[str, List[str]]:
     """Evaluate."""
     normalized_sources = reported_sources or set()
     findings = _coverage_findings(stats, min_percent)
@@ -221,7 +221,7 @@ def evaluate(
     return status, findings
 
 
-def _append_component_lines(lines: list[str], payload: dict[str, Any]) -> None:
+def _append_component_lines(lines: List[str], payload: Dict[str, Any]) -> None:
     """Append component lines."""
     components = payload.get("components") or []
     if components:
@@ -233,7 +233,7 @@ def _append_component_lines(lines: list[str], payload: dict[str, Any]) -> None:
     lines.append(_NONE_LIST_ITEM)
 
 
-def _append_covered_source_lines(lines: list[str], payload: dict[str, Any]) -> None:
+def _append_covered_source_lines(lines: List[str], payload: Dict[str, Any]) -> None:
     """Append covered source lines."""
     sources = payload.get("covered_sources") or []
     if sources:
@@ -242,7 +242,7 @@ def _append_covered_source_lines(lines: list[str], payload: dict[str, Any]) -> N
     lines.append(_NONE_LIST_ITEM)
 
 
-def _append_finding_lines(lines: list[str], payload: dict[str, Any]) -> None:
+def _append_finding_lines(lines: List[str], payload: Dict[str, Any]) -> None:
     """Append finding lines."""
     findings = payload.get("findings") or []
     if findings:
@@ -251,7 +251,7 @@ def _append_finding_lines(lines: list[str], payload: dict[str, Any]) -> None:
     lines.append(_NONE_LIST_ITEM)
 
 
-def _render_md(payload: dict[str, Any]) -> str:
+def _render_md(payload: Dict[str, Any]) -> str:
     """Render md."""
     lines = [
         "# Coverage 100 Gate",
@@ -271,12 +271,12 @@ def _render_md(payload: dict[str, Any]) -> str:
 
 
 def _build_payload(
-    stats: list[CoverageStats],
-    covered_sources: set[str],
+    stats: List[CoverageStats],
+    covered_sources: Set[str],
     min_percent: float,
-    findings: list[str],
+    findings: List[str],
     status: str,
-) -> dict[str, Any]:
+) -> Dict[str, Any]:
     """Build payload."""
     return {
         "status": status,
@@ -297,7 +297,7 @@ def _build_payload(
     }
 
 
-def _write_outputs(payload: dict[str, Any], *, out_json: Path, out_md: Path) -> str:
+def _write_outputs(payload: Dict[str, Any], *, out_json: Path, out_md: Path) -> str:
     """Write outputs."""
     os.makedirs(out_json.parent, exist_ok=True)
     os.makedirs(out_md.parent, exist_ok=True)

--- a/scripts/quality/_required_checks_http.py
+++ b/scripts/quality/_required_checks_http.py
@@ -34,11 +34,11 @@ class GitHubRequest:
     sha: str
     token: str
     endpoint: str
-    query: dict[str, str] | None = None
+    query: Dict[str, str] | None = None
     attempts: int = 5
 
 
-def _parse_repo(raw: str) -> tuple[str, str]:
+def _parse_repo(raw: str) -> Tuple[str, str]:
     """Validate and normalize an owner/repo identifier."""
     text = (raw or "").strip()
     if "/" not in text:
@@ -58,7 +58,7 @@ def _parse_sha(raw: str) -> str:
     return sha.lower()
 
 
-def _github_headers(token: str) -> dict[str, str]:
+def _github_headers(token: str) -> Dict[str, str]:
     """Build the HTTP headers for GitHub commit endpoint requests."""
     return {
         "Accept": "application/vnd.github+json",
@@ -93,7 +93,7 @@ def _next_retry_wait(wait_seconds: int) -> int:
     return min(wait_seconds * 2, 10)
 
 
-def _request_payload_with_retry(request: GitHubRequest) -> dict[str, Any]:
+def _request_payload_with_retry(request: GitHubRequest) -> Dict[str, Any]:
     """Fetch one GitHub payload, retrying transient endpoint failures."""
     wait_seconds = 1
     last_error: Exception | None = None
@@ -145,7 +145,7 @@ def _api_get_check_runs(
     repo: str,
     sha: str,
     token: str,
-) -> dict[str, Any]:
+) -> Dict[str, Any]:
     """Fetch the check-runs payload for the target commit SHA."""
     return _request_payload_with_retry(
         GitHubRequest(
@@ -159,7 +159,7 @@ def _api_get_check_runs(
     )
 
 
-def _api_get_status(*, owner: str, repo: str, sha: str, token: str) -> dict[str, Any]:
+def _api_get_status(*, owner: str, repo: str, sha: str, token: str) -> Dict[str, Any]:
     """Fetch the combined commit-status payload for the target SHA."""
     return _request_payload_with_retry(
         GitHubRequest(
@@ -172,7 +172,7 @@ def _api_get_status(*, owner: str, repo: str, sha: str, token: str) -> dict[str,
     )
 
 
-def _check_run_context(run: dict[str, Any]) -> tuple[str, dict[str, str]] | None:
+def _check_run_context(run: Dict[str, Any]) -> Tuple[str, Dict[str, str]] | None:
     """Normalize a GitHub check run into the shared context payload."""
     name = str(run.get("name") or "").strip()
     if not name:
@@ -184,7 +184,7 @@ def _check_run_context(run: dict[str, Any]) -> tuple[str, dict[str, str]] | None
     }
 
 
-def _status_context(status: dict[str, Any]) -> tuple[str, dict[str, str]] | None:
+def _status_context(status: Dict[str, Any]) -> Tuple[str, Dict[str, str]] | None:
     """Normalize a GitHub commit status into the shared context payload."""
     name = str(status.get("context") or "").strip()
     if not name:
@@ -198,11 +198,11 @@ def _status_context(status: dict[str, Any]) -> tuple[str, dict[str, str]] | None
 
 
 def _collect_contexts(
-    check_runs_payload: dict[str, Any],
-    status_payload: dict[str, Any],
-) -> dict[str, dict[str, str]]:
+    check_runs_payload: Dict[str, Any],
+    status_payload: Dict[str, Any],
+) -> Dict[str, Dict[str, str]]:
     """Merge check-run and status payloads into one context map."""
-    contexts: dict[str, dict[str, str]] = {}
+    contexts: Dict[str, Dict[str, str]] = {}
 
     for run in check_runs_payload.get("check_runs", []) or []:
         entry = _check_run_context(run)
@@ -219,7 +219,7 @@ def _collect_contexts(
     return contexts
 
 
-def _check_run_failure(context: str, observed: dict[str, str]) -> str | None:
+def _check_run_failure(context: str, observed: Dict[str, str]) -> str | None:
     """Return a failure message for a check-run context, if any."""
     state = observed.get("state")
     if state != "completed":
@@ -231,7 +231,7 @@ def _check_run_failure(context: str, observed: dict[str, str]) -> str | None:
     return None
 
 
-def _status_failure(context: str, observed: dict[str, str]) -> str | None:
+def _status_failure(context: str, observed: Dict[str, str]) -> str | None:
     """Return a failure message for a commit-status context, if any."""
     conclusion = observed.get("conclusion")
     if conclusion != "success":
@@ -240,12 +240,12 @@ def _status_failure(context: str, observed: dict[str, str]) -> str | None:
 
 
 def _evaluate(
-    required: list[str],
-    contexts: dict[str, dict[str, str]],
-) -> tuple[str, list[str], list[str]]:
+    required: List[str],
+    contexts: Dict[str, Dict[str, str]],
+) -> Tuple[str, List[str], List[str]]:
     """Return the aggregate required-check status plus missing and failed items."""
-    missing: list[str] = []
-    failed: list[str] = []
+    missing: List[str] = []
+    failed: List[str] = []
 
     for context in required:
         observed = contexts.get(context)

--- a/scripts/quality/_required_checks_impl.py
+++ b/scripts/quality/_required_checks_impl.py
@@ -18,7 +18,7 @@ class SettledChecksRequest:
     repo_arg: str
     sha: str
     token: str
-    required: list[str]
+    required: List[str]
     timeout_seconds: int
     poll_seconds: int
 
@@ -70,7 +70,7 @@ def _parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def _render_md(payload: dict[str, Any]) -> str:
+def _render_md(payload: Dict[str, Any]) -> str:
     """Render md."""
     lines = [
         "# Quality Zero Gate - Required Contexts",
@@ -98,7 +98,7 @@ def _render_md(payload: dict[str, Any]) -> str:
     return "\n".join(lines) + "\n"
 
 
-def _required_contexts(args: argparse.Namespace) -> list[str]:
+def _required_contexts(args: argparse.Namespace) -> List[str]:
     """Required contexts."""
     required = [item.strip() for item in args.required_context if item.strip()]
     if not required:
@@ -120,9 +120,9 @@ def _snapshot(
     *,
     repo_arg: str,
     sha: str,
-    required: list[str],
-    contexts: dict[str, dict[str, str]],
-) -> dict[str, Any]:
+    required: List[str],
+    contexts: Dict[str, Dict[str, str]],
+) -> Dict[str, Any]:
     """Snapshot."""
     status, missing, failed = _evaluate(required, contexts)
     return {
@@ -137,7 +137,7 @@ def _snapshot(
     }
 
 
-def _has_in_progress_check_run(contexts: dict[str, dict[str, str]]) -> bool:
+def _has_in_progress_check_run(contexts: Dict[str, Dict[str, str]]) -> bool:
     """Has in progress check run."""
     return any(
         observed.get("source") == "check_run" and observed.get("state") != "completed"
@@ -145,7 +145,7 @@ def _has_in_progress_check_run(contexts: dict[str, dict[str, str]]) -> bool:
     )
 
 
-def _should_wait(payload: dict[str, Any]) -> bool:
+def _should_wait(payload: Dict[str, Any]) -> bool:
     """Should wait."""
     if payload["status"] == "pass":
         return False
@@ -154,10 +154,10 @@ def _should_wait(payload: dict[str, Any]) -> bool:
     return _has_in_progress_check_run(payload["contexts"])
 
 
-def _collect_until_settled(request: SettledChecksRequest) -> dict[str, Any]:
+def _collect_until_settled(request: SettledChecksRequest) -> Dict[str, Any]:
     """Collect until settled."""
     deadline = time.time() + max(request.timeout_seconds, 1)
-    final_payload: dict[str, Any] | None = None
+    final_payload: Dict[str, Any] | None = None
 
     while time.time() <= deadline:
         check_runs = _api_get_check_runs(

--- a/scripts/quality/assert_coverage_100.py
+++ b/scripts/quality/assert_coverage_100.py
@@ -88,10 +88,10 @@ def parse_named_path(value: str):
     return parse_named_path_impl(value, SAFE_INPUT_FILE_PATH_IN_WORKSPACE)
 
 
-def _collect_stats(args: argparse.Namespace) -> tuple[list[CoverageStats], set[str]]:
+def _collect_stats(args: argparse.Namespace) -> Tuple[List[CoverageStats], Set[str]]:
     """Collect stats."""
-    stats: list[CoverageStats] = []
-    covered_sources: set[str] = set()
+    stats: List[CoverageStats] = []
+    covered_sources: Set[str] = set()
     for item in args.xml:
         name, path = parse_named_path(item)
         stats.append(parse_coverage_xml(name, path))

--- a/scripts/quality/check_codacy_zero.py
+++ b/scripts/quality/check_codacy_zero.py
@@ -65,38 +65,38 @@ def _parse_args() -> Any:
 def _request_json(
     request: Any = None,
     **kwargs: Any,
-) -> dict[str, Any]:
+) -> Dict[str, Any]:
     """Request the Codacy issue-search payload for the target repository scope."""
     return _support_helper("_request_json")(request=request, **kwargs)
 
 
 def _extract_numeric_total(
-    payload: dict[str, Any],
-    keys: tuple[str, ...],
+    payload: Dict[str, Any],
+    keys: Tuple[str, ...],
 ) -> int | None:
     """Extract the first numeric total value from a payload using fallback keys."""
     return _impl_helper("_extract_numeric_total")(payload, keys)
 
 
-def _provider_candidates(preferred: str) -> list[str]:
+def _provider_candidates(preferred: str) -> List[str]:
     """Return the ordered provider aliases to try for Codacy API resolution."""
     return _support_helper("_provider_candidates")(preferred)
 
 
-def _first_text(issue: dict[str, Any], keys: tuple[str, ...]) -> str:
+def _first_text(issue: Dict[str, Any], keys: Tuple[str, ...]) -> str:
     """Return the first populated text field from a Codacy issue payload."""
     return _support_helper("_first_text")(issue, keys)
 
 
-def _format_issue_sample(issue: dict[str, Any]) -> str | None:
+def _format_issue_sample(issue: Dict[str, Any]) -> str | None:
     """Render one sample Codacy issue into a short human-readable finding."""
     return _support_helper("_format_issue_sample")(issue)
 
 
 def _sample_issue_findings(
-    payload: dict[str, Any],
+    payload: Dict[str, Any],
     limit: int = 5,
-) -> list[str]:
+) -> List[str]:
     """Extract a bounded sample of issue descriptions from the Codacy payload."""
     return _support_helper("_sample_issue_findings")(payload, limit)
 
@@ -104,7 +104,7 @@ def _sample_issue_findings(
 def _fetch_open_issues_for_provider(
     request: Any = None,
     **kwargs: Any,
-) -> tuple[bool, int | None, list[str], Exception | None]:
+) -> Tuple[bool, int | None, List[str], Exception | None]:
     """Query Codacy for one provider alias and interpret the result payload."""
     return _impl_helper("_fetch_open_issues_for_provider")(request=request, **kwargs)
 
@@ -112,12 +112,12 @@ def _fetch_open_issues_for_provider(
 def _query_open_issues(
     request: Any = None,
     **kwargs: Any,
-) -> tuple[int | None, list[str]]:
+) -> Tuple[int | None, List[str]]:
     """Query Codacy across provider aliases until one returns a settled result."""
     return _impl_helper("_query_open_issues")(request=request, **kwargs)
 
 
-def _render_md(payload: dict[str, Any]) -> str:
+def _render_md(payload: Dict[str, Any]) -> str:
     """Render the markdown artifact for the Codacy zero gate result."""
     return _impl_helper("_render_md")(payload)
 
@@ -127,7 +127,7 @@ def main() -> int:
     args = _parse_args()
     branch = getattr(args, "branch", "")
     token = (args.token or os.environ.get("CODACY_API_TOKEN", "")).strip()
-    findings: list[str] = []
+    findings: List[str] = []
     open_issues: int | None = None
 
     if not token:

--- a/scripts/quality/check_deepscan_zero.py
+++ b/scripts/quality/check_deepscan_zero.py
@@ -15,9 +15,9 @@ from collections.abc import Callable
 
 TOTAL_KEYS = {"total", "totalItems", "total_items", "count", "hits", "open_issues"}
 
-RequestJsonHttps = Callable[..., tuple[Any, dict[str, str]]]
+RequestJsonHttps = Callable[..., Tuple[Any, Dict[str, str]]]
 SafeOutputPathInWorkspace = Callable[..., Path]
-SplitValidatedHttpsUrl = Callable[..., tuple[str, str, dict[str, str]]]
+SplitValidatedHttpsUrl = Callable[..., Tuple[str, str, Dict[str, str]]]
 
 
 @dataclass(frozen=True)
@@ -28,7 +28,7 @@ class DeepScanRequest:
     path: str
     query: dict
     token: str
-    findings: list[str]
+    findings: List[str]
 
 
 def _load_security_imports() -> Any:
@@ -76,7 +76,7 @@ def _parse_args() -> argparse.Namespace:
 
 def extract_total_open(payload: Any) -> int | None:
     """Extract total open."""
-    stack: list[Any] = [payload]
+    stack: List[Any] = [payload]
     while stack:
         node = stack.pop()
         if isinstance(node, dict):
@@ -91,8 +91,8 @@ def extract_total_open(payload: Any) -> int | None:
 
 
 def _request_json(
-    *, host: str, path: str, query: dict[str, str], token: str
-) -> dict[str, Any]:
+    *, host: str, path: str, query: Dict[str, str], token: str
+) -> Dict[str, Any]:
     """Request json."""
     payload, _headers = request_json_https(
         host=host,
@@ -110,7 +110,7 @@ def _request_json(
     return payload
 
 
-def _resolve_deepscan_endpoint(open_issues_url: str) -> tuple[str, str, dict[str, str]]:
+def _resolve_deepscan_endpoint(open_issues_url: str) -> Tuple[str, str, Dict[str, str]]:
     """Resolve deepscan endpoint."""
     return split_validated_https_url(
         open_issues_url,
@@ -205,7 +205,7 @@ def main() -> int:
     token = (args.token or os.environ.get("DEEPSCAN_API_TOKEN", "")).strip()
     open_issues_url = os.environ.get("DEEPSCAN_OPEN_ISSUES_URL", "").strip()
 
-    findings: list[str] = []
+    findings: List[str] = []
     open_issues: int | None = None
 
     if not token:

--- a/scripts/quality/check_quality_secrets.py
+++ b/scripts/quality/check_quality_secrets.py
@@ -58,10 +58,10 @@ def _parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def _dedupe(items: list[str]) -> list[str]:
+def _dedupe(items: List[str]) -> List[str]:
     """Dedupe."""
-    seen: set[str] = set()
-    out: list[str] = []
+    seen: Set[str] = set()
+    out: List[str] = []
     for item in items:
         key = str(item or "").strip()
         if not key or key in seen:
@@ -76,10 +76,10 @@ def _is_missing(name: str) -> bool:
     return not str(os.environ.get(name, "")).strip()
 
 
-def _partition_required(names: list[str]) -> tuple[list[str], list[str]]:
+def _partition_required(names: List[str]) -> Tuple[List[str], List[str]]:
     """Partition required."""
-    missing: list[str] = []
-    present: list[str] = []
+    missing: List[str] = []
+    present: List[str] = []
     for name in names:
         if _is_missing(name):
             missing.append(name)
@@ -89,8 +89,8 @@ def _partition_required(names: list[str]) -> tuple[list[str], list[str]]:
 
 
 def evaluate_env(
-    required_secrets: list[str], required_vars: list[str]
-) -> dict[str, list[str]]:
+    required_secrets: List[str], required_vars: List[str]
+) -> Dict[str, List[str]]:
     """Evaluate env."""
     missing_secrets, present_secrets = _partition_required(required_secrets)
     missing_vars, present_vars = _partition_required(required_vars)

--- a/scripts/quality/check_required_checks.py
+++ b/scripts/quality/check_required_checks.py
@@ -58,7 +58,7 @@ def _parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def _parse_repo(raw: str) -> tuple[str, str]:
+def _parse_repo(raw: str) -> Tuple[str, str]:
     """Validate and normalize an owner/repo argument for GitHub API calls."""
     return _impl_helper("_parse_repo")(raw)
 
@@ -68,7 +68,7 @@ def _parse_sha(raw: str) -> str:
     return _impl_helper("_parse_sha")(raw)
 
 
-def _github_headers(token: str) -> dict[str, str]:
+def _github_headers(token: str) -> Dict[str, str]:
     """Build GitHub API headers for the required-checks requests."""
     return _impl_helper("_github_headers")(token)
 
@@ -105,7 +105,7 @@ def _next_retry_wait(wait_seconds: int) -> int:
     return _impl_helper("_next_retry_wait")(wait_seconds)
 
 
-def _request_payload_with_retry(request: Any) -> dict[str, Any]:
+def _request_payload_with_retry(request: Any) -> Dict[str, Any]:
     """Fetch one GitHub payload with retry semantics applied."""
     return _impl_helper("_request_payload_with_retry")(request)
 
@@ -116,7 +116,7 @@ def _api_get_check_runs(
     repo: str,
     sha: str,
     token: str,
-) -> dict[str, Any]:
+) -> Dict[str, Any]:
     """Fetch the check-run payload for the target commit SHA."""
     return _impl_helper("_api_get_check_runs")(
         owner=owner,
@@ -126,7 +126,7 @@ def _api_get_check_runs(
     )
 
 
-def _api_get_status(*, owner: str, repo: str, sha: str, token: str) -> dict[str, Any]:
+def _api_get_status(*, owner: str, repo: str, sha: str, token: str) -> Dict[str, Any]:
     """Fetch the commit-status payload for the target commit SHA."""
     return _impl_helper("_api_get_status")(
         owner=owner,
@@ -136,48 +136,48 @@ def _api_get_status(*, owner: str, repo: str, sha: str, token: str) -> dict[str,
     )
 
 
-def _check_run_context(run: dict[str, Any]) -> tuple[str, dict[str, str]] | None:
+def _check_run_context(run: Dict[str, Any]) -> Tuple[str, Dict[str, str]] | None:
     """Normalize one check-run entry into the shared context shape."""
     return _impl_helper("_check_run_context")(run)
 
 
-def _status_context(status: dict[str, Any]) -> tuple[str, dict[str, str]] | None:
+def _status_context(status: Dict[str, Any]) -> Tuple[str, Dict[str, str]] | None:
     """Normalize one status entry into the shared context shape."""
     return _impl_helper("_status_context")(status)
 
 
 def _collect_contexts(
-    check_runs_payload: dict[str, Any],
-    status_payload: dict[str, Any],
-) -> dict[str, dict[str, str]]:
+    check_runs_payload: Dict[str, Any],
+    status_payload: Dict[str, Any],
+) -> Dict[str, Dict[str, str]]:
     """Merge check-run and status payloads into one context map."""
     return _impl_helper("_collect_contexts")(check_runs_payload, status_payload)
 
 
-def _check_run_failure(context: str, observed: dict[str, str]) -> str | None:
+def _check_run_failure(context: str, observed: Dict[str, str]) -> str | None:
     """Return the failure summary for a check-run context, if any."""
     return _impl_helper("_check_run_failure")(context, observed)
 
 
-def _status_failure(context: str, observed: dict[str, str]) -> str | None:
+def _status_failure(context: str, observed: Dict[str, str]) -> str | None:
     """Return the failure summary for a commit-status context, if any."""
     return _impl_helper("_status_failure")(context, observed)
 
 
 def _evaluate(
-    required: list[str],
-    contexts: dict[str, dict[str, str]],
-) -> tuple[str, list[str], list[str]]:
+    required: List[str],
+    contexts: Dict[str, Dict[str, str]],
+) -> Tuple[str, List[str], List[str]]:
     """Evaluate whether every required context is present and successful."""
     return _impl_helper("_evaluate")(required, contexts)
 
 
-def _render_md(payload: dict[str, Any]) -> str:
+def _render_md(payload: Dict[str, Any]) -> str:
     """Render the markdown summary for the required-check gate."""
     return _impl_helper("_render_md")(payload)
 
 
-def _required_contexts(args: argparse.Namespace) -> list[str]:
+def _required_contexts(args: argparse.Namespace) -> List[str]:
     """Return the normalized list of required check context names."""
     return _impl_helper("_required_contexts")(args)
 
@@ -187,22 +187,22 @@ def _github_token() -> str:
     return _impl_helper("_github_token")()
 
 
-def _snapshot(*args, **kwargs) -> dict[str, Any]:
+def _snapshot(*args, **kwargs) -> Dict[str, Any]:
     """Build the current required-check snapshot payload."""
     return _impl_helper("_snapshot")(*args, **kwargs)
 
 
-def _has_in_progress_check_run(contexts: dict[str, dict[str, str]]) -> bool:
+def _has_in_progress_check_run(contexts: Dict[str, Dict[str, str]]) -> bool:
     """Return whether any observed check run is still in progress."""
     return _impl_helper("_has_in_progress_check_run")(contexts)
 
 
-def _should_wait(payload: dict[str, Any]) -> bool:
+def _should_wait(payload: Dict[str, Any]) -> bool:
     """Return whether polling should continue for the current snapshot."""
     return _impl_helper("_should_wait")(payload)
 
 
-def _collect_until_settled(request: Any) -> dict[str, Any]:
+def _collect_until_settled(request: Any) -> Dict[str, Any]:
     """Poll GitHub until the required contexts settle or time out."""
     return _impl_helper("_collect_until_settled")(request)
 

--- a/scripts/quality/check_sentry_zero.py
+++ b/scripts/quality/check_sentry_zero.py
@@ -35,7 +35,7 @@ class SentryScanRequest:
     """Parameters for scanning Sentry projects for unresolved issues."""
 
     org: str
-    projects: list[str]
+    projects: List[str]
     token: str
 
 
@@ -69,7 +69,7 @@ def _parse_args() -> argparse.Namespace:
 
 def _request_project_issues(
     org: str, project: str, token: str
-) -> tuple[list[Any], dict[str, str]]:
+) -> Tuple[List[Any], Dict[str, str]]:
     """Request project issues."""
     org_slug = encode_identifier(org, field_name="Sentry org")
     project_slug = encode_identifier(project, field_name="Sentry project")
@@ -89,7 +89,7 @@ def _request_project_issues(
     return payload, headers
 
 
-def _hits_from_headers(headers: dict[str, str]) -> int | None:
+def _hits_from_headers(headers: Dict[str, str]) -> int | None:
     """Hits from headers."""
     raw = headers.get("x-hits")
     if not raw:
@@ -100,13 +100,13 @@ def _hits_from_headers(headers: dict[str, str]) -> int | None:
         return None
 
 
-def _collect_projects(args: argparse.Namespace, env: Mapping[str, str]) -> list[str]:
+def _collect_projects(args: argparse.Namespace, env: Mapping[str, str]) -> List[str]:
     """Collect projects."""
     projects = [p for p in args.project if p]
     if projects:
         return projects
 
-    resolved: list[str] = []
+    resolved: List[str] = []
     for env_name in ("SENTRY_PROJECT_BACKEND", "SENTRY_PROJECT_WEB"):
         value = str(env.get(env_name, "")).strip()
         if value:
@@ -114,9 +114,9 @@ def _collect_projects(args: argparse.Namespace, env: Mapping[str, str]) -> list[
     return resolved
 
 
-def _missing_config_findings(token: str, org: str, projects: list[str]) -> list[str]:
+def _missing_config_findings(token: str, org: str, projects: List[str]) -> List[str]:
     """Missing config findings."""
-    findings: list[str] = []
+    findings: List[str] = []
     if not token:
         findings.append("SENTRY_AUTH_TOKEN is missing.")
     if not org:
@@ -129,10 +129,10 @@ def _missing_config_findings(token: str, org: str, projects: list[str]) -> list[
 
 
 def _resolve_unresolved_count(
-    issues: list[Any],
-    headers: dict[str, str],
+    issues: List[Any],
+    headers: Dict[str, str],
     project: str,
-    failures: list[str],
+    failures: List[str],
 ) -> int:
     """Resolve unresolved count."""
     unresolved = _hits_from_headers(headers)
@@ -171,13 +171,13 @@ def _coerce_scan_request(*args: Any, **kwargs: Any) -> SentryScanRequest:
 
 def _scan_projects(
     *args: Any, **kwargs: Any
-) -> tuple[str, list[dict[str, Any]], list[str], list[str]]:
+) -> Tuple[str, List[Dict[str, Any]], List[str], List[str]]:
     """Scan projects."""
     request = _coerce_scan_request(*args, **kwargs)
     mode = "strict"
-    project_results: list[dict[str, Any]] = []
-    findings: list[str] = []
-    failures: list[str] = []
+    project_results: List[Dict[str, Any]] = []
+    findings: List[str] = []
+    failures: List[str] = []
 
     for project in request.projects:
         try:
@@ -251,7 +251,7 @@ def main() -> int:
     projects = _collect_projects(args, os.environ)
 
     findings = _missing_config_findings(token, org, projects)
-    project_results: list[dict[str, Any]] = []
+    project_results: List[Dict[str, Any]] = []
     mode = "strict"
 
     if findings:

--- a/scripts/quality/check_sonar_zero.py
+++ b/scripts/quality/check_sonar_zero.py
@@ -54,8 +54,8 @@ def _auth_header(token: str) -> str:
 
 
 def _request_json(
-    *, path: str, query: dict[str, str], auth_header: str
-) -> dict[str, Any]:
+    *, path: str, query: Dict[str, str], auth_header: str
+) -> Dict[str, Any]:
     """Request json."""
     payload, _headers = request_json_https(
         host=SONAR_API_HOST,
@@ -75,7 +75,7 @@ def _request_json(
 
 def _build_issue_query(
     project_key: str, *, branch: str, pull_request: str
-) -> dict[str, str]:
+) -> Dict[str, str]:
     """Build issue query."""
     query = {
         "componentKeys": project_key,
@@ -103,7 +103,7 @@ def _build_quality_gate_query(
 
 def _build_hotspot_query(
     project_key: str, *, branch: str, pull_request: str
-) -> dict[str, str]:
+) -> Dict[str, str]:
     """Build hotspot query."""
     query = {
         "projectKey": project_key,
@@ -123,7 +123,7 @@ def _fetch_sonar_status(
     project_key: str,
     branch: str,
     pull_request: str,
-) -> tuple[int, str, int]:
+) -> Tuple[int, str, int]:
     """Fetch sonar status."""
     issues_payload = _request_json(
         path="/api/issues/search",
@@ -163,7 +163,7 @@ def _evaluate_sonar(
     pull_request: str,
 ) -> tuple:
     """Evaluate sonar."""
-    findings: list[str] = []
+    findings: List[str] = []
     open_issues: int | None = None
     quality_gate: str | None = None
     open_hotspots: int | None = None

--- a/scripts/security_helpers.py
+++ b/scripts/security_helpers.py
@@ -29,10 +29,10 @@ class _HttpsRequestInput:
 
     host: str
     path: str
-    headers: dict[str, str]
+    headers: Dict[str, str]
     method: str = "GET"
-    query: dict[str, str] | None = None
-    data: dict[str, Any] | None = None
+    query: Dict[str, str] | None = None
+    data: Dict[str, Any] | None = None
     timeout: int = 30
 
 
@@ -43,7 +43,7 @@ class _HttpsExecutionRequest:
     host: str
     method: str
     request_target: str
-    headers: dict[str, str]
+    headers: Dict[str, str]
     body: str | None
     timeout: int
 
@@ -60,14 +60,14 @@ def _parse_https_url(raw_url: str):
     return parsed
 
 
-def _normalized_hosts(values: set[str] | None) -> set[str]:
+def _normalized_hosts(values: Set[str] | None) -> Set[str]:
     """Normalize hostname allowlist values for exact or suffix matching."""
     if not values:
         return set()
     return {value.lower().strip(".") for value in values if value.strip(".")}
 
 
-def _hostname_matches_suffix(hostname: str, suffixes: set[str]) -> bool:
+def _hostname_matches_suffix(hostname: str, suffixes: Set[str]) -> bool:
     """Return whether the hostname matches any allowed suffix entry."""
     return any(
         hostname == suffix or hostname.endswith(f".{suffix}") for suffix in suffixes
@@ -77,8 +77,8 @@ def _hostname_matches_suffix(hostname: str, suffixes: set[str]) -> bool:
 def _validate_hostname_allowlists(
     hostname: str,
     *,
-    allowed_hosts: set[str] | None = None,
-    allowed_host_suffixes: set[str] | None = None,
+    allowed_hosts: Set[str] | None = None,
+    allowed_host_suffixes: Set[str] | None = None,
 ) -> None:
     """Validate a hostname against optional exact and suffix allowlists."""
     exact_hosts = _normalized_hosts(allowed_hosts)
@@ -112,8 +112,8 @@ def _reject_local_targets(hostname: str) -> None:
 def normalize_https_url(
     raw_url: str,
     *,
-    allowed_hosts: set[str] | None = None,
-    allowed_host_suffixes: set[str] | None = None,
+    allowed_hosts: Set[str] | None = None,
+    allowed_host_suffixes: Set[str] | None = None,
     strip_query: bool = False,
 ) -> str:
     """Validate user-provided URLs for CLI scripts.
@@ -162,9 +162,9 @@ def encode_identifier(raw: str, *, field_name: str) -> str:
 def split_validated_https_url(
     raw_url: str,
     *,
-    allowed_hosts: set[str] | None = None,
-    allowed_host_suffixes: set[str] | None = None,
-) -> tuple[str, str, dict[str, str]]:
+    allowed_hosts: Set[str] | None = None,
+    allowed_host_suffixes: Set[str] | None = None,
+) -> Tuple[str, str, Dict[str, str]]:
     """Validate an HTTPS URL and split it into host, path, and query pairs."""
     safe_url = normalize_https_url(
         raw_url,
@@ -196,7 +196,7 @@ def _normalize_https_path(path: str) -> str:
     return safe_path
 
 
-def _build_request_target(path: str, query: dict[str, str] | None) -> str:
+def _build_request_target(path: str, query: Dict[str, str] | None) -> str:
     """Build a request target from a normalized path and query mapping."""
     query_text = urllib.parse.urlencode(query or {}, doseq=False)
     return path + (f"?{query_text}" if query_text else "")
@@ -210,7 +210,7 @@ def _build_https_url(host: str, request_target: str) -> str:
     )
 
 
-def _json_body_or_none(data: dict[str, Any] | None) -> str | None:
+def _json_body_or_none(data: Dict[str, Any] | None) -> str | None:
     """Serialize a JSON request body when one is present."""
     return json.dumps(data) if data is not None else None
 
@@ -224,7 +224,7 @@ def _secure_ssl_context() -> ssl.SSLContext:
     return context
 
 
-def _read_https_success(response) -> tuple[int, str, str, dict[str, str]]:
+def _read_https_success(response) -> Tuple[int, str, str, Dict[str, str]]:
     """Read a successful HTTPS response into normalized primitives."""
     raw_body = response.read().decode("utf-8")
     response_headers = {str(k).lower(): str(v) for k, v in response.headers.items()}
@@ -235,7 +235,7 @@ def _read_https_success(response) -> tuple[int, str, str, dict[str, str]]:
 
 def _read_https_error(
     exc: urllib.error.HTTPError,
-) -> tuple[int, str, str, dict[str, str]]:
+) -> Tuple[int, str, str, Dict[str, str]]:
     """Read an HTTPS error response into normalized primitives."""
     raw_body = (
         exc.read().decode("utf-8", errors="replace") if exc.fp is not None else ""
@@ -249,7 +249,7 @@ def _read_https_error(
 
 def _execute_https_request(
     request: _HttpsExecutionRequest,
-) -> tuple[int, str, str, dict[str, str]]:
+) -> Tuple[int, str, str, Dict[str, str]]:
     """Execute an HTTPS request and return status, reason, body, and headers."""
     http_request = urllib.request.Request(
         url=_build_https_url(request.host, request.request_target),
@@ -294,7 +294,7 @@ def _coerce_https_request(*args: Any, **kwargs: Any) -> _HttpsRequestInput:
     return request
 
 
-def request_json_https(*args: Any, **kwargs: Any) -> tuple[Any, dict[str, str]]:
+def request_json_https(*args: Any, **kwargs: Any) -> Tuple[Any, Dict[str, str]]:
     """Execute an HTTPS request and decode its JSON response payload."""
     request = _coerce_https_request(*args, **kwargs)
     validated_host = _normalize_https_host(request.host)

--- a/tests/_gui_controller_fixtures.py
+++ b/tests/_gui_controller_fixtures.py
@@ -99,20 +99,20 @@ class _MockView:
 
     def __init__(self) -> None:
         """Handle   init  ."""
-        self.enabled_states: list[bool] = []
-        self.busy_states: list[bool] = []
-        self.status_texts: list[str] = []
-        self.root_labels: list[str] = []
-        self.details_values: list[str] = []
-        self.details_enabled: list[bool] = []
-        self.context_values: list[list[str]] = []
+        self.enabled_states: List[bool] = []
+        self.busy_states: List[bool] = []
+        self.status_texts: List[str] = []
+        self.root_labels: List[str] = []
+        self.details_values: List[str] = []
+        self.details_enabled: List[bool] = []
+        self.context_values: List[List[str]] = []
         self.tree = MagicMock()
         self.tree.selection = MagicMock(return_value=())
         self.tree.get_children = MagicMock(return_value=[])
         self.tree.insert = MagicMock(return_value="item1")
         self.tree.delete = MagicMock()
         self.tree.tag_configure = MagicMock()
-        self.details_vars: dict[str, _Var] = {
+        self.details_vars: Dict[str, _Var] = {
             "name": _Var(""),
             "context": _Var(""),
             "source": _Var(""),
@@ -143,11 +143,11 @@ class _MockView:
         """Handle set root label."""
         self.root_labels.append(text)
 
-    def set_context_values(self, contexts: list[str]) -> None:
+    def set_context_values(self, contexts: List[str]) -> None:
         """Handle set context values."""
         self.context_values.append(contexts)
 
-    def set_wsl_distros(self, distros: list[str], *, enabled: bool) -> None:
+    def set_wsl_distros(self, distros: List[str], *, enabled: bool) -> None:
         """Stub for testing."""
 
     def configure_row_styles(self) -> None:
@@ -157,7 +157,7 @@ class _MockView:
     def clear_table() -> None:
         """Stub for testing."""
 
-    def insert_table_row(self, values: tuple[Any, ...], *, striped: bool) -> str:
+    def insert_table_row(self, values: Tuple[Any, ...], *, striped: bool) -> str:
         """Handle insert table row.
 
         Captures call args so production code matches our test surface; the
@@ -188,7 +188,7 @@ class _Harness(EnvInspectorController):
         self._during_bootstrap = False
 
     @staticmethod
-    def _load_tk_modules() -> tuple[Any, Any, Any, Any]:
+    def _load_tk_modules() -> Tuple[Any, Any, Any, Any]:
         """Handle  load tk modules."""
         return (
             _BOOTSTRAP_TK_MODULE,
@@ -204,7 +204,7 @@ class _Harness(EnvInspectorController):
     def _apply_theme(self) -> None:
         """Stub for testing."""
 
-    def _load_boot_state(self, _root_path: Path) -> tuple[PersistedUiState, Path]:
+    def _load_boot_state(self, _root_path: Path) -> Tuple[PersistedUiState, Path]:
         """Handle  load boot state."""
         return PersistedUiState(context="linux"), Path.cwd()
 
@@ -226,7 +226,7 @@ class _Harness(EnvInspectorController):
 
 def _make_record(**overrides: object) -> EnvRecord:
     """Handle  make record."""
-    defaults: dict[str, Any] = {
+    defaults: Dict[str, Any] = {
         "source_type": "dotenv",
         "source_id": "dotenv:/workspace/.env",
         "source_path": "/workspace/.env",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,8 +8,8 @@ from typing import Dict, List, cast
 import env_inspector_core.cli as cli_mod
 from env_inspector_core.cli import build_parser, run_cli
 
-RecordRow = dict[str, object]
-ServiceCall = dict[str, object]
+RecordRow = Dict[str, object]
+ServiceCall = Dict[str, object]
 
 
 class ListArgs(argparse.Namespace):
@@ -17,7 +17,7 @@ class ListArgs(argparse.Namespace):
 
     root: str
     context: str | None
-    source: list[str]
+    source: List[str]
     wsl_path: str | None
     distro: str | None
     scan_depth: int
@@ -33,7 +33,7 @@ class FakeService:
         self.last_preview_remove: ServiceCall | None = None
         self.last_list: ServiceCall | None = None
 
-    def list_records(self, **kwargs: object) -> list[RecordRow]:
+    def list_records(self, **kwargs: object) -> List[RecordRow]:
         """List records."""
         self.last_list = kwargs
         secret_flag = bool(1)
@@ -55,33 +55,33 @@ class FakeService:
             }
         ]
 
-    def preview_set(self, **kwargs: object) -> list[dict[str, object]]:
+    def preview_set(self, **kwargs: object) -> List[Dict[str, object]]:
         """Preview set."""
         self.last_preview_set = kwargs
         return [{"success": True, "operation_id": "op-preview-set"}]
 
-    def preview_remove(self, **kwargs: object) -> list[dict[str, object]]:
+    def preview_remove(self, **kwargs: object) -> List[Dict[str, object]]:
         """Preview remove."""
         self.last_preview_remove = kwargs
         return [{"success": True, "operation_id": "op-preview-remove"}]
 
-    def set_key(self, **kwargs: object) -> dict[str, object]:
+    def set_key(self, **kwargs: object) -> Dict[str, object]:
         """Set key."""
         self.last_set = kwargs
         return {"success": True, "operation_id": "op-set"}
 
-    def remove_key(self, **kwargs: object) -> dict[str, object]:
+    def remove_key(self, **kwargs: object) -> Dict[str, object]:
         """Remove key."""
         self.last_remove = kwargs
         return {"success": True, "operation_id": "op-remove"}
 
     @staticmethod
-    def list_backups(**kwargs: object) -> list[str]:
+    def list_backups(**kwargs: object) -> List[str]:
         """List backups."""
         return ["/workspace/backup1"]
 
     @staticmethod
-    def restore_backup(**kwargs: object) -> dict[str, object]:
+    def restore_backup(**kwargs: object) -> Dict[str, object]:
         """Restore backup."""
         return {"success": True, "operation_id": "op-restore"}
 
@@ -89,7 +89,7 @@ class FakeService:
 class FixedRowsService:
     """Stub service returning a fixed set of record rows."""
 
-    def __init__(self, rows: list[RecordRow]) -> None:
+    def __init__(self, rows: List[RecordRow]) -> None:
         self.last_list: ServiceCall | None = None
         self._rows = rows
 
@@ -99,11 +99,11 @@ class FixedRowsService:
         include_raw_secrets: bool,
         root: str,
         context: str | None,
-        source: list[str],
+        source: List[str],
         wsl_path: str | None,
         distro: str | None,
         scan_depth: int,
-    ) -> list[RecordRow]:
+    ) -> List[RecordRow]:
         """List records."""
         self.last_list = {
             "include_raw_secrets": include_raw_secrets,
@@ -152,7 +152,7 @@ def test_run_cli_list_json_contract(capsys):
     code = run_cli(["list", "--output", "json"], service=svc)
     case = _case()
     case.assertEqual(code, 0)
-    last_list = cast(dict[str, object], svc.last_list)
+    last_list = cast(Dict[str, object], svc.last_list)
     case.assertIsNotNone(last_list)
     case.assertIs(last_list["include_raw_secrets"], False)
     out = capsys.readouterr().out
@@ -167,7 +167,7 @@ def test_run_cli_list_non_json_uses_export_records(capsys):
     code = run_cli(["list", "--output", "csv"], service=svc)
     case = _case()
     case.assertEqual(code, 0)
-    last_list = cast(dict[str, object], svc.last_list)
+    last_list = cast(Dict[str, object], svc.last_list)
     case.assertIsNotNone(last_list)
     case.assertIs(last_list["include_raw_secrets"], False)
     out = capsys.readouterr().out
@@ -306,7 +306,7 @@ def test_run_cli_export_backup_and_restore(capsys):
     case.assertEqual(export_code, 0)
     case.assertEqual(backup_code, 0)
     case.assertEqual(restore_code, 0)
-    last_list = cast(dict[str, object], svc.last_list)
+    last_list = cast(Dict[str, object], svc.last_list)
     case.assertIsNotNone(last_list)
     case.assertIs(last_list["include_raw_secrets"], False)
 

--- a/tests/test_core_coverage_providers_wsl.py
+++ b/tests/test_core_coverage_providers_wsl.py
@@ -22,7 +22,7 @@ class _CompletedProcessLike:
     returncode: int = 0
     stdout: bytes = b""
     stderr: bytes = b""
-    args: list[Any] = field(default_factory=list)
+    args: List[Any] = field(default_factory=list)
 
 
 def _case() -> unittest.TestCase:

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -159,7 +159,7 @@ def test_resolve_legacy_print_secrets_root_does_not_renormalize_validated_root(
     workspace.mkdir()
     monkeypatch.chdir(workspace)
 
-    calls: list[str] = []
+    calls: List[str] = []
 
     def _validated_root(_value):
         """Return the already validated workspace root for the legacy resolver."""

--- a/tests/test_gui_controller.py
+++ b/tests/test_gui_controller.py
@@ -29,8 +29,8 @@ class _View:
     """Minimal view stub used for busy-state assertions."""
 
     def __init__(self) -> None:
-        self.enabled_states: list[bool] = []
-        self.busy_states: list[bool] = []
+        self.enabled_states: List[bool] = []
+        self.busy_states: List[bool] = []
 
     def set_mutation_actions_enabled(self, enabled: bool) -> None:
         """Record whether mutation actions were enabled."""
@@ -113,7 +113,7 @@ class _ControllerHarness(EnvInspectorController):
         self._during_bootstrap = False
 
     @staticmethod
-    def _load_tk_modules() -> tuple[Any, Any, Any, Any]:
+    def _load_tk_modules() -> Tuple[Any, Any, Any, Any]:
         """Provide stub Tk modules for controller bootstrap."""
         return (
             _BOOTSTRAP_TK_MODULE,
@@ -129,7 +129,7 @@ class _ControllerHarness(EnvInspectorController):
     def _apply_theme(self) -> None:
         """Skip theme configuration during tests."""
 
-    def _load_boot_state(self, _root_path: Path) -> tuple[PersistedUiState, Path]:
+    def _load_boot_state(self, _root_path: Path) -> Tuple[PersistedUiState, Path]:
         """Provide a deterministic boot state for controller tests."""
         return PersistedUiState(context="linux"), Path.cwd()
 
@@ -170,7 +170,7 @@ class _ContextSelectionHarness(_ControllerHarness):
 
     def __init__(self) -> None:
         super().__init__()
-        self.calls: list[str] = []
+        self.calls: List[str] = []
 
     def refresh_data(self) -> None:
         """Record explicit refresh calls after bootstrap."""
@@ -196,7 +196,7 @@ class _RefreshHarness(_ControllerHarness):
         self.key_text = _Var("API_TOKEN")
         self.effective_value_var = _Var("")
         self.view = None
-        self.events: list[tuple[str, object | None]] = []
+        self.events: List[Tuple[str, object | None]] = []
 
     def _set_busy(self, busy: bool) -> None:
         """Record busy-state updates."""
@@ -244,19 +244,19 @@ class _OperationHarness(_ControllerHarness):
         self.key_text = _Var("API_TOKEN")
         self.value_text = _Var("abc")
         self.selected_targets = ["windows:user"]
-        self.records_raw: list[EnvRecord] = []
-        self.calls: list[tuple[str, object | None]] = []
+        self.records_raw: List[EnvRecord] = []
+        self.calls: List[Tuple[str, object | None]] = []
         self.messagebox = cast(Any, _MessageBox())
 
     def _set_status(self, _text: str) -> None:
         """Ignore status updates during mutation tests."""
         return None
 
-    def choose_targets(self) -> list[str]:
+    def choose_targets(self) -> List[str]:
         """Return the current target selection."""
         return list(self.selected_targets)
 
-    def _maybe_choose_dotenv_targets(self, _key: str, targets: list[str]) -> list[str]:
+    def _maybe_choose_dotenv_targets(self, _key: str, targets: List[str]) -> List[str]:
         """Keep dotenv targets unchanged during tests."""
         return list(targets)
 
@@ -265,8 +265,8 @@ class _OperationHarness(_ControllerHarness):
         action: str,
         key: str,
         value: str,
-        targets: list[str],
-    ) -> list[dict[str, object]]:
+        targets: List[str],
+    ) -> List[Dict[str, object]]:
         """Record preview calls and return a successful preview payload."""
         self.calls.append(("preview", action))
         return [{"target": "windows:user", "success": True, "diff_preview": ""}]
@@ -274,7 +274,7 @@ class _OperationHarness(_ControllerHarness):
     def _confirm_diff(
         self,
         action: str,
-        previews: list[dict[str, object]],
+        previews: List[Dict[str, object]],
         preview_only: bool = False,
     ) -> bool:
         """Record confirmation requests and always accept them."""
@@ -286,8 +286,8 @@ class _OperationHarness(_ControllerHarness):
         action: str,
         key: str,
         value: str,
-        targets: list[str],
-    ) -> dict[str, object]:
+        targets: List[str],
+    ) -> Dict[str, object]:
         """Record apply calls and return a successful result payload."""
         self.calls.append(("apply", action))
         return {"success": True, "operation_id": "op-1"}

--- a/tests/test_gui_controller_actions_coverage.py
+++ b/tests/test_gui_controller_actions_coverage.py
@@ -18,7 +18,7 @@ _NEGATIVE_FLAG_TEXT = "no"  # avoid Bandit B106 false-positive on _text="no" lit
 
 def _make_record(**overrides: object) -> EnvRecord:
     """Make record."""
-    defaults: dict[str, Any] = {
+    defaults: Dict[str, Any] = {
         "source_type": "dotenv",
         "source_id": "dotenv:/workspace/.env",
         "source_path": "/workspace/.env",
@@ -85,8 +85,8 @@ class _ActionTestMixin(EnvInspectorControllerActionsMixin):
         self.root_path = Path("/workspace")
 
         self._selected: DisplayedRow | None = None
-        self._status_calls: list[str] = []
-        self._effective_calls: list[str] = []
+        self._status_calls: List[str] = []
+        self._effective_calls: List[str] = []
         self._refresh_calls: int = 0
 
     def _selected_row(self) -> Any:

--- a/tests/test_gui_models_coverage.py
+++ b/tests/test_gui_models_coverage.py
@@ -25,7 +25,7 @@ from tests.assertions import ensure
 
 def _make_record(**overrides: object) -> EnvRecord:
     """Make record."""
-    defaults: dict[str, Any] = {
+    defaults: Dict[str, Any] = {
         "source_type": "dotenv",
         "source_id": "dotenv:/workspace/.env",
         "source_path": "/workspace/.env",

--- a/tests/test_gui_path_actions.py
+++ b/tests/test_gui_path_actions.py
@@ -22,7 +22,7 @@ def test_open_source_path_uses_resolved_file_uri(tmp_path: Path):
     local_file = tmp_path / "a.env"
     local_file.write_text("A=1\n", encoding="utf-8")
 
-    calls: list[str] = []
+    calls: List[str] = []
 
     def fake_opener(uri: str) -> bool:
         """Fake opener."""

--- a/tests/test_gui_table_logic.py
+++ b/tests/test_gui_table_logic.py
@@ -15,7 +15,7 @@ from tests.assertions import ensure
 
 def _rec(name: str, value: str, **overrides: object) -> EnvRecord:
     """Rec."""
-    payload: dict[str, object] = {
+    payload: Dict[str, object] = {
         "source_type": "dotenv",
         "source_path": "/workspace/.env",
         "context": "windows",

--- a/tests/test_gui_table_logic_coverage.py
+++ b/tests/test_gui_table_logic_coverage.py
@@ -15,7 +15,7 @@ from tests.assertions import ensure
 
 def _rec(name: str, value: str, **overrides: object) -> EnvRecord:
     """Rec."""
-    payload: dict[str, object] = {
+    payload: Dict[str, object] = {
         "source_type": "dotenv",
         "source_path": "/workspace/.env",
         "context": "windows",

--- a/tests/test_gui_view_coverage.py
+++ b/tests/test_gui_view_coverage.py
@@ -28,7 +28,7 @@ class _MockTkModule:
 
     def __init__(self) -> None:
         """Handle   init  ."""
-        self._vars: list[MagicMock] = []
+        self._vars: List[MagicMock] = []
 
     def __getattr__(self, name: str) -> Any:
         """Delegate PascalCase tkinter names to snake_case methods."""

--- a/tests/test_linux_support.py
+++ b/tests/test_linux_support.py
@@ -88,11 +88,11 @@ def _patch_linux_etc_environment_reads(
 
 def _patch_linux_etc_environment_denied(
     monkeypatch: pytest.MonkeyPatch, etc_env: Path
-) -> list[str]:
+) -> List[str]:
     """Force direct `/etc/environment` writes to raise `PermissionError`."""
     target = _patch_linux_etc_environment_reads(monkeypatch, etc_env)
     real_write_text_file = EnvInspectorService._write_text_file
-    writes: list[str] = []
+    writes: List[str] = []
 
     def fake_write_text_file(path: Path, text: str, *, ensure_parent: bool) -> None:
         """Raise on direct target writes while allowing ordinary fixture writes."""
@@ -175,7 +175,7 @@ def test_service_list_contexts_hides_current_wsl_bridge_distro(
             return True
 
         @staticmethod
-        def list_distros_for_ui() -> list[str]:
+        def list_distros_for_ui() -> List[str]:
             """Return distros for the UI context list."""
             return ["Ubuntu", "Debian"]
 
@@ -223,7 +223,7 @@ def test_service_list_contexts_keeps_all_distros_without_active_linux_bridge(
             return True
 
         @staticmethod
-        def list_distros_for_ui() -> list[str]:
+        def list_distros_for_ui() -> List[str]:
             """Return bridge distros for the context picker."""
             return ["Ubuntu", "Debian"]
 

--- a/tests/test_pr39_owned_coverage.py
+++ b/tests/test_pr39_owned_coverage.py
@@ -87,7 +87,7 @@ def test_main_gui_mode_runs_app_with_resolved_root(
     )
     monkeypatch.setattr(env_inspector, "resolve_scan_root", lambda _root: workspace)
 
-    captured: dict[str, object] = {}
+    captured: Dict[str, object] = {}
 
     class _FakeApp:
         """Capture GUI application construction and execution."""
@@ -364,7 +364,7 @@ def test_service_listing_filters_cover_registry_fallback(
 def test_privileged_writer_returns_after_direct_write(tmp_path: Path) -> None:
     """Direct writes should bypass sudo when they already succeed."""
     target = tmp_path / "environment"
-    writes: dict[str, object] = {}
+    writes: Dict[str, object] = {}
 
     def _write_text_file(path: Path, text: str) -> None:
         """Capture and perform the direct file write."""

--- a/tests/test_pr54_coverage_branches.py
+++ b/tests/test_pr54_coverage_branches.py
@@ -319,7 +319,7 @@ def test_coerce_scan_request_covers_positional_branches() -> None:
 
 def test_resolve_unresolved_count_without_hits_header_and_without_issues() -> None:
     """Test resolve unresolved count without hits header and without issues."""
-    failures: list[str] = []
+    failures: List[str] = []
 
     unresolved = sentry_mod._resolve_unresolved_count([], {}, "proj", failures)
 

--- a/tests/test_providers_branch_coverage.py
+++ b/tests/test_providers_branch_coverage.py
@@ -119,7 +119,7 @@ def test_collect_wsl_records_includes_bashrc_and_etc_pairs() -> None:
             return True
 
         @staticmethod
-        def list_distros() -> list[str]:
+        def list_distros() -> List[str]:
             """Return a single distro for collection."""
             return ["Ubuntu"]
 
@@ -155,7 +155,7 @@ def test_collect_wsl_records_respects_excluded_distros() -> None:
             return True
 
         @staticmethod
-        def list_distros() -> list[str]:
+        def list_distros() -> List[str]:
             """Return two distros so one can be excluded."""
             return ["Ubuntu", "Debian"]
 
@@ -212,7 +212,7 @@ def test_collect_wsl_dotenv_records_builds_records_from_scanned_env_files() -> N
             _distro: str,
             _root_path: str,
             _max_depth: int,
-        ) -> list[str]:
+        ) -> List[str]:
             """Return the dotenv files that should be scanned."""
             return ["/workspace/.env"]
 

--- a/tests/test_quality_codacy_deepscan_branches.py
+++ b/tests/test_quality_codacy_deepscan_branches.py
@@ -252,7 +252,7 @@ def test_codacy_query_open_issues_fallback_and_last_error(monkeypatch):
         codacy_mod, "_provider_candidates", lambda _preferred: ["gh", "github"]
     )
 
-    responses: list[tuple[bool, int | None, list[str], Exception | None]] = [
+    responses: List[Tuple[bool, int | None, List[str], Exception | None]] = [
         (False, None, [], _http_error(404)),
         (True, 0, [], None),
     ]
@@ -315,7 +315,7 @@ def test_deepscan_resolve_and_fetch_open_issues_paths(monkeypatch):
     case.assertEqual(path, "/api/projects/1/issues/open")
     case.assertEqual(query, {"scope": "pull-request"})
 
-    findings: list[str] = []
+    findings: List[str] = []
     monkeypatch.setattr(
         deepscan_mod,
         "_request_json",
@@ -350,7 +350,7 @@ def test_deepscan_resolve_and_fetch_open_issues_paths(monkeypatch):
 
 def test_deepscan_fetch_open_issues_handles_unparseable_total(monkeypatch):
     """Test deepscan fetch open issues handles unparseable total."""
-    findings: list[str] = []
+    findings: List[str] = []
     monkeypatch.setattr(
         deepscan_mod, "_request_json", lambda **_kwargs: {"meta": {"count": "n/a"}}
     )

--- a/tests/test_quality_http_builders.py
+++ b/tests/test_quality_http_builders.py
@@ -17,11 +17,11 @@ def _fixture_token() -> str:
 
 def test_codacy_request_json_uses_fixed_host_and_validated_segments(monkeypatch):
     """Test codacy request json uses fixed host and validated segments."""
-    captured: dict[str, object] = {}
+    captured: Dict[str, object] = {}
 
     def _fake_request_json_https(
         **kwargs: object,
-    ) -> tuple[dict[str, int], dict[str, str]]:
+    ) -> Tuple[Dict[str, int], Dict[str, str]]:
         """Fake request json https."""
         captured.update(kwargs)
         return {"total": 0}, {}
@@ -60,11 +60,11 @@ def test_codacy_request_json_rejects_unsafe_identifier():
 
 def test_deepscan_request_json_uses_fixed_host(monkeypatch):
     """Test deepscan request json uses fixed host."""
-    captured: dict[str, object] = {}
+    captured: Dict[str, object] = {}
 
     def _fake_request_json_https(
         **kwargs: object,
-    ) -> tuple[dict[str, int], dict[str, str]]:
+    ) -> Tuple[Dict[str, int], Dict[str, str]]:
         """Fake request json https."""
         captured.update(kwargs)
         return {"open_issues": 0}, {}
@@ -85,11 +85,11 @@ def test_deepscan_request_json_uses_fixed_host(monkeypatch):
 
 def test_sentry_request_project_issues_uses_fixed_host(monkeypatch):
     """Test sentry request project issues uses fixed host."""
-    captured: dict[str, object] = {}
+    captured: Dict[str, object] = {}
 
     def _fake_request_json_https(
         **kwargs: object,
-    ) -> tuple[list[object], dict[str, str]]:
+    ) -> Tuple[List[object], Dict[str, str]]:
         """Fake request json https."""
         captured.update(kwargs)
         return [], {"x-hits": "0"}

--- a/tests/test_security_helpers.py
+++ b/tests/test_security_helpers.py
@@ -30,8 +30,8 @@ def test_identifier_and_url_helpers():
 
 def test_request_json_https_success(monkeypatch):
     """Return JSON and headers from a successful HTTPS request."""
-    recorded: dict[str, Any] = {}
-    captured_context: dict[str, sec.ssl.SSLContext] = {}
+    recorded: Dict[str, Any] = {}
+    captured_context: Dict[str, sec.ssl.SSLContext] = {}
 
     class _Response:
         """Minimal HTTP response stub used by the HTTPS helper tests."""

--- a/tests/test_service_coverage_branches.py
+++ b/tests/test_service_coverage_branches.py
@@ -128,11 +128,11 @@ def test_collect_wsl_rows_uses_linux_exclusion_and_dotenv(
     svc.current_wsl_distro = "Ubuntu"
     monkeypatch.setattr(svc.wsl, "available", lambda: True)
 
-    calls: dict[str, object] = {}
+    calls: Dict[str, object] = {}
 
     def _fake_collect_wsl_records(
         wsl, include_etc: bool, exclude_distros
-    ) -> list[EnvRecord]:
+    ) -> List[EnvRecord]:
         """Fake collect wsl records."""
         calls["exclude"] = exclude_distros
         return [
@@ -143,7 +143,7 @@ def test_collect_wsl_rows_uses_linux_exclusion_and_dotenv(
 
     def _fake_collect_wsl_dotenv_records(
         wsl, distro: str, root_path: str, max_depth: int
-    ) -> list[EnvRecord]:
+    ) -> List[EnvRecord]:
         """Fake collect wsl dotenv records."""
         calls["dotenv"] = (distro, root_path, max_depth)
         return [
@@ -284,7 +284,7 @@ def test_update_helpers_cover_dispatch_and_error_branches(monkeypatch, tmp_path:
             apply_changes=False,
         )
 
-    wsl_writes: list[tuple[str, str, str]] = []
+    wsl_writes: List[Tuple[str, str, str]] = []
     monkeypatch.setattr(svc.wsl, "read_file", lambda distro, path: "")
     monkeypatch.setattr(
         svc.wsl,
@@ -406,7 +406,7 @@ def test_restore_helpers_cover_linux_and_wsl_targets(
     svc._restore_linux_target(target="linux:bashrc", text="export A=1\n")
     ensure((fake_home / ".bashrc").read_text(encoding="utf-8") == "export A=1\n")
 
-    etc_calls: list[str] = []
+    etc_calls: List[str] = []
     monkeypatch.setattr(
         svc, "_write_linux_etc_environment_with_privilege", etc_calls.append
     )
@@ -416,7 +416,7 @@ def test_restore_helpers_cover_linux_and_wsl_targets(
     with pytest.raises(RuntimeError, match="Unsupported Linux restore target"):
         svc._restore_linux_target(target="linux:unknown", text="x")
 
-    wsl_calls: list[tuple[str, str, str]] = []
+    wsl_calls: List[Tuple[str, str, str]] = []
     monkeypatch.setattr(
         svc.wsl,
         "write_file_with_privilege",
@@ -457,11 +457,11 @@ def test_restore_helpers_cover_powershell_and_registry(
 
         def __init__(self) -> None:
             """Init."""
-            self.removed: list[tuple[str, str]] = []
-            self.sets: list[tuple[str, str, str]] = []
+            self.removed: List[Tuple[str, str]] = []
+            self.sets: List[Tuple[str, str, str]] = []
 
         @staticmethod
-        def list_scope(scope: str) -> dict[str, str]:
+        def list_scope(scope: str) -> Dict[str, str]:
             """List scope."""
             return {"KEEP": "1", "DROP": "2"}
 
@@ -485,7 +485,7 @@ def test_restore_helpers_cover_powershell_and_registry(
 def test_restore_helpers_cover_dispatch(tmp_path: Path, monkeypatch) -> None:
     """Test restore helpers cover dispatch."""
     svc = EnvInspectorService(state_dir=tmp_path / "state")
-    calls: list[str] = []
+    calls: List[str] = []
     monkeypatch.setattr(
         svc, "_restore_linux_target", lambda **kwargs: calls.append("linux")
     )

--- a/tests/test_service_path_guards.py
+++ b/tests/test_service_path_guards.py
@@ -138,7 +138,7 @@ def test_restore_wsl_dotenv_backup_uses_wsl_write_file(tmp_path: Path, monkeypat
     monkeypatch.chdir(tmp_path)
     svc = EnvInspectorService(state_dir=tmp_path / "state")
 
-    calls: list[tuple[str, str, str]] = []
+    calls: List[Tuple[str, str, str]] = []
     monkeypatch.setattr(
         svc.wsl,
         "write_file",
@@ -159,7 +159,7 @@ def test_restore_wsl_bashrc_backup_uses_wsl_write_file(tmp_path: Path, monkeypat
     monkeypatch.chdir(tmp_path)
     svc = EnvInspectorService(state_dir=tmp_path / "state")
 
-    calls: list[tuple[str, str, str]] = []
+    calls: List[Tuple[str, str, str]] = []
     monkeypatch.setattr(
         svc.wsl,
         "write_file",
@@ -191,7 +191,7 @@ def test_restore_wsl_dotenv_backup_rejects_path_traversal(tmp_path: Path, monkey
     monkeypatch.chdir(tmp_path)
     svc = EnvInspectorService(state_dir=tmp_path / "state")
 
-    calls: list[tuple[str, str, str]] = []
+    calls: List[Tuple[str, str, str]] = []
     monkeypatch.setattr(
         svc.wsl,
         "write_file",
@@ -247,7 +247,7 @@ def test_restore_powershell_target_all_users_uses_program_files_root(
     svc = EnvInspectorService(state_dir=tmp_path / "state")
     profile = tmp_path / "program_files" / "PowerShell" / "7" / "profile.ps1"
 
-    writes: dict[str, object] = {}
+    writes: Dict[str, object] = {}
     monkeypatch.setattr(
         EnvInspectorService,
         "_validated_powershell_restore_path",

--- a/tests/test_wsl_privilege.py
+++ b/tests/test_wsl_privilege.py
@@ -21,7 +21,7 @@ def _proc(
 
 def test_write_file_with_privilege_root_success() -> None:
     """Write through the root path when the first privileged attempt succeeds."""
-    calls: list[list[str]] = []
+    calls: List[List[str]] = []
 
     def runner(cmd, **_kwargs) -> CompletedProcess:
         """Capture the command issued by the privileged root write path."""
@@ -41,8 +41,8 @@ def test_write_file_with_privilege_root_success() -> None:
 
 def test_write_file_with_privilege_falls_back_to_sudo() -> None:
     """Retry with `sudo tee` when the direct root write attempt fails."""
-    calls: list[list[str]] = []
-    inputs: list[bytes | None] = []
+    calls: List[List[str]] = []
+    inputs: List[bytes | None] = []
 
     def runner(cmd, **kwargs) -> CompletedProcess:
         """Record write attempts and fail the direct root path once."""
@@ -84,7 +84,7 @@ def test_available_probes_command_and_returns_false_when_probe_fails(
     tmp_path: Path,
 ) -> None:
     """Return false when the WSL availability probe exits unsuccessfully."""
-    calls: list[list[str]] = []
+    calls: List[List[str]] = []
     fake_wsl = tmp_path / "wsl.exe"
     fake_wsl.write_text("", encoding="utf-8")
 


### PR DESCRIPTION
## **User description**
## Summary
Codacy's PyLintPython3 ships with an older PyLint that lacks proper PEP 585 handling, raising 'unsubscriptable-object' (E1136) on `list[X]`/`dict[K,V]`. Restore typing.List/Dict imports across 61 files.

Closes ~414 false-positive E1136 findings without disabling any rules.

## Test plan
- [ ] env-inspector-ci stays green
- [ ] Coverage 100 stays at 100%
- [ ] Codacy Zero open count drops materially

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Downgraded PEP 585 built‑in generics to `typing` equivalents to stop Codacy’s older PyLint from flagging E1136 unsubscriptable errors. Removes ~414 false positives with no runtime or API changes.

- **Bug Fixes**
  - Replaced `list[...]`, `dict[...]`, `tuple[...]`, `set[...]`, etc. with `typing` imports (`List`, `Dict`, `Tuple`, `Set`, `FrozenSet`, `Type`) across 61 files, including quality scripts and tests.
  - Updated Protocols, type aliases, and function signatures to use `typing` generics; behavior unchanged.
  - Codacy analysis no longer reports E1136 without disabling any rules.

<sup>Written for commit 8cacafcfa64a7f55e2f7aecd4d3373b5f7979b63. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Restore older typing syntax so Codacy stops flagging false unsubscriptable errors**

### What Changed
- Replaced newer built-in generic annotations with `typing` equivalents across the app, GUI, scripts, and tests
- Kept runtime behavior unchanged while making the code compatible with Codacy’s older PyLint checks
- Updated test helpers and type checks to match the revised annotations

### Impact
`✅ Fewer false Codacy E1136 findings`
`✅ Cleaner static analysis reports`
`✅ No runtime behavior changes`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=kV14QkNzOL5dAsvEeq1JKnpyQ59yAQlYmhBT6QaXF5g&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
