### PR TITLE
fix(cobertura): extract _parse_condition_coverage helper to drop PyLint R0914

### DIFF
--- a/scripts/cobertura_to_sonar_generic.py
+++ b/scripts/cobertura_to_sonar_generic.py
@@ -57,11 +57,19 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def _parse_condition_coverage(condition_coverage: str) -> tuple[int, int]:
+    """Parse Cobertura ``condition-coverage`` like ``"50% (1/2)"`` → (covered, total)."""
+    if "(" not in condition_coverage:
+        return (0, 0)
+    fraction = condition_coverage.split("(")[1].rstrip(")")
+    covered_str, total_str = fraction.split("/")
+    return (int(covered_str), int(total_str))
+
+
 def collect_lines(in_path: Path) -> dict[str, dict[int, tuple[int, int, int]]]:
     """Parse cobertura XML, return per-file/line (hits, branches, covered)."""
     by_file: dict[str, dict[int, tuple[int, int, int]]] = defaultdict(dict)
-    tree = ET.parse(str(in_path))
-    root = tree.getroot()
+    root = ET.parse(str(in_path)).getroot()
     for cls in root.iter("class"):
         filename = cls.get("filename", "")
         if not filename:
@@ -69,17 +77,12 @@ def collect_lines(in_path: Path) -> dict[str, dict[int, tuple[int, int, int]]]:
         for line in cls.iter("line"):
             number = int(line.get("number", 0))
             hits = int(line.get("hits", 0))
-            branch = line.get("branch", "false") == "true"
-            condition_coverage = line.get("condition-coverage", "")
-            if branch and "(" in condition_coverage:
-                # e.g. "50% (1/2)"
-                fraction = condition_coverage.split("(")[1].rstrip(")")
-                covered, total = fraction.split("/")
-                branches_to_cover = int(total)
-                covered_branches = int(covered)
-            else:
-                branches_to_cover = 0
-                covered_branches = 0
+            is_branch = line.get("branch", "false") == "true"
+            covered_branches, branches_to_cover = (
+                _parse_condition_coverage(line.get("condition-coverage", ""))
+                if is_branch
+                else (0, 0)
+            )
             by_file[filename][number] = (hits, branches_to_cover, covered_branches)
     return by_file
 

--- a/tests/test_cobertura_to_sonar_generic.py
+++ b/tests/test_cobertura_to_sonar_generic.py
@@ -61,6 +61,16 @@ def test_collect_lines_parses_hits_and_branches(tmp_path: Path) -> None:
     assert rows[3] == (2, 2, 1)
 
 
+def test_parse_condition_coverage_returns_zeros_when_no_paren() -> None:
+    """``_parse_condition_coverage`` short-circuits to (0, 0) on malformed input."""
+    module = _load_module()
+    # Empty string and any input lacking '(' both fall to the (0, 0) early
+    # return — exercising the branch that complementary fixture data
+    # (which always passes well-formed condition-coverage) doesn't reach.
+    assert module._parse_condition_coverage("") == (0, 0)
+    assert module._parse_condition_coverage("100%") == (0, 0)
+
+
 def test_emit_xml_round_trips_through_converter(tmp_path: Path) -> None:
     """``emit_xml`` produces Sonar Generic XML with line + branch attrs."""
     module = _load_module()


### PR DESCRIPTION
## **User description**
## Summary

Last lingering Codacy issue on env-inspector main:
- `PyLintPython3_R0914` — `collect_lines()` has 16 local variables (threshold 15).
- The other 7 stale findings are from `Pylint (deprecated)` engine that PR #108 already disabled in `.codacy.yml` — Codacy hasn't re-analyzed yet.

## Changes

- **`scripts/cobertura_to_sonar_generic.py`**: extract `_parse_condition_coverage` helper for parsing the Cobertura `condition-coverage` string ("50% (1/2)" → (covered, total)). Drops 4 locals from `collect_lines` (`fraction`, `covered`, `total`, `condition_coverage`). Also inlines `tree.getroot()` to drop the temporary `tree` variable.

`collect_lines` is now at 11/15 — well under threshold — with a unit-testable seam for the fraction parser.

## Verified locally

- All 5 `tests/test_cobertura_to_sonar_generic.py` tests pass.

## Test plan

- [ ] Codacy main reports 0 issues post-merge (after the deprecated-Pylint cache also refreshes)
- [ ] env-inspector main `shared-scanner-matrix / Codacy Zero` gate passes — last red gate on the repo

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes the PyLint “too many locals” warning in the Cobertura converter and adds a unit test for malformed branch coverage strings. Behavior is unchanged; all tests pass.

- **Refactors**
  - Extracted `_parse_condition_coverage` to parse "50% (1/2)", reducing `collect_lines` locals from 16 to 11 and clearing `PyLintPython3_R0914`.
  - Inlined `ET.parse(...).getroot()` and added a test for the early-return path.

<sup>Written for commit 1594f5a8cace4dd795f8df11307b2d70e0c37557. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/env-inspector/pull/109?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Fix a Cobertura coverage parsing warning and add coverage for malformed input**

### What Changed
- Coverage parsing now handles branch lines with a small dedicated parser, while non-branch lines still report zero branches
- The converter’s output stays the same, but the parsing logic is simpler and no longer hits the local-variable limit warning
- Added a test for malformed or empty branch coverage strings so the early-return path is covered

### Impact
`✅ No change in coverage output`
`✅ Fewer lint failures in the coverage converter`
`✅ Safer handling of malformed branch coverage strings`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=E4rzIt-hzcdiGRuDpP2LHQVj5KbDESD6t8HWATwbobM&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
