### PR TITLE
fix(ci): correct Codacy API endpoint for bulk ignore

### DIFF
--- a/.github/workflows/codacy-mark-fp.yml
+++ b/.github/workflows/codacy-mark-fp.yml
@@ -83,34 +83,28 @@ jobs:
           ]
           print(f"Matching target patterns: {len(target_issues)}")
 
-          marked = 0
+          # Use the bulkIgnoreIssues endpoint:
+          #   POST /analysis/organizations/{provider}/{org}/repositories/{repo}/issues/ignore
+          bulk_url = f"{base}/analysis/organizations/gh/{owner}/repositories/{repo}/issues/ignore"
+          ignored = 0
           failures = 0
-          for issue in target_issues:
-              issue_id = issue.get("issueId") or issue.get("resultDataId")
-              if not issue_id:
-                  continue
-              # Try different known endpoints; Codacy has changed API versions
-              endpoints = [
-                  f"{base}/organizations/gh/{owner}/repositories/{repo}/issues/{issue_id}/status",
-                  f"{base}/analysis/organizations/gh/{owner}/repositories/{repo}/issues/{issue_id}/status",
-              ]
-              body = json.dumps({"status": "FalsePositive"}).encode("utf-8")
-              done = False
-              for url in endpoints:
-                  req = urllib.request.Request(url, headers=headers, method="PATCH", data=body)
-                  try:
-                      with urllib.request.urlopen(req, timeout=30) as resp:
-                          _ = resp.read()
-                      marked += 1
-                      done = True
-                      break
-                  except Exception as exc:
-                      last_err = str(exc)
-                      continue
-              if not done:
-                  failures += 1
-                  if failures <= 3:
-                      print(f"FAILED to mark {issue_id}: {last_err}")
+          batch_size = 50
+          issue_ids = [
+              i.get("issueId") for i in target_issues if i.get("issueId")
+          ]
+          for i in range(0, len(issue_ids), batch_size):
+              batch = issue_ids[i : i + batch_size]
+              body = json.dumps({"issueIds": batch}).encode("utf-8")
+              req = urllib.request.Request(
+                  bulk_url, headers=headers, method="POST", data=body
+              )
+              try:
+                  with urllib.request.urlopen(req, timeout=60) as resp:
+                      _ = resp.read()
+                  ignored += len(batch)
+              except Exception as exc:
+                  failures += len(batch)
+                  print(f"Batch {i}-{i + len(batch)} failed: {exc}")
 
-          print(f"\nMarked {marked}/{len(target_issues)} issues; failures={failures}")
+          print(f"\nBulk-ignored {ignored}/{len(issue_ids)} issues; failures={failures}")
           PY


### PR DESCRIPTION
## **User description**
The earlier FP-marker used a non-existent PATCH endpoint. Switch to `POST /issues/ignore` with `{'issueIds': [...]}` body, batched at 50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CI Codacy false-positive marker by switching to the correct bulk ignore API, replacing the invalid per-issue PATCH calls. This restores FP marking by sending issue IDs in batches of 50.

- **Bug Fixes**
  - Use `POST /analysis/organizations/{provider}/{org}/repositories/{repo}/issues/ignore` with `{"issueIds": [...]}`.
  - Batch requests at 50 IDs, raise timeout to 60s, and report ignored vs. failures.
  - Remove per-issue `PATCH /issues/{id}/status` attempts and fallback endpoints.

<sup>Written for commit d6427003c857a13bbb37bc79ce4612895231b03c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Fix Codacy false-positive marking in CI**

### What Changed
- CI now marks Codacy false positives through the supported bulk ignore request, instead of trying endpoints that no longer work.
- Matching issues are sent in groups of 50, which avoids oversized requests and lets the job continue handling larger batches.
- The workflow now reports how many issues were ignored and how many failed, with clearer error output when a batch does not succeed.

### Impact
`✅ CI can still mark Codacy false positives`
`✅ Fewer failed ignore attempts on larger issue sets`
`✅ Clearer Codacy cleanup results in workflow logs`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=7HkTDDh8dDSeUe2MLO2Zpl9sJ0t6v-Axhh7TBNleqhY&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
