### PR TITLE
fix: cover run_operation wrapper + clear W0613 regressions

### DIFF
--- a/tests/_gui_controller_fixtures.py
+++ b/tests/_gui_controller_fixtures.py
@@ -157,7 +157,8 @@ class _MockView:
     def clear_table() -> None:
         """Stub for testing."""
 
-    def insert_table_row(  # pylint: disable=no-self-use
+    # pylint: disable=no-self-use,unused-argument  # mirror view protocol
+    def insert_table_row(
         self, values: Tuple[Any, ...], *, striped: bool
     ) -> str:
         """Handle insert table row.

--- a/tests/test_gui_controller_operations_coverage.py
+++ b/tests/test_gui_controller_operations_coverage.py
@@ -128,6 +128,15 @@ def test_run_operation_no_key():
     ctrl.messagebox.showerror.assert_called_once()
 
 
+def test_public_run_operation_delegates_to_private():
+    """Public run_operation entry point delegates to _run_operation."""
+    ctrl = _Harness()
+    ctrl.key_text = _Var("")
+    ctrl.messagebox = MagicMock()
+    ctrl.run_operation("set")
+    ctrl.messagebox.showerror.assert_called_once()
+
+
 def test_run_operation_preview_fails():
     """Test run operation preview fails."""
     ctrl = _Harness()

--- a/tests/test_security_helpers.py
+++ b/tests/test_security_helpers.py
@@ -120,6 +120,7 @@ def test_request_json_https_http_error(monkeypatch):
         """Opener stub that always raises an HTTP error."""
 
         @staticmethod
+        # pylint: disable=unused-argument  # urllib calls open() with timeout kw
         def open(request, timeout=0):  # noqa: ARG004 - urllib calls with this kw
             """Raise a deterministic HTTP error for the request."""
             # timeout intentionally unused — urllib calls open() with this kw


### PR DESCRIPTION
## **User description**
🤖

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Restore full test coverage and clear W0613 regressions by testing the `run_operation` public wrapper and documenting unused arguments in test stubs.

- **Bug Fixes**
  - Added `test_public_run_operation_delegates_to_private` to confirm `run_operation` delegates to `_run_operation` via the no-key path.
  - Added `# pylint: disable=unused-argument` to `insert_table_row` and `_FakeOpener.open()` to keep protocol-compatible signatures without dummy deletes.

<sup>Written for commit 7fd74870e7820446a217003d575024a5b725634c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Restore coverage for the public operation path and keep test stubs aligned with real calls

### What Changed
- Added a test that exercises the public operation entry point and confirms it follows the same missing-key error path as the underlying operation flow
- Kept test doubles compatible with real app calls while removing unused-argument lint warnings
- Updated the failing HTTP opener stub so it accepts the timeout argument used during requests

### Impact
`✅ Restored coverage for the public operation path`
`✅ Fewer lint failures in test code`
`✅ More stable GUI and security tests`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=ZJTRAPtreT6XielNwjhyxvAyF4ow4-MDLBBjxl9lZyI&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
