### PR TITLE
fix(bandit): per-line nosec B105 for is_secret: False

### DIFF
--- a/tests/_gui_controller_fixtures.py
+++ b/tests/_gui_controller_fixtures.py
@@ -233,7 +233,7 @@ def _make_record(**overrides: object) -> EnvRecord:
         "context": "linux",
         "name": "KEY",
         "value": "val",
-        "is_secret": False,
+        "is_secret": False,  # nosec B105
         "is_persistent": False,
         "is_mutable": True,
         "precedence_rank": 50,

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -99,7 +99,7 @@ def test_legacy_print_secrets_skips_non_secret_rows(
         """List records."""
         return [
             {
-                "is_secret": False,
+                "is_secret": False,  # nosec B105
                 "source_type": "dotenv",
                 "source_id": ".env",
                 "name": "PUBLIC_VAR",

--- a/tests/test_gui_controller_actions_coverage.py
+++ b/tests/test_gui_controller_actions_coverage.py
@@ -25,7 +25,7 @@ def _make_record(**overrides: object) -> EnvRecord:
         "context": "windows",
         "name": "KEY",
         "value": "val",
-        "is_secret": False,
+        "is_secret": False,  # nosec B105
         "is_persistent": False,
         "is_mutable": True,
         "precedence_rank": 50,

--- a/tests/test_gui_models_coverage.py
+++ b/tests/test_gui_models_coverage.py
@@ -32,7 +32,7 @@ def _make_record(**overrides: object) -> EnvRecord:
         "context": "windows",
         "name": "KEY",
         "value": "val",
-        "is_secret": False,
+        "is_secret": False,  # nosec B105
         "is_persistent": False,
         "is_mutable": True,
         "precedence_rank": 50,

--- a/tests/test_gui_table_logic.py
+++ b/tests/test_gui_table_logic.py
@@ -19,7 +19,7 @@ def _rec(name: str, value: str, **overrides: object) -> EnvRecord:
         "source_type": "dotenv",
         "source_path": "/workspace/.env",
         "context": "windows",
-        "is_secret": False,
+        "is_secret": False,  # nosec B105
         "is_persistent": False,
         "is_mutable": True,
         "precedence_rank": 50,

--- a/tests/test_gui_table_logic_coverage.py
+++ b/tests/test_gui_table_logic_coverage.py
@@ -19,7 +19,7 @@ def _rec(name: str, value: str, **overrides: object) -> EnvRecord:
         "source_type": "dotenv",
         "source_path": "/workspace/.env",
         "context": "windows",
-        "is_secret": False,
+        "is_secret": False,  # nosec B105
         "is_persistent": False,
         "is_mutable": True,
         "precedence_rank": 50,


### PR DESCRIPTION
## **User description**
🤖

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppresses `bandit` B105 false positives in tests by adding per-line `# nosec B105` to dict entries with `"is_secret": False`. This affects only test fixtures and unblocks CI.

- **Bug Fixes**
  - Added `# nosec B105` on six test records where `is_secret: False` appears so `bandit` doesn’t misflag boolean fields as hardcoded secrets.

<sup>Written for commit 389b0f861bdc890b5e89a18061f7d31052be9fa4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Suppress false bandit warnings in test fixtures that use `is_secret: False`

### What Changed
- Added `# nosec B105` to test records where `is_secret` is explicitly set to `False`
- Prevents the security scanner from treating boolean test data as a hardcoded secret
- Keeps CI checks focused on real secret warnings instead of test-only false positives

### Impact
`✅ Fewer false security warnings in test runs`
`✅ Cleaner CI output`
`✅ Less time spent reviewing non-issues`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=Ghzv1RA22Fja9IRAYHJPJ-10uxAPyn_Ow_RLxOmdXMo&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
