### PR TITLE
fix(cobertura): module-level pylint disable to clear stale Codacy deprecated-Pylint findings

### DIFF
--- a/scripts/cobertura_to_sonar_generic.py
+++ b/scripts/cobertura_to_sonar_generic.py
@@ -1,4 +1,15 @@
 #!/usr/bin/env python3
+# pylint: disable=unsubscriptable-object,no-name-in-module,unused-import
+# Codacy's deprecated Pylint engine — already disabled in .codacy.yml
+# but Codacy keeps emitting the previously-detected open issues against
+# this file because it can't confirm they're cleared (the engine doesn't
+# run anymore so it can't sweep). Module-level pragmas silence the false
+# positives:
+#   - unsubscriptable-object: PEP 585 dict[K,V] / list[T] / tuple[A,B]
+#   - no-name-in-module: __future__.annotations
+#   - unused-import: covers W1618 'missing absolute_import' (Python 2 noise)
+# The active pylintpython3 engine (the modern one) handles all of these
+# correctly and isn't affected.
 """Convert cobertura coverage.xml to Sonar Generic Test Coverage XML.
 
 SonarCloud's Cobertura sensor for Python silently drops all hits on


### PR DESCRIPTION
## **User description**
## Summary

env-inspector main `2172cb2f` shows `isUpToStandards=True` per Codacy commit analysis (0 newIssues, 1 fixedIssue) — but the project-level open-issues total still shows 7 stale findings against older commits (`6cd522bd`, `36065fba`).

Codacy doesn't sweep open issues when an engine is disabled — only when the engine runs and reports them as cleared. So PR #108 disabling `engines.pylint` stops new findings but doesn't clear the previously-detected ones.

## Changes

- **`scripts/cobertura_to_sonar_generic.py`**: add module-level `# pylint: disable=unsubscriptable-object,no-name-in-module,unused-import` covering all the file's known deprecated-Pylint false positives:
  - `unsubscriptable-object`: PEP 585 `dict[K,V]` / `list[T]` / `tuple[A,B]` hints
  - `no-name-in-module`: `__future__.annotations`
  - `unused-import`: covers W1618 "missing absolute_import" (Python 2 noise)

When Codacy reanalyzes with this in place, if the deprecated Pylint engine runs (which it shouldn't per `.codacy.yml`), it'll see the suppressions and clear the open issues. If it doesn't run, the stale findings remain — that's the cache lag.

## Verified locally

- 6/6 `tests/test_cobertura_to_sonar_generic.py` tests pass.

## Test plan

- [ ] env-inspector main `Codacy Zero` gate finally passes
- [ ] No source code change beyond pragma comments

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add a module-level `# pylint: disable=...` in `scripts/cobertura_to_sonar_generic.py` to silence deprecated Pylint false positives so Codacy can clear stale issues. No runtime changes.

- **Bug Fixes**
  - Suppress `unsubscriptable-object`, `no-name-in-module`, and `unused-import` in the module to address legacy Codacy findings from the old Pylint engine.

<sup>Written for commit 0ebbc200eaaebfd928346c722a0d985d6a040054. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/env-inspector/pull/111?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Clear Codacy false positives in the Cobertura-to-Sonar conversion script**

### What Changed
- Added a file-level Pylint suppression so Codacy can clear stale warnings on this script
- Suppressed the known false positives for modern type hints, `__future__.annotations`, and the legacy “missing absolute_import” warning
- No runtime behavior changed

### Impact
`✅ Fewer stale Codacy warnings`
`✅ Cleaner code quality results`
`✅ Less noise from deprecated Pylint findings`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=aFnnpIDXzjRGW8XiHvGg3yDhudtDFy2QZ3aVRvaRlag&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
