### PR TITLE
fix(qlty): reduce dialog builder arg counts under smell threshold

### DIFF
--- a/env_inspector_gui/dialogs.py
+++ b/env_inspector_gui/dialogs.py
@@ -22,6 +22,11 @@ class TargetPickerDialog:
         import tkinter as tk
         from tkinter import ttk
 
+        # Stash the tkinter modules on the instance so per-row builders can
+        # use them without inflating their own parameter counts (qlty smell
+        # threshold is 5 params; passing tk + ttk would push us over).
+        self._tk = tk
+        self._ttk = ttk
         self.result: List[str] | None = None
         self._targets = list(targets)
         self._vars: Dict[str, tk.BooleanVar] = {}
@@ -45,8 +50,8 @@ class TargetPickerDialog:
         ttk.Label(frame, text="Choose one or more targets for this operation:").pack(
             anchor="w", pady=(0, 8)
         )
-        self._build_search_row(frame, tk, ttk)
-        self._build_preset_row(frame, ttk)
+        self._build_search_row(frame)
+        self._build_preset_row(frame)
 
         canvas = tk.Canvas(frame, highlightthickness=0)
         scroll = ttk.Scrollbar(frame, orient="vertical", command=canvas.yview)
@@ -59,9 +64,7 @@ class TargetPickerDialog:
 
         canvas.pack(side="left", fill="both", expand=True)
         scroll.pack(side="right", fill="y")
-        self._build_target_checks(
-            body, selected_set, has_selected=selected is not None, tk=tk, ttk=ttk
-        )
+        self._build_target_checks(body, selected_set, has_selected=selected is not None)
 
         self.selected_count_label = ttk.Label(frame, text="")
         self.selected_count_label.pack(anchor="w", pady=(8, 0))
@@ -76,8 +79,10 @@ class TargetPickerDialog:
         # the Coverage 100 Gate would treat as a partial branch).
         cast(Any, self.search_entry).focus_set()
 
-    def _build_search_row(self, frame: Any, tk: Any, ttk: Any) -> None:
+    def _build_search_row(self, frame: Any) -> None:
         """Build search row."""
+        ttk = self._ttk
+        tk = self._tk
         search_row = ttk.Frame(frame)
         search_row.pack(fill="x", pady=(0, 8))
         ttk.Label(search_row, text="Search:").pack(side="left")
@@ -86,8 +91,9 @@ class TargetPickerDialog:
         self.search_entry.pack(side="left", fill="x", expand=True, padx=(6, 0))
         self.search_entry.bind("<KeyRelease>", self._on_search_keyrelease)
 
-    def _build_preset_row(self, frame: Any, ttk: Any) -> None:
+    def _build_preset_row(self, frame: Any) -> None:
         """Build preset row."""
+        ttk = self._ttk
         preset_row = ttk.Frame(frame)
         preset_row.pack(fill="x", pady=(0, 8))
         ttk.Button(preset_row, text="Select All", command=self._select_all).pack(
@@ -112,10 +118,10 @@ class TargetPickerDialog:
         selected_set: Set[str],
         *,
         has_selected: bool,
-        tk: Any,
-        ttk: Any,
     ) -> None:
         """Build target checks."""
+        tk = self._tk
+        ttk = self._ttk
         for target in self._targets:
             default = target in selected_set if has_selected else True
             var = tk.BooleanVar(value=default)


### PR DESCRIPTION
## **User description**
🤖

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce parameter counts in dialog builder helpers to satisfy QLTY’s smell threshold without changing behavior. `tk`/`ttk` are now stored on the instance and used internally.

- **Refactors**
  - Store `tk` and `ttk` as `self._tk` and `self._ttk`, removing them from helper method signatures.
  - Update `_build_search_row`, `_build_preset_row`, and `_build_target_checks` to pull from `self`, bringing arg counts to 2, 2, and 4.

<sup>Written for commit c17b777eebe00963afb97f6fe6d21e4093fa96e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Keep the target picker dialog behavior the same while reducing internal argument counts

### What Changed
- The target picker dialog now keeps its tkinter helpers on the dialog instance instead of passing them through each builder
- Search, preset buttons, and target checkboxes still work the same, but they are built with fewer parameters
- The dialog still opens with the same default selections, search box focus, and selection count updates

### Impact
`✅ No change to target selection behavior`
`✅ No change to search and preset button behavior`
`✅ Keeps the dialog compatible with quality checks`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=J-Bvup9YriMh943joJBbC3T8aHSyzJ_8lMI606UV54o&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
