### PR TITLE
fix(sonar): patch coverage.xml <sources> to single absolute repo root

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -43,6 +43,30 @@ jobs:
           # project showed ``line_coverage=0%``.
           pytest -q --cov=. --cov-branch --cov-report=xml:coverage.xml || true
 
+          # Post-process coverage.xml: ``relative_files = True`` produces
+          # multiple empty ``<source>`` elements which Sonar's Cobertura
+          # sensor can't resolve against indexed source files. Replace
+          # with a single ``<source>`` pointing at the project root so
+          # ``<class filename>`` lookup works.
+          if [ -f coverage.xml ]; then
+            python - <<'PY'
+          import xml.etree.ElementTree as ET
+          import os
+
+          tree = ET.parse('coverage.xml')
+          root = tree.getroot()
+          sources = root.find('sources')
+          if sources is not None:
+              for src in list(sources):
+                  sources.remove(src)
+              new_src = ET.SubElement(sources, 'source')
+              new_src.text = os.getcwd()
+          tree.write('coverage.xml', xml_declaration=True, encoding='utf-8')
+          print('Patched <sources> to single absolute repo root.')
+          PY
+            head -8 coverage.xml
+          fi
+
       - name: SonarCloud Scan
         # The 40-hex value after @ is the SonarSource sonarqube-scan-action's
         # git commit SHA (required by Codacy's


### PR DESCRIPTION
## **User description**
## Summary

Despite \`--cov=.\` and \`relative_files = True\` in \`.coveragerc\` (PR #105), \`coverage.py\` v7 emits two empty \`<source>\` elements:

\`\`\`xml
<sources>
  <source></source>
  <source>.</source>
</sources>
\`\`\`

Sonar's Cobertura sensor parses the file in 180ms but can't resolve \`<class filename>\` paths against any indexed source file because the \`<source>\` value is empty. The \"Zero Coverage Sensor\" then marks all 9,938 lines as 0% covered.

## Fix

Post-process \`coverage.xml\` after pytest writes it: clear the empty \`<source>\` elements and add a single one pointing at \`\$PWD\` (the GitHub workspace). Sonar's parser then maps \`env_inspector_core/cli.py\` to \`\$PWD/env_inspector_core/cli.py\` which it has already indexed.

## Test plan

- [x] Local repro: pytest --cov=. emits empty `<source>` elements
- [ ] CI runs Python post-processor and emits a single absolute `<source>` element
- [ ] After merge, SonarCloud main analysis shows `line_coverage=100.0%`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Patch `coverage.xml` in CI to set a single absolute <source> at the repo root so Sonar can resolve file paths. Fixes SonarCloud showing 0% coverage by restoring accurate line coverage.

- **Bug Fixes**
  - Update `.github/workflows/sonar.yml` to run a Python step after `pytest --cov` that removes empty `<source>` entries and adds one pointing to `$PWD`.
  - Ensures Sonar’s Cobertura sensor maps `<class filename>` correctly and computes real coverage.

<sup>Written for commit e323516121d2973e9a55460461e4bfbba7d8f614. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/env-inspector/pull/106?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Fix Sonar coverage reporting by normalizing coverage paths**

### What Changed
- After test coverage is generated, the workflow now rewrites `coverage.xml` to remove empty source entries and keep one source pointing to the repository root.
- This lets SonarCloud match covered files to the code it scanned, instead of treating coverage as unresolved.
- The workflow also prints a small preview of the updated coverage file for easier checks during CI.

### Impact
`✅ Accurate Sonar coverage`
`✅ Fewer false 0% coverage reports`
`✅ Clearer CI coverage checks`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=GV5CSpB3ODjYqUiDxgHmQuekyVA3DxBP7c474TusA4U&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
