### PR TITLE
fix(codacy): tail cleanup — semgrep, no-member, R0801 note

### DIFF
--- a/env_inspector_core/service_restore.py
+++ b/env_inspector_core/service_restore.py
@@ -45,7 +45,8 @@ def restore_linux_target(*args, **kwargs) -> None:
         path_out: Path = Path(Path.home(), ".bashrc").resolve()
         bashrc_parent = Path(path_out.parent)
         bashrc_parent.mkdir(parents=True, exist_ok=True)
-        path_out.write_text(text, encoding="utf-8")
+        # PyLint mis-infers path_out as PurePath despite the explicit Path annotation.
+        path_out.write_text(text, encoding="utf-8")  # pylint: disable=no-member
         return
     if target == etc_target:
         write_linux_etc_env_fn(text)

--- a/scripts/quality/_codacy_zero_impl.py
+++ b/scripts/quality/_codacy_zero_impl.py
@@ -228,8 +228,10 @@ def _query_open_issues(
             return open_issues, findings
         last_exc = error
     findings = [
-        f"Codacy API endpoint was not found for provider(s): "
-        f"{', '.join(provider_candidates_fn(request.provider))}."
+        (
+            f"Codacy API endpoint was not found for provider(s): "
+            f"{', '.join(provider_candidates_fn(request.provider))}."
+        )
     ]
     if last_exc is not None:
         findings.append(f"Last Codacy API error: {last_exc}")

--- a/tests/test_gui_dialogs_coverage.py
+++ b/tests/test_gui_dialogs_coverage.py
@@ -263,7 +263,8 @@ class TestTargetPickerDialog:
         for var in dialog._vars.values():
             var.get.return_value = True
         dialog._update_selected_count()
-        dialog.selected_count_label.configure.assert_called()
+        # PyLint can't see through MagicMock attributes; assert_called is real on mocks.
+        dialog.selected_count_label.configure.assert_called()  # pylint: disable=no-member
 
     def test_sync_scrollregion(self):
         """Test sync scrollregion."""


### PR DESCRIPTION
## **User description**
Final tail cleanup of remaining Codacy findings. 🤖

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Final cleanup of Codacy findings to reduce CI noise without changing behavior. Fixes Semgrep implicit string concatenation and silences targeted false-positive `pylint(no-member)` checks.

- **Bug Fixes**
  - `_codacy_zero_impl.py`: Wrapped string building in parentheses inside the findings list to avoid implicit concatenation flagged by Semgrep.
  - `service_restore.py`: Added per-line `# pylint: disable=no-member` for `Path.write_text` where PyLint mis-infers `PurePath`.
  - `tests/test_gui_dialogs_coverage.py`: Added per-line `# pylint: disable=no-member` for `selected_count_label.configure.assert_called()` on a `MagicMock` (PyLint can’t see mock attributes). Remaining R0801 duplicates are intentional in fixture blocks.

<sup>Written for commit c31e4ba6516932403b1a0c0678c31fcdb1653672. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Fix a few Codacy false positives in cleanup and test code

### What Changed
- Wrapped one Codacy error message in a single grouped string so it no longer triggers a Semgrep warning about implicit string concatenation
- Marked two mock and path-related test lines so PyLint no longer flags them as false errors
- Left the repeated `is_secret: False` fixture blocks unchanged because they are intentional copies across separate test cases

### Impact
`✅ Fewer false CI warnings`
`✅ Cleaner lint reports`
`✅ Less noise from intentional test setup`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=drzPVmSVh1imatjVXrViyjKQYItcNKrDgHJpVzA6eQA&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
