### PR TITLE
chore(deepsource): add config to enable strict-zero scope alignment

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,41 @@
+version = 1
+
+# Keep this file explicit so provider-side analysis re-reads repo scope changes.
+# Mirrors the .codacy.yml exclusions so the strict-zero contract converges
+# across all four cloud platforms (Codacy / SonarCloud / qlty / DeepSource).
+
+exclude_patterns = [
+  "tests/**",                  # Bandit B101 (use of `assert`) is a test idiom, not a finding
+  "build/**",
+  "dist/**",
+  "docs/**",
+  "reports/**",
+  "release-notes/**",
+  "scripts/cobertura_to_sonar_generic.py",  # one-off coverage transform shim
+  "__pycache__/**",
+]
+
+test_patterns = [
+  "tests/**",
+]
+
+[[analyzers]]
+name = "python"
+enabled = true
+
+  [analyzers.meta]
+  runtime_version = "3.x.x"
+  max_line_length = 180
+  skip_doc_coverage = ["module", "magic", "init", "class", "nonpublic"]
+
+[[analyzers]]
+name = "secrets"
+enabled = true
+
+[[analyzers]]
+name = "shell"
+enabled = true
+
+[[analyzers]]
+name = "test-coverage"
+enabled = true


### PR DESCRIPTION
## **User description**
## Summary

env-inspector had no `.deepsource.toml`. The repo isn't analysed on the DeepSource dashboard (cloud HTML returns "not found" for the `all`/`recommended` issue pattern), so DeepSource doesn't know which paths to analyse vs. exclude.

This PR adds a config that mirrors the existing `.codacy.yml` + Sonar exclusions so when `DEEPSOURCE_DSN` secret is configured and analysis starts running, the four cloud platforms converge on the same scope.

Shape mirrors airline's `.deepsource.toml`:
- Python + secrets + shell + test-coverage analysers
- `exclude_patterns` matches `.codacy.yml`'s `exclude_paths` (`tests/**`, `build/dist/docs/reports/release-notes/`, the cobertura transform shim)
- `test_patterns = ["tests/**"]`

## Why now

User flagged this as part of the fleet-wide strict-zero push: *"env inspector has 0 issues, but no code coverage uploaded remedy that"*.

This PR does the analyser-config half; the `DEEPSOURCE_DSN` secret needs to be set on the repo (Settings → Secrets → Actions) for actual coverage upload to start flowing.

## Test plan

- [ ] Branch CI green
- [ ] Operator: add `DEEPSOURCE_DSN` to repo secrets (separate manual step)
- [ ] After secret + merge, DeepSource dashboard starts showing analysis results scoped to the configured analysers

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add `.deepsource.toml` to enable DeepSource analysis and align its scope with Codacy and Sonar. Prepares the repo for coverage upload once `DEEPSOURCE_DSN` is set.

- **New Features**
  - Configure analyzers: `python`, `secrets`, `shell`, `test-coverage`.
  - Match exclusions with `.codacy.yml`/Sonar: exclude `tests/**`, `build/**`, `dist/**`, docs/report dirs, and `scripts/cobertura_to_sonar_generic.py`; mark `tests/**` as tests.

- **Migration**
  - Add the `DEEPSOURCE_DSN` GitHub secret to start analysis and coverage reporting.

<sup>Written for commit f17689fc27973604b245ab2a0b5835e9c2ded0a1. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/env-inspector/pull/113?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Add DeepSource analysis config to match existing repo scope

### What Changed
- Added DeepSource settings so the repo can be analyzed with the same file scope as Codacy and SonarCloud
- Excluded test files, build output, docs, reports, release notes, caches, and the coverage transform script from analysis
- Marked tests as test files and enabled Python, secrets, shell, and test coverage checks

### Impact
`✅ Consistent code scanning across tools`
`✅ Fewer false positives from tests and generated files`
`✅ Coverage analysis ready once DeepSource access is configured`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=XT9zDG9DDXHaqtd45EwCR2b88ImTd3SwuHF9CUigfhU&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
