### PR TITLE
fix(codacy): final pylint disables + R0917 refactor

### DIFF
--- a/env_inspector_gui/dialogs.py
+++ b/env_inspector_gui/dialogs.py
@@ -59,7 +59,9 @@ class TargetPickerDialog:
 
         canvas.pack(side="left", fill="both", expand=True)
         scroll.pack(side="right", fill="y")
-        self._build_target_checks(body, selected_set, selected is not None, tk, ttk)
+        self._build_target_checks(
+            body, selected_set, has_selected=selected is not None, tk=tk, ttk=ttk
+        )
 
         self.selected_count_label = ttk.Label(frame, text="")
         self.selected_count_label.pack(anchor="w", pady=(8, 0))
@@ -105,7 +107,13 @@ class TargetPickerDialog:
         )
 
     def _build_target_checks(
-        self, body: Any, selected_set: Set[str], has_selected: bool, tk: Any, ttk: Any
+        self,
+        body: Any,
+        selected_set: Set[str],
+        *,
+        has_selected: bool,
+        tk: Any,
+        ttk: Any,
     ) -> None:
         """Build target checks."""
         for target in self._targets:

--- a/tests/_gui_controller_fixtures.py
+++ b/tests/_gui_controller_fixtures.py
@@ -157,7 +157,9 @@ class _MockView:
     def clear_table() -> None:
         """Stub for testing."""
 
-    def insert_table_row(self, values: Tuple[Any, ...], *, striped: bool) -> str:
+    def insert_table_row(  # pylint: disable=no-self-use
+        self, values: Tuple[Any, ...], *, striped: bool
+    ) -> str:
         """Handle insert table row.
 
         Captures call args so production code matches our test surface; the

--- a/tests/test_core_coverage_remaining.py
+++ b/tests/test_core_coverage_remaining.py
@@ -51,7 +51,7 @@ def test_cli_csv_output(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None
     ensure("MY_VAR" in output or "context" in output)
 
 
-def test_cli_csv_empty_rows(
+def test_cli_csv_empty_rows(  # pylint: disable=unused-argument
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,  # noqa: ARG001 - pytest fixture
 ) -> None:

--- a/tests/test_gui_controller_coverage.py
+++ b/tests/test_gui_controller_coverage.py
@@ -208,7 +208,8 @@ def test_choose_folder_selected(tmp_path: Path):
     ctrl.service.list_records_raw = MagicMock(return_value=[])
     ctrl.service.resolve_effective = MagicMock(return_value=None)
     ctrl.state_dir = Path("/var/state-fixture")
-    with (
+    # PyLint < 2.10 mis-reads parenthesized-with as a tuple context manager (E1129).
+    with (  # pylint: disable=not-context-manager
         patch("env_inspector_gui.controller.resolve_scan_root", return_value=tmp_path),
         patch("env_inspector_gui.controller.save_ui_state"),
     ):

--- a/tests/test_pr54_coverage_branches.py
+++ b/tests/test_pr54_coverage_branches.py
@@ -154,7 +154,7 @@ def test_write_linux_etc_environment_with_privilege_rejects_invalid_arguments(
         )
 
 
-def test_restore_helpers_reject_positional_arguments(
+def test_restore_helpers_reject_positional_arguments(  # pylint: disable=unused-argument
     tmp_path: Path,  # noqa: ARG001 - pytest fixture
 ) -> None:
     """Test restore helpers reject positional arguments."""

--- a/tests/test_quality_branch_coverage.py
+++ b/tests/test_quality_branch_coverage.py
@@ -85,7 +85,7 @@ def test_sentry_collect_projects_prefers_args_and_env_fallback():
 def test_sentry_scan_projects_covers_header_fallback_and_failures(monkeypatch):
     """Test sentry scan projects covers header fallback and failures."""
 
-    def _fake_request_project_issues(_org: str, project: str, token: str):
+    def _fake_request_project_issues(_org: str, project: str, token: str):  # pylint: disable=unused-argument
         """Fake request project issues."""
         return [{"id": "1"}], {}
 

--- a/tests/test_service_coverage_branches.py
+++ b/tests/test_service_coverage_branches.py
@@ -131,7 +131,7 @@ def test_collect_wsl_rows_uses_linux_exclusion_and_dotenv(
     calls: Dict[str, object] = {}
 
     def _fake_collect_wsl_records(
-        wsl, include_etc: bool, exclude_distros
+        wsl, include_etc: bool, exclude_distros  # pylint: disable=unused-argument
     ) -> List[EnvRecord]:
         """Fake collect wsl records."""
         calls["exclude"] = exclude_distros
@@ -142,7 +142,7 @@ def test_collect_wsl_rows_uses_linux_exclusion_and_dotenv(
         ]
 
     def _fake_collect_wsl_dotenv_records(
-        wsl, distro: str, root_path: str, max_depth: int
+        wsl, distro: str, root_path: str, max_depth: int  # pylint: disable=unused-argument
     ) -> List[EnvRecord]:
         """Fake collect wsl dotenv records."""
         calls["dotenv"] = (distro, root_path, max_depth)


### PR DESCRIPTION
## **User description**
Final batch. 🤖

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Final Codacy cleanup that refactors a dialog helper to reduce positional args and adds targeted `pylint` disables for known false positives. No runtime behavior changes.

- **Refactors**
  - `_build_target_checks` now requires keyword-only args (`has_selected`, `tk`, `ttk`); call site updated to satisfy `pylint` R0917.

- **Bug Fixes**
  - Added `pylint: disable=not-context-manager` for a parenthesized with that older `pylint` mis-parses (E1129).
  - Added `pylint: disable=unused-argument` and `no-self-use` in test stubs/mocks to mirror production interfaces without warnings.

<sup>Written for commit 14a44699fcd73293f03ef7ff10a4eebe671e7a26. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Clean up PyLint false positives without changing app behavior**

### What Changed
- Updated one dialog helper call to use named inputs, avoiding a PyLint warning about too many positional arguments.
- Added targeted PyLint suppressions in tests where stubs and mock helpers intentionally match production call shapes.
- Marked one older parenthesized `with` test case so it is not flagged by older PyLint versions.

### Impact
`✅ Fewer false-positive lint warnings`
`✅ Cleaner test coverage runs`
`✅ No change to app behavior`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=CEsHJBZGp10GEuVLkVmmAuvBQHGpnmbuxBpFLi-HYZY&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
