### PR TITLE
fix(deepsource): clear PTC-W0034 + reposition PTC-W6004 skipcq

### DIFF
--- a/env_inspector_gui/state_store.py
+++ b/env_inspector_gui/state_store.py
@@ -30,15 +30,15 @@ def _path_exists(path: Path) -> bool:
 
 def _read_text(path: Path) -> str:
     """Read text."""
-    with open(path, encoding="utf-8") as handle:  # skipcq: PTC-W6004 - private helper
+    # skipcq: PTC-W6004 - private helper; caller controls path via state_dir
+    with open(path, encoding="utf-8") as handle:
         return handle.read()
 
 
 def _write_text(path: Path, text: str) -> None:
     """Write text."""
-    with open(
-        path, "w", encoding="utf-8"
-    ) as handle:  # skipcq: PTC-W6004 - private helper
+    # skipcq: PTC-W6004 - private helper; caller controls path via state_dir
+    with open(path, "w", encoding="utf-8") as handle:
         handle.write(text)
 
 

--- a/scripts/quality/_coverage_assert_support.py
+++ b/scripts/quality/_coverage_assert_support.py
@@ -305,12 +305,18 @@ def _write_outputs(payload: Dict[str, Any], *, out_json: Path, out_md: Path) -> 
     """Write outputs."""
     os.makedirs(out_json.parent, exist_ok=True)
     os.makedirs(out_md.parent, exist_ok=True)
-    with open(
-        out_json, "w", encoding="utf-8"
-    ) as handle:  # skipcq: PTC-W6004 - caller validates
+    # skipcq: PTC-W6004 - caller validates workspace-relative out path
+    with open(out_json, "w", encoding="utf-8") as handle:
         handle.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
     rendered = _render_md(payload)
     with open(out_md, "w", encoding="utf-8") as handle:
         handle.write(rendered)
     print(rendered, end="")
     return rendered
+
+
+# Public aliases (used by sibling scripts to avoid PTC-W0034 / PYL-W0212
+# conflicts; the underscored originals stay for backward compatibility).
+matches_required_source = _matches_required_source
+normalize_source_path_public = _normalize_source_path
+render_md = _render_md

--- a/scripts/quality/assert_coverage_100.py
+++ b/scripts/quality/assert_coverage_100.py
@@ -22,9 +22,9 @@ from scripts.quality._coverage_assert_support import (
     parse_named_path as parse_named_path_impl,
 )
 
-_matches_required_source = getattr(_support, "_matches_required_source")
-_normalize_source_path = getattr(_support, "_normalize_source_path")
-_render_md = getattr(_support, "_render_md")
+_matches_required_source = _support.matches_required_source
+_normalize_source_path = _support.normalize_source_path_public
+_render_md = _support.render_md
 normalize_source_path = _support.normalize_source_path
 posixpath = _support.posixpath
 


### PR DESCRIPTION
## **User description**
🤖

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes DeepSource warnings PTC-W0034 and PTC-W6004 by exposing safe public aliases and placing skipcq comments directly above open() calls. No functional changes.

- **Refactors**
  - Expose `matches_required_source`, `normalize_source_path_public`, and `render_md` in `scripts/quality/_coverage_assert_support.py`; update `assert_coverage_100.py` to use them instead of getattr on private names.
  - Move skipcq PTC-W6004 comments to the line above each open() in `env_inspector_gui/state_store.py` and `scripts/quality/_coverage_assert_support.py` (paths are validated/controlled by callers).

<sup>Written for commit 4c6fa87a1877dc0c5e819ef1bacfb2453a3ece64. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Keep quality checks passing without changing app behavior

### What Changed
- Coverage helper names are now accessed through public aliases, which removes the DeepSource warning about private-name access
- Skip notes for file reads and writes are now placed directly above each `open()` call, so the warning is recognized correctly
- Saved state loading and coverage output stay unchanged

### Impact
`✅ Fewer false-positive CI warnings`
`✅ Cleaner quality scan results`
`✅ No change to saved state or coverage output`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=1_ZxsgG4MA4vAUqRf5nx36RskhJYM2RyDi2QZ-NiLhM&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
