### PR TITLE
fix(cobertura): suppress deprecated Pylint E1136 on _parse_condition_coverage

### DIFF
--- a/scripts/cobertura_to_sonar_generic.py
+++ b/scripts/cobertura_to_sonar_generic.py
@@ -57,8 +57,19 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def _parse_condition_coverage(condition_coverage: str) -> tuple[int, int]:
-    """Parse Cobertura ``condition-coverage`` like ``"50% (1/2)"`` → (covered, total)."""
+def _parse_condition_coverage(  # pylint: disable=unsubscriptable-object
+    condition_coverage: str,
+) -> tuple[int, int]:
+    """Parse Cobertura ``condition-coverage`` like ``"50% (1/2)"`` → (covered, total).
+
+    The ``# pylint: disable=unsubscriptable-object`` is a workaround for
+    Codacy's deprecated Pylint engine — it doesn't recognise PEP 585
+    subscripted built-ins like ``tuple[int, int]`` even with
+    ``from __future__ import annotations`` in scope. The active
+    ``pylintpython3`` engine handles PEP 585 correctly; this comment
+    only silences the deprecated duplicate that ``.codacy.yml`` already
+    disables but Codacy keeps emitting from cache.
+    """
     if "(" not in condition_coverage:
         return (0, 0)
     fraction = condition_coverage.split("(")[1].rstrip(")")


### PR DESCRIPTION
## **User description**
## Summary

Codacy main analyzed PR #109's commit (b1c711cf) and reports 1 newIssue:

```
[Pylint (deprecated)/PyLint_E1136] scripts/cobertura_to_sonar_generic.py:60
Value 'tuple' is unsubscriptable
```

The deprecated Pylint engine doesn't recognise PEP 585 subscripted built-ins (`tuple[int, int]`) — the active `pylintpython3` engine handles them correctly. The `.codacy.yml` from PR #108 already disables `engines.pylint` but Codacy keeps emitting cached findings from the deprecated tool.

## Changes

- **`scripts/cobertura_to_sonar_generic.py`**: add inline `# pylint: disable=unsubscriptable-object` pragma on `_parse_condition_coverage` to silence the false positive. Includes a comment explaining the workaround.

## Verified locally

- 6/6 `tests/test_cobertura_to_sonar_generic.py` tests pass.

## Test plan

- [ ] Codacy reports 0 issues on the post-merge commit
- [ ] env-inspector main `shared-scanner-matrix / Codacy Zero` gate passes — last red gate on the repo


___

## **CodeAnt-AI Description**
**Silence a false Codacy warning in Cobertura parsing**

### What Changed
- Adds a local lint ignore so Codacy stops flagging the Cobertura condition-coverage parser as invalid on `tuple[int, int]`
- Keeps coverage parsing behavior unchanged; this only removes the repeated false warning from Codacy reports

### Impact
`✅ Fewer false Codacy alerts`
`✅ Cleaner lint reports`
`✅ No change to coverage parsing results`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=vJiaHBh6YYV3uBblEuQa0-iTycqkraRP0HJYWeC5Lfc&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
