### PR TITLE
fix(sonar): produce repo-relative coverage.xml so Sonar applies coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,36 @@
+# Coverage configuration for env-inspector.
+#
+# Drives ``--cov=.`` to produce repo-relative filenames in
+# ``coverage.xml`` so SonarCloud's Cobertura sensor can match them
+# against indexed source files. Without this, pytest-cov's per-package
+# ``--cov=env_inspector --cov=env_inspector_core`` style emits multiple
+# ``<source>`` roots that Sonar can't disambiguate, so coverage applies
+# to nothing and the project shows ``line_coverage=0%`` even when
+# Codecov reports 100%.
+[run]
+source = .
+omit =
+    tests/*
+    .venv/*
+    build/*
+    dist/*
+    htmlcov/*
+    .tmp_platform/*
+    coverage_platform/*
+    setup.py
+    conftest.py
+    scripts/__init__.py
+    scripts/security_helpers.py
+    scripts/quality/*
+relative_files = True
+
+[report]
+# Exclude unreachable / type-checker-only lines from the denominator
+# so coverage reflects actual runtime behaviour.
+exclude_lines =
+    pragma: no cover
+    raise NotImplementedError
+    if __name__ == .__main__.:
+    if TYPE_CHECKING:
+    if typing.TYPE_CHECKING:
+    \.\.\. *$

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -32,8 +32,16 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install pytest pytest-cov
-          pytest -q --cov=env_inspector --cov=env_inspector_core --cov=env_inspector_gui \
-            --cov-branch --cov-report=xml:coverage.xml || true
+          # Use ``--cov=.`` (repo root) so coverage.xml has a single
+          # ``<source>`` element that SonarCloud's Cobertura sensor can
+          # use to map ``<class filename>`` paths back to indexed files.
+          # Coverage scope (which files count) is governed by
+          # ``.coveragerc`` (omits tests/, scripts/quality/**, etc).
+          # The previous per-package style (``--cov=env_inspector ...``)
+          # produced multiple ``<source>`` roots that Sonar couldn't
+          # disambiguate, so coverage applied to nothing and the
+          # project showed ``line_coverage=0%``.
+          pytest -q --cov=. --cov-branch --cov-report=xml:coverage.xml || true
 
       - name: SonarCloud Scan
         # The 40-hex value after @ is the SonarSource sonarqube-scan-action's


### PR DESCRIPTION
## **User description**
## Summary

SonarCloud reports \`line_coverage=0%\` on env-inspector main despite Codecov showing 100%.

## Root cause

\`pytest-cov\`'s per-package coverage style (\`--cov=env_inspector --cov=env_inspector_core --cov=env_inspector_gui\`) emits a \`coverage.xml\` with three \`<source>\` roots and \`<class filename>\` values relative to one of those roots. Sonar's Cobertura sensor can't disambiguate which root each filename belongs to, so it fails to match any indexed source file. The \"Zero Coverage Sensor\" then marks all 9,938 lines as 0%.

## Fix

1. New \`.coveragerc\` with \`relative_files = True\` and \`source = .\` (the repo root). Coverage scope governed by \`omit\` patterns matching the existing Sonar exclusions (\`tests/\`, \`scripts/quality/**\`, etc) plus \`[report] exclude_lines\` for \`if TYPE_CHECKING:\` / \`...\` placeholders.

2. \`sonar.yml\` invokes \`pytest --cov=. --cov-branch --cov-report=xml\` so the resulting \`coverage.xml\` has a single \`<source>\` element and \`<class filename>\` paths Sonar can resolve 1:1 against indexed files.

## Local verification

\`\`\`
$ pytest -q --cov=. --cov-report=xml:coverage.xml
566 passed
$ python -c \"import xml.etree.ElementTree as ET; r=ET.parse('coverage.xml').getroot(); print(f'lines={r.get(\\\"lines-valid\\\")} covered={r.get(\\\"lines-covered\\\")} rate={r.get(\\\"line-rate\\\")}')\"
lines=3074 covered=3074 rate=1
\`\`\`

100% local. After merge, SonarCloud main analysis should show \`line_coverage=100.0%\`.

## Test plan

- [x] \`.coveragerc\` produces single \`<source>\` element, repo-relative \`filename\` paths
- [x] Local pytest --cov=. → 100% with omits applied
- [ ] CI confirms Sonar Zero gate stays green and Sonar reanalysis bumps line_coverage 0%→100%

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SonarCloud showing 0% coverage by generating a repo-rooted `coverage.xml` that maps to indexed files. Adds `.coveragerc` and updates CI to run `pytest --cov=.` so Sonar applies coverage correctly.

- **Bug Fixes**
  - Added `.coveragerc` with `source=.`, `relative_files=True`, and `omit`/`exclude_lines` aligned with existing Sonar exclusions.
  - Updated `.github/workflows/sonar.yml` to run `pytest --cov=. --cov-branch --cov-report=xml:coverage.xml`, producing a single `<source>` root with repo-relative paths.
  - Outcome: SonarCloud should reflect real coverage (~100%) instead of 0%.

<sup>Written for commit 629dedb995d47b32aa1dc9463f0b5e83fa567de9. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/env-inspector/pull/105?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Make SonarCloud pick up coverage from the test run**

### What Changed
- Coverage reports now use repo-relative file paths, so SonarCloud can match them to the right source files and stop showing 0% coverage
- The Sonar workflow now runs coverage from the repository root instead of combining separate package paths
- Lines that only exist for type checking or unreachable placeholders are excluded from coverage counts

### Impact
`✅ SonarCloud shows real coverage instead of 0%`
`✅ Fewer false zero-coverage reports in CI`
`✅ More accurate coverage numbers for runtime code`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=gpeXt44yo2j2Q07nKMOwGqeReaGnbUgzYhy6qPWw4js&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
