### PR TITLE
fix(sonar): exclude vendored platform scripts from coverage denominator

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,5 +7,14 @@ sonar.tests=tests
 
 sonar.exclusions=**/__pycache__/**,**/*.pyc,build/**,dist/**,htmlcov/**,coverage_platform/**,.tmp_platform/**,.venv/**,**/node_modules/**
 
+# Coverage scope exclusions: vendored platform scripts under scripts/quality/**
+# are owned by Prekzursil/quality-zero-platform and tested there. env-inspector
+# COPIES the files via the platform's bootstrap workflow but does not author or
+# test them. Including them in env-inspector's coverage denominator at 0% line
+# coverage drags new_coverage down for changes that don't touch them. We still
+# scan them for quality issues — this only excludes them from the coverage
+# percentage calculation. (Same pattern Prekzursil/event-link uses.)
+sonar.coverage.exclusions=scripts/__init__.py,scripts/quality/**,scripts/security_helpers.py
+
 sonar.python.version=3.12
 sonar.python.coverage.reportPaths=coverage.xml


### PR DESCRIPTION
## **User description**
After PR #100 + #102 unblocked the Sonar Zero gate, env-inspector main now fails the SonarCloud Code Analysis quality gate on new_coverage=67.3% (threshold 80%).

Root cause: `sonar.sources` includes `scripts/` which contains 1547 lines of vendored platform scripts (`_codacy_zero_impl.py` +128 uncovered, `_codacy_zero_support.py` +86, `_coverage_assert_support.py` +160, `_required_checks_http.py` +110, …). env-inspector COPIES these via the platform bootstrap but does not author or test them.

Fix: add `sonar.coverage.exclusions` for `scripts/quality/**` + 2 helper files. The files are still scanned for quality issues — this only removes them from the coverage percentage denominator.

Same pattern `Prekzursil/event-link` uses (PR #134, project memory).


___

## **CodeAnt-AI Description**
Keep Sonar coverage from counting vendored platform scripts

### What Changed
- Excludes vendored scripts under `scripts/quality/` from the coverage percentage, so they no longer pull down the reported coverage for env-inspector changes
- Also excludes two helper files from the coverage denominator while still leaving these files in quality scans

### Impact
`✅ More accurate Sonar coverage results`
`✅ Fewer false coverage drops`
`✅ Less risk of Sonar gate failures on unrelated changes`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=VULsNmZb7NCCAJ2oPZWRyoyw7oC8GSyK1KRhd7b3k7o&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude vendored platform scripts from the Sonar coverage denominator to prevent false coverage drops and quality gate failures. These files are still analyzed for issues; this only adjusts coverage scope.

- **Bug Fixes**
  - Set `sonar.coverage.exclusions` to `scripts/quality/**`, `scripts/__init__.py`, and `scripts/security_helpers.py`.
  - Left `sonar.sources` and `sonar.exclusions` unchanged so quality issues on these files are still reported.

<sup>Written for commit cea4641a809b7e0b67e4c783de35bbc803f5c8d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

