### PR TITLE
fix(sonar): add explicit SonarCloud scan workflow

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,41 @@
+name: SonarCloud Scan
+
+permissions:
+  contents: read
+  pull-requests: read
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  sonarcloud:
+    name: SonarCloud Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          # Shallow clones disable Sonar's blame information; fetch full history.
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install test deps and run with coverage
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest pytest-cov
+          pytest -q --cov=env_inspector --cov=env_inspector_core --cov=env_inspector_gui \
+            --cov-branch --cov-report=xml:coverage.xml || true
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@v5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,11 @@
+sonar.organization=prekzursil
+sonar.projectKey=Prekzursil_env-inspector
+sonar.projectName=env-inspector
+
+sonar.sources=env_inspector_core,env_inspector_gui,env_inspector.py,scripts
+sonar.tests=tests
+
+sonar.exclusions=**/__pycache__/**,**/*.pyc,build/**,dist/**,htmlcov/**,coverage_platform/**,.tmp_platform/**,.venv/**,**/node_modules/**
+
+sonar.python.version=3.12
+sonar.python.coverage.reportPaths=coverage.xml


### PR DESCRIPTION
## **User description**
## Problem
env-inspector main keeps failing the platform's `Sonar Zero` gate because SonarCloud's auto-analysis is stuck on SHA `ca15a4059f60` (4 days old). The platform's `check_sonar_zero.py` script polls Sonar for an analysis on the current main HEAD and times out when no fresh analysis exists.

Sonar reports 0 issues / qualityGateStatus=OK on the older SHA — the code is clean, Sonar just hasn't re-scanned.

## Fix
Add an explicit `SonarCloud Scan` workflow that runs on push to main + PRs, replacing the unreliable auto-analysis with explicit CI-driven scans pointing at the new `sonar-project.properties` (python source/test paths + coverage upload).

## After this lands
Every push to main produces a fresh Sonar analysis on the current SHA, and the `Sonar Zero` gate sees a fresh analysis instead of the stale 4-day-old one.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an explicit SonarCloud scan workflow for pushes to main and PRs to replace unreliable auto-analysis. This ensures fresh analysis per commit and unblocks the platform’s Sonar Zero gate.

- **Bug Fixes**
  - Added `.github/workflows/sonar.yml` to run scans on push, PR, and manual dispatch.
  - Run tests with Python 3.12 using `pytest` + `pytest-cov` to generate `coverage.xml` for Sonar.
  - Use full-depth checkout to keep blame info; authenticate with `SONAR_TOKEN`.
  - Added `sonar-project.properties` with sources, tests, exclusions, Python version, and coverage report path.

<sup>Written for commit a34c1a941b4af4f48da5e31dd4e9bca11c3cd30a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Run fresh SonarCloud scans on main and pull requests**

### What Changed
- SonarCloud now runs automatically on pushes to `main`, pull requests, and manual runs.
- Each scan uses full repository history so code ownership and change tracking work correctly.
- Tests run with coverage before the scan, and the coverage report is included in SonarCloud results.
- The scan now uses a project config that defines the source files, tests, exclusions, and Python version.

### Impact
`✅ Fresh Sonar results on every main push`
`✅ Fewer Sonar Zero gate timeouts`
`✅ Clearer code-quality reporting on pull requests`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=3yUh14LDn005LfZn4oPthR_RWPfhm_h_3SXf-EXD0KE&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
