### PR TITLE
fix(security): clear Opengrep non-literal-import via justified in-code annotation

### DIFF
--- a/scripts/quality/_module_loader.py
+++ b/scripts/quality/_module_loader.py
@@ -19,12 +19,24 @@ def load_quality_module(qualified_name: str, bare_name: str) -> Any:
     execution). When that module is unavailable (direct script execution),
     ensures the ``scripts/quality`` directory is importable and falls back to
     the bare module name. Returns the imported module object.
+
+    Security note: ``qualified_name``/``bare_name`` are NOT untrusted input.
+    Every call site passes a pair of hard-coded string literals naming a
+    sibling quality-gate module (e.g. ``"scripts.quality._codacy_zero_impl"``
+    / ``"_codacy_zero_impl"``); the values never derive from CLI args, env,
+    network, or the filesystem. Opengrep/Semgrep's ``non-literal-import``
+    audit rule is purely syntactic and fires on any non-literal argument, so
+    the two ``import_module`` calls below carry a ``# nosemgrep`` annotation
+    rather than a refactor (no allowlist guard can make the rule pass while
+    keeping a variable module name).
     """
     try:
+        # nosemgrep: python.lang.security.audit.non-literal-import.non-literal-import
         return importlib.import_module(qualified_name)
     except ModuleNotFoundError:  # pragma: no cover - direct script execution
         helper_root = Path(__file__).resolve().parent
         helper_root_str = str(helper_root)
         if helper_root_str not in sys.path:
             sys.path.insert(0, helper_root_str)
+        # nosemgrep: python.lang.security.audit.non-literal-import.non-literal-import
         return importlib.import_module(bare_name)


### PR DESCRIPTION
## **User description**
## Summary

Real-fixes the two **Opengrep / Semgrep `non-literal-import`** (ERROR-severity, Security category) Codacy findings in `scripts/quality/_module_loader.py` via a behavior-preserving in-code suppression with a written security justification (the repo already uses this idiom: `# nosec B404`, `# noqa: D401 - ...`).

### The finding

`load_quality_module()` calls `importlib.import_module()` with a **variable** module name, so Opengrep's `python.lang.security.audit.non-literal-import.non-literal-import` rule flags it as an arbitrary-code-load risk (2 findings: lines 24 and 30).

### Why an annotation is the correct resolution (not a refactor)

- **No untrusted-input path exists.** Every call site passes a pair of **hard-coded string literals** naming a sibling quality-gate module (e.g. `"scripts.quality._codacy_zero_impl"` / `"_codacy_zero_impl"`). The names never derive from CLI args, env vars, network, or the filesystem.
- **The rule is purely syntactic** — it fires on *any* non-literal argument and cannot be satisfied by an allowlist guard while the loader keeps a variable module name (which is the whole point of the package-then-bare fallback). Making the argument literal would defeat the function.
- Per project policy, the behavior-preserving resolution for a true-false-positive in our own code is an **in-code suppression annotation with a written justification** — which is what this PR adds, plus an expanded `Security note:` in the docstring.

### Verification (all green, local)

- `pytest -q -s --cov=...` → **581 passed**
- `ruff check .` → **All checks passed** (the annotation does not trip E501/UP rules)
- `bandit -r` → **No issues identified**
- Semgrep replay with the **exact Codacy rule id** → **0 findings** after the annotation (was 2)
- Coverage **unchanged** (the change touches only `scripts/quality/_module_loader.py`, already covered by `tests/test_quality_security_imports.py`; the two Windows-local partial branches in `service.py`/`service_listing.py` are pre-existing platform branches covered by the CI ubuntu+windows matrix merge)

## Out of scope — operator action required (NOT dismissed)

The remaining **6** open Codacy issues (4x `PyLint_W1618` "import missing `from __future__ import absolute_import`" + 2x `PyLint_E1136` "Value 'Callable' is unsubscriptable") all come from the **"Pylint (deprecated)"** tool (uuid `34225275-f79e-4b85-8126-c7512c987c0d`), which has `usesConfigurationFile: false` and therefore ignores `.pylintrc` and the `.codacy.yml` engine toggles.

These are **tool-only artifacts, not code defects** — proven locally:
- Modern `pylint` reports `W1618`/`W1619` were **removed from pylint** (no such rule exists since pylint 2.0) and does **not** emit `E1136` on `collections.abc.Callable[[], None]` (correct on Python 3.12).
- `ruff` is clean; applying the "obvious" literal fixes (`from __future__ import absolute_import` / `typing.Callable`) would instead introduce ruff `UP010`/`UP035` violations.

**Resolution (operator / dashboard, no code change possible):** disable the redundant **"Pylint (deprecated)"** tool in the Codacy coding standard **"Copy of Standard" (id 150050)** — the modern **"Pylint"** tool is already enabled in the same standard and *does* read `.pylintrc`, so this removes a deprecated duplicate analyzer with no loss of coverage. The Codacy MCP exposes no mutation endpoint for this; it requires the dashboard or an admin REST `PATCH`. Per policy these are **reported as residual, not dismissed**.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `# nosemgrep` annotations and a short security note to `scripts/quality/_module_loader.py` to clear two `Opengrep`/`Semgrep` `non-literal-import` findings while preserving the trusted dynamic `importlib.import_module` behavior.

<sup>Written for commit 85f66785dc084d25514d97ace000fed97c0093e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Prekzursil/env-inspector/pull/122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Clear false-positive security findings for trusted module loading**

### What Changed
- Added a security note explaining that the imported module names come from hard-coded, trusted values rather than user input.
- Marked both module import calls so the Codacy/Opengrep non-literal-import warning is no longer raised.
- Kept the same import behavior for both package execution and direct script execution.

### Impact
`✅ Fewer false security alerts`
`✅ Cleaner Codacy scans`
`✅ No change to quality-module loading behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
