### PR TITLE
fix(codacy): pin SonarSource action to SHA + nosemgrep FP

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -36,6 +36,14 @@ jobs:
             --cov-branch --cov-report=xml:coverage.xml || true
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v5
+        # The 40-hex value after @ is the SonarSource sonarqube-scan-action's
+        # git commit SHA (required by Codacy's
+        # third-party-action-not-pinned-to-commit-sha rule). Semgrep's
+        # secrets.sonarqube-docs-api-key rule matches the same 40-hex shape
+        # and flags this as a hardcoded API key — that's a false positive
+        # because git commit SHAs and SonarQube API keys share the same
+        # 40-hex shape but only one of those (the API key) carries
+        # credential value.
+        uses: SonarSource/sonarqube-scan-action@2f77a1ec69fb1d595b06f35ab27e97605bdef703  # v5  # nosemgrep
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## **User description**
After PR #100 added the SonarCloud workflow with @v5 tag pin, env-inspector main fails Codacy Zero with 1 issue: third-party-action-not-pinned-to-commit-sha. Pin to the v5 commit SHA + add inline nosemgrep for the docs-api-key false positive.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Codacy Zero failure by pinning `SonarSource/sonarqube-scan-action` to the v5 commit SHA and adding a `nosemgrep` suppression for a false positive on the SHA.

- **Bug Fixes**
  - Pin `SonarSource/sonarqube-scan-action` to a commit SHA to satisfy `third-party-action-not-pinned-to-commit-sha`.
  - Add inline `# nosemgrep` with a brief note to suppress `secrets.sonarqube-docs-api-key` false positive (SHA shape, not a credential).

<sup>Written for commit 4157998df84ce9187170d52e9850193c157451e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Pin the SonarCloud scan action in the workflow and avoid a false secret warning**

### What Changed
- The SonarCloud scan workflow now uses a fixed commit reference instead of a moving version tag
- A note was added to explain that the pinned value is a commit SHA, not a secret, so the workflow no longer triggers a false API key warning

### Impact
`✅ Fewer Codacy workflow failures`
`✅ Safer dependency pinning`
`✅ Fewer false secret alerts in CI`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=UEiszAo5E4Qn6pDYozcvxOLbTW56MiKSoSiZnjtEWnQ&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
