### PR TITLE
fix(codacy): reorder imports — keep import_module() after all imports

### DIFF
--- a/reports/sentry.md
+++ b/reports/sentry.md
@@ -1,0 +1,14 @@
+# Sentry Zero Gate
+
+- Status: `pass`
+- Mode: `skipped`
+- Org: ``
+- Timestamp (UTC): `2026-04-27T07:42:18.952014+00:00`
+
+## Project results
+- None
+
+## Findings
+- SENTRY_AUTH_TOKEN is missing.
+- SENTRY_ORG is missing.
+- No Sentry projects configured (SENTRY_PROJECT_BACKEND/SENTRY_PROJECT_WEB).

--- a/tests/test_backup_and_audit.py
+++ b/tests/test_backup_and_audit.py
@@ -7,11 +7,12 @@ from pathlib import Path
 import pytest
 
 from importlib import import_module
-storage_mod = import_module('env_inspector_core.storage')
 from env_inspector_core.models import OperationResult
 from env_inspector_core.service import EnvInspectorService
 from env_inspector_core.storage import AuditLogger, BackupManager
 from tests.assertions import ensure
+
+storage_mod = import_module('env_inspector_core.storage')
 
 
 def test_backup_manager_retention_and_restore(tmp_path: Path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,8 +6,9 @@ import unittest
 from typing import Dict, List, cast
 
 from importlib import import_module
-cli_mod = import_module('env_inspector_core.cli')
 from env_inspector_core.cli import build_parser, run_cli
+
+cli_mod = import_module('env_inspector_core.cli')
 
 RecordRow = Dict[str, object]
 ServiceCall = Dict[str, object]

--- a/tests/test_linux_support.py
+++ b/tests/test_linux_support.py
@@ -6,11 +6,12 @@ from typing import List
 import pytest
 
 from importlib import import_module
-service_module = import_module('env_inspector_core.service')
 from env_inspector_core.models import EnvRecord
 from env_inspector_core.providers import collect_dotenv_records, collect_linux_records
 from env_inspector_core.service import EnvInspectorService
 from tests.assertions import ensure
+
+service_module = import_module('env_inspector_core.service')
 
 _ORIGINAL_PATH_EXISTS = service_module._path_exists
 _ORIGINAL_READ_TEXT_IF_EXISTS = service_module._read_text_if_exists

--- a/tests/test_pr39_owned_coverage.py
+++ b/tests/test_pr39_owned_coverage.py
@@ -10,9 +10,6 @@ import pytest
 
 from importlib import import_module
 import env_inspector
-cli_module = import_module('env_inspector_core.cli')
-service_module = import_module('env_inspector_core.service')
-service_listing_module = import_module('env_inspector_core.service_listing')
 import env_inspector_core.service_privileged as service_privileged_module
 from env_inspector_core.models import EnvRecord, OperationResult
 from env_inspector_core.path_policy import PathPolicyError
@@ -20,6 +17,10 @@ from env_inspector_core.service import EnvInspectorService
 from env_inspector_core.service_ops import OperationResultInput, operation_result
 from scripts.quality import assert_coverage_100 as coverage_mod
 from tests.assertions import ensure
+
+cli_module = import_module('env_inspector_core.cli')
+service_module = import_module('env_inspector_core.service')
+service_listing_module = import_module('env_inspector_core.service_listing')
 
 
 def _record(

--- a/tests/test_pr54_coverage_branches.py
+++ b/tests/test_pr54_coverage_branches.py
@@ -7,14 +7,16 @@ from typing import List
 import pytest
 
 from importlib import import_module
-service_module = import_module('env_inspector_core.service')
-service_listing_module = import_module('env_inspector_core.service_listing')
-service_privileged_module = import_module('env_inspector_core.service_privileged')
-service_restore_module = import_module('env_inspector_core.service_restore')
+
 from env_inspector_core.constants import SOURCE_DOTENV
 from env_inspector_core.service import EnvInspectorService
 from scripts.quality import check_sentry_zero as sentry_mod
 from tests.assertions import ensure
+
+service_module = import_module('env_inspector_core.service')
+service_listing_module = import_module('env_inspector_core.service_listing')
+service_privileged_module = import_module('env_inspector_core.service_privileged')
+service_restore_module = import_module('env_inspector_core.service_restore')
 
 
 def test_list_records_rejects_request_and_kwargs(tmp_path: Path) -> None:

--- a/tests/test_service_coverage_branches.py
+++ b/tests/test_service_coverage_branches.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Tuple
 import pytest
 
 from importlib import import_module
-service_module = import_module('env_inspector_core.service')
+
 from env_inspector_core.constants import (
     SOURCE_DOTENV,
     SOURCE_LINUX_BASHRC,
@@ -19,6 +19,8 @@ from env_inspector_core.constants import (
 from env_inspector_core.models import EnvRecord
 from env_inspector_core.service import EnvInspectorService
 from tests.assertions import ensure
+
+service_module = import_module('env_inspector_core.service')
 
 
 def _record(

--- a/tests/test_service_path_guards.py
+++ b/tests/test_service_path_guards.py
@@ -6,10 +6,11 @@ from typing import Dict, List, Tuple
 import pytest
 
 from importlib import import_module
-service_module = import_module('env_inspector_core.service')
-service_paths_module = import_module('env_inspector_core.service_paths')
 from env_inspector_core.service import EnvInspectorService
 from tests.assertions import ensure
+
+service_module = import_module('env_inspector_core.service')
+service_paths_module = import_module('env_inspector_core.service_paths')
 
 
 def test_is_path_within_returns_false_for_unrelated_roots(tmp_path: Path):

--- a/tests/test_service_preview.py
+++ b/tests/test_service_preview.py
@@ -5,9 +5,10 @@ from pathlib import Path
 import pytest
 
 from importlib import import_module
-service_module = import_module('env_inspector_core.service')
 from env_inspector_core.service import EnvInspectorService
 from tests.assertions import ensure
+
+service_module = import_module('env_inspector_core.service')
 
 _ORIGINAL_PATH_EXISTS = service_module._path_exists
 _ORIGINAL_READ_TEXT_IF_EXISTS = service_module._read_text_if_exists


### PR DESCRIPTION
## **User description**
PR #97 introduced `from importlib import import_module` followed by `xxx = import_module('y')` calls, which Codacy's PyLintPython3 + Ruff E402 flag as 58 "import not at top of file" issues because the `import_module(...)` assignment statements appeared between import statements.

Reorder in 8 test files: all imports first, then assignments at module-top.

Verified: 566 tests pass. Closes ~58 of 63 Codacy issues.


___

## **CodeAnt-AI Description**
**Reorder test file imports so checks pass cleanly**

### What Changed
- Moved `import_module()` assignments to after all import lines in several test files so import-order checks no longer flag them
- Kept test coverage unchanged while avoiding import-position warnings in Codacy and Ruff
- Added a Sentry gate report showing the check passed, with missing configuration noted as skipped

### Impact
`✅ Fewer import-order warnings`
`✅ Cleaner Codacy results`
`✅ Easier test maintenance`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=s-ew4z9FPDDRCO5AhHIvM4JsN_RNLexOHgX-dM3HYgo&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reordered `import_module()` assignments to come after all imports in 8 test files to satisfy `ruff` E402 and `pylint` import-at-top rules. Resolves ~58 `Codacy` “import not at top of file” warnings; all 566 tests pass.

<sup>Written for commit 73aecf3398099727f7e761302adfe20a24d1658a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

