### PR TITLE
fix(codacy): disable R0801 (duplicate-code) FP on module docstrings

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -6,10 +6,20 @@ py-version = 3.12
 # / PEP 585 idiom; disable only those specific false-positive rules.
 # Real findings still surface — this is rule configuration, not a file/issue
 # exclusion.
+#
+# R0801 (duplicate-code/similar-lines) flags single-line module docstrings as
+# "Similar lines in 2 files" because every module's first line follows the
+# pattern ``"""<Name> module."""`` — Pylint's similarity detector sees the
+# pattern as duplication. Raising ``min-similarity-lines`` would help most
+# repos, but Codacy's hosted Pylint runs without our [SIMILARITIES] override,
+# so disabling R0801 is the only reliable fix. Real cross-file duplication is
+# already covered by qlty's duplicate-code rule + Codacy's own duplication
+# percentage metric.
 disable =
     E0611,
     E1136,
     R0201,
+    R0801,
     R0903,
     W0104,
     W0212,


### PR DESCRIPTION
## **User description**
Codacy's PyLintPython3 reports 5 R0801 "Similar lines in 2 files" findings on every module-level docstring (`"""<Name> module."""` pattern) — the documented R0801 false-positive shape (short identical lines tripping the duplication detector).

Affected files (per Codacy issue list at commit `a0801c3`):
- `env_inspector_gui/__init__.py:1`
- `env_inspector_gui/dialogs.py:1`
- `env_inspector_gui/secret_policy.py:1`
- `tests/conftest.py:1`
- `tests/test_quality_http_builders.py:1`

Real cross-file duplication is already covered by qlty's duplicate-code rule + Codacy's own duplication percentage metric, so disabling R0801 in Pylint specifically is a surgical fix.

Closes 5/5 open Codacy issues on env-inspector main.


___

## **CodeAnt-AI Description**
**Stop Codacy from flagging module docstrings as duplicate code**

### What Changed
- Disabled the duplicate-code warning that was incorrectly firing on one-line module docstrings
- Kept the rest of the code-quality checks active, so real duplication issues still show up

### Impact
`✅ Fewer false Codacy alerts`
`✅ Cleaner code-review signal`
`✅ Less noise from module docstrings`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=O0IlC5oXHV14TytL8xjHJFNHyumQG71_TCUWNKsQEZo&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disabled `pylint` R0801 (duplicate-code) to stop false positives from one-line module docstrings in Codacy. This reduces noise in quality checks while real duplication remains covered by `qlty` and Codacy’s duplication metric.

<sup>Written for commit e346835a05b27c6eb6f771a112e78f81aaa67cda. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

